### PR TITLE
Accept other DataSetLocation implementations

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/DataSetLocation.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/DataSetLocation.java
@@ -13,24 +13,16 @@
 
 package org.talend.dataprep.api.dataset;
 
-import java.io.Serializable;
-
-import org.talend.dataprep.api.dataset.location.HdfsLocation;
-import org.talend.dataprep.api.dataset.location.HttpLocation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.talend.dataprep.api.dataset.location.LocalStoreLocation;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.io.Serializable;
 
 /**
  * Information about the dataset location.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@JsonSubTypes({ //
-@JsonSubTypes.Type(value = LocalStoreLocation.class, name = LocalStoreLocation.NAME), //
-        @JsonSubTypes.Type(value = HttpLocation.class, name = HttpLocation.NAME), //
-        @JsonSubTypes.Type(value = HdfsLocation.class, name = HdfsLocation.NAME) })
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", defaultImpl = LocalStoreLocation.class)
 public interface DataSetLocation extends Serializable {
 
     /** Return the location name (e.g local, http...). */

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/json/DataSetLocationMapping.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/json/DataSetLocationMapping.java
@@ -1,0 +1,25 @@
+package org.talend.dataprep.api.dataset.json;
+
+import org.talend.dataprep.api.dataset.DataSetLocation;
+
+/**
+ * Declares a mapping between a {@link DataSetLocation} class and its JSON type.
+ *
+ * This is used for JSON marshalling / unmarshalling of {@link DataSetLocation} implementations
+ *
+ * See {@link DataSetLocationModule}
+ */
+public interface DataSetLocationMapping {
+
+    /**
+     * @return the string identifying the {@link DataSetLocation} sub-type
+     */
+    String getLocationType();
+
+    /**
+     * @return the corresponding {@link DataSetLocation} implementation.
+     */
+    Class<? extends DataSetLocation> getLocationClass();
+
+
+}

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/json/DataSetLocationModule.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/json/DataSetLocationModule.java
@@ -1,0 +1,34 @@
+package org.talend.dataprep.api.dataset.json;
+
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.talend.dataprep.api.dataset.DataSetLocation;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Jackson module that gathers all declared {@link DataSetLocationMapping} found in the current
+ * context and registers them as a sub-type of {@link DataSetLocation}.
+ *
+ * Used for JSON unmarshalling as a replacement of the {@link com.fasterxml.jackson.annotation.JsonSubTypes}
+ * annotation on {@link DataSetLocation}.
+ */
+@Component
+public class DataSetLocationModule extends SimpleModule {
+
+    @Autowired(required = false)
+    private List<DataSetLocationMapping> mappings = new ArrayList<>();
+
+    @PostConstruct
+    public void init(){
+        mappings.forEach(mapping -> registerLocationMapping(mapping.getLocationType(), mapping.getLocationClass()));
+    }
+
+    protected void registerLocationMapping(String type, Class<? extends DataSetLocation> locationClass){
+        this.registerSubtypes(new NamedType(locationClass, type));
+    }
+}

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/api/dataset/json/DefaultLocationMappingConfiguration.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/api/dataset/json/DefaultLocationMappingConfiguration.java
@@ -1,0 +1,46 @@
+package org.talend.dataprep.api.dataset.json;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.talend.dataprep.api.dataset.DataSetLocation;
+import org.talend.dataprep.api.dataset.location.HdfsLocation;
+import org.talend.dataprep.api.dataset.location.HttpLocation;
+
+/**
+ * Declares default DataSetLocations for tests
+ */
+@Configuration
+public class DefaultLocationMappingConfiguration {
+
+    @Bean
+    public DataSetLocationMapping httpLocationMapping() {
+        return new DefaultDataSetLocationMapping(HttpLocation.NAME, HttpLocation.class);
+    }
+
+    @Bean
+    public DataSetLocationMapping hdfsLocationMapping() {
+        return new DefaultDataSetLocationMapping(HdfsLocation.NAME, HdfsLocation.class);
+    }
+
+    private static class DefaultDataSetLocationMapping implements DataSetLocationMapping{
+
+        private final String locationType;
+
+        private final Class<? extends DataSetLocation> locationClass;
+
+        public DefaultDataSetLocationMapping(String locationType, Class<? extends DataSetLocation> locationClass) {
+            this.locationType = locationType;
+            this.locationClass = locationClass;
+        }
+
+        @Override
+        public String getLocationType() {
+            return locationType;
+        }
+
+        @Override
+        public Class<? extends DataSetLocation> getLocationClass() {
+            return locationClass;
+        }
+    }
+}

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/locator/DataSetLocator.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/locator/DataSetLocator.java
@@ -17,11 +17,12 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.talend.dataprep.api.dataset.DataSetLocation;
+import org.talend.dataprep.api.dataset.json.DataSetLocationMapping;
 
 /**
  * Interface for dataset locators.
  */
-public interface DataSetLocator {
+public interface DataSetLocator extends DataSetLocationMapping {
 
     /**
      * @param contentType the content type to analyse.

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/locator/DataSetLocatorService.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/locator/DataSetLocatorService.java
@@ -13,16 +13,16 @@
 
 package org.talend.dataprep.dataset.service.locator;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.talend.dataprep.api.dataset.DataSetLocation;
 import org.talend.dataprep.api.dataset.location.LocalStoreLocation;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * Service that retrieve dataset location from dataset locators.

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/locator/HdfsDataSetLocator.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/locator/HdfsDataSetLocator.java
@@ -13,17 +13,17 @@
 
 package org.talend.dataprep.dataset.service.locator;
 
-import java.io.IOException;
-import java.io.InputStream;
-
-import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import org.springframework.stereotype.Component;
-import org.talend.dataprep.api.dataset.DataSetLocation;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import org.talend.dataprep.api.dataset.DataSetLocation;
+import org.talend.dataprep.api.dataset.location.HdfsLocation;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Dataset locator for remote hdfs datasets.
@@ -36,7 +36,8 @@ public class HdfsDataSetLocator implements DataSetLocator {
 
     /** Jackson builder. */
     @Autowired
-    private Jackson2ObjectMapperBuilder builder;
+    @Lazy
+    private ObjectMapper objectMapper;
 
     /**
      * @see DataSetLocator#accept(String)
@@ -51,9 +52,17 @@ public class HdfsDataSetLocator implements DataSetLocator {
      */
     @Override
     public DataSetLocation getLocation(InputStream connectionParameters) throws IOException {
-        ObjectMapper mapper = builder.build();
-        JsonParser parser = mapper.getFactory().createParser(connectionParameters);
-        return mapper.readerFor(DataSetLocation.class).readValue(parser);
+        JsonParser parser = objectMapper.getFactory().createParser(connectionParameters);
+        return objectMapper.readerFor(DataSetLocation.class).readValue(parser);
     }
 
+    @Override
+    public String getLocationType() {
+        return HdfsLocation.NAME;
+    }
+
+    @Override
+    public Class<? extends DataSetLocation> getLocationClass() {
+        return HdfsLocation.class;
+    }
 }

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/locator/HttpDataSetLocator.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/locator/HttpDataSetLocator.java
@@ -13,17 +13,17 @@
 
 package org.talend.dataprep.dataset.service.locator;
 
-import java.io.IOException;
-import java.io.InputStream;
-
-import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
-import org.springframework.stereotype.Component;
-import org.talend.dataprep.api.dataset.DataSetLocation;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import org.talend.dataprep.api.dataset.DataSetLocation;
+import org.talend.dataprep.api.dataset.location.HttpLocation;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Dataset locator for remote http datasets.
@@ -36,7 +36,8 @@ public class HttpDataSetLocator implements DataSetLocator {
 
     /** Jackson builder. */
     @Autowired
-    private Jackson2ObjectMapperBuilder builder;
+    @Lazy
+    private ObjectMapper objectMapper;
 
     /**
      * @see DataSetLocator#accept(String)
@@ -51,9 +52,17 @@ public class HttpDataSetLocator implements DataSetLocator {
      */
     @Override
     public DataSetLocation getLocation(InputStream connectionParameters) throws IOException {
-        ObjectMapper mapper = builder.build();
-        JsonParser parser = mapper.getFactory().createParser(connectionParameters);
-        return mapper.readerFor(DataSetLocation.class).readValue(parser);
+        JsonParser parser = objectMapper.getFactory().createParser(connectionParameters);
+        return objectMapper.readerFor(DataSetLocation.class).readValue(parser);
     }
 
+    @Override
+    public String getLocationType() {
+        return HttpLocation.NAME;
+    }
+
+    @Override
+    public Class<? extends DataSetLocation> getLocationClass() {
+        return HttpLocation.class;
+    }
 }


### PR DESCRIPTION
Because the current implement uses @JsonSubTypes on the DataSetLocation interface where all implementations are explicitely listed, it not possible to provide a custom implementation of DataSetLocation whereas DataPrep offers a pluggeable way to define DataSetLocators and DataSetContentStores.

The idea here was to replace the JsonSubTypes by a Jackson module that lists declared DataSetLocation implementations (declaration is made using an instance of DataSetLocationMapping).

I made DataSetLocator extend DataSetLocationMapping so that it's the Locator responsability to define the Location it works with.