### PR TITLE
TDP-2091: authorize Mask data action on non String typed columns.

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/api/action/metadata/datamasking/MaskDataByDomain.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/api/action/metadata/datamasking/MaskDataByDomain.java
@@ -73,7 +73,7 @@ public class MaskDataByDomain extends ActionMetadata implements ColumnAction {
      */
     @Override
     public boolean acceptColumn(ColumnMetadata column) {
-        return Type.STRING.equals(Type.get(column.getType()));
+        return Type.STRING.isAssignableFrom(Type.get(column.getType()));
     }
 
     /**
@@ -105,17 +105,17 @@ public class MaskDataByDomain extends ActionMetadata implements ColumnAction {
             final String columnId = actionContext.getColumnId();
             final ColumnMetadata column = rowMetadata.getById(columnId);
             final String domain = column.getDomain();
-            final String type = column.getType();
+            final Type type = Type.get(column.getType());
             LOGGER.trace(">>> type: " + type + " metadata: " + column);
             try {
-                if (Type.DATE.getName().equals(type)) {
+                if (Type.DATE.equals(type)) {
                     final List<PatternFrequency> patternFreqList = column.getStatistics().getPatternFrequencies();
                     final List<String> dateTimePatternList = patternFreqList.stream() //
                             .map(PatternFrequency::getPattern) //
                             .collect(Collectors.toList());
-                    actionContext.get(MASKER, p -> new ValueDataMasker(domain, type, dateTimePatternList));
+                    actionContext.get(MASKER, p -> new ValueDataMasker(domain, type.getName(), dateTimePatternList));
                 } else {
-                    actionContext.get(MASKER, p -> new ValueDataMasker(domain, type));
+                    actionContext.get(MASKER, p -> new ValueDataMasker(domain, type.getName()));
                 }
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/transformation/api/action/metadata/datamasking/MaskDataByDomainTest.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/transformation/api/action/metadata/datamasking/MaskDataByDomainTest.java
@@ -260,15 +260,15 @@ public class MaskDataByDomainTest extends AbstractMetadataBaseTest {
     @Test
     public void should_accept_column() {
         assertTrue(maskDataByDomain.acceptColumn(getColumn(Type.STRING)));
+        assertTrue(maskDataByDomain.acceptColumn(getColumn(Type.DATE)));
+        assertTrue(maskDataByDomain.acceptColumn(getColumn(Type.NUMERIC)));
+        assertTrue(maskDataByDomain.acceptColumn(getColumn(Type.INTEGER)));
+        assertTrue(maskDataByDomain.acceptColumn(getColumn(Type.FLOAT)));
+        assertTrue(maskDataByDomain.acceptColumn(getColumn(Type.BOOLEAN)));
     }
 
     @Test
     public void should_not_accept_column() {
-        assertFalse(maskDataByDomain.acceptColumn(getColumn(Type.DATE)));
-        assertFalse(maskDataByDomain.acceptColumn(getColumn(Type.NUMERIC)));
-        assertFalse(maskDataByDomain.acceptColumn(getColumn(Type.INTEGER)));
-        assertFalse(maskDataByDomain.acceptColumn(getColumn(Type.FLOAT)));
-        assertFalse(maskDataByDomain.acceptColumn(getColumn(Type.BOOLEAN)));
         assertFalse(maskDataByDomain.acceptColumn(getColumn(Type.ANY)));
     }
 }

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/SuggestionTests.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/SuggestionTests.java
@@ -1,20 +1,21 @@
-//  ============================================================================
+// ============================================================================
 //
-//  Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
 //
-//  This source code is available under agreement available at
-//  https://github.com/Talend/data-prep/blob/master/LICENSE
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
 //
-//  You should have received a copy of the agreement
-//  along with this program; if not, write to Talend SA
-//  9 rue Pages 92150 Suresnes, France
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
 //
-//  ============================================================================
+// ============================================================================
 
 package org.talend.dataprep.transformation.service;
 
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -211,6 +212,37 @@ public class SuggestionTests extends TransformationServiceBaseTests {
 
         // then
         assertEquals(expectedSuggestions, response, false);
+    }
+
+    /**
+     * @see <a href="https://jira.talendforge.org/browse/TDP-2091">TDP-2091_improve_new_actions_suggestions</a>
+     * @throws Exception
+     */
+    @Test
+    public void ensureThatDataMaskingAndPhoneFormatAreSuggestedOnPhoneColumns() throws Exception {
+        // given
+        // @formatter:off
+        final String columnMetadata = "{\n" +
+                "  \"id\": \"id\",\n" +
+                "  \"quality\": {\n" +
+                "    \"empty\": 5,\n" +
+                "    \"invalid\": 10,\n" +
+                "    \"valid\": 72\n" +
+                "  },\n" +
+                "  \"type\": \"integer\",\n" +
+                "  \"domain\": \"FR_PHONE\"\n" +
+                "}";
+
+        given() //
+            .contentType(JSON) //
+            .body(columnMetadata) //
+        .when() //
+            .post("/suggest/column?limit=100") // 100 just to make sure that we get all the suggestions
+        .then()
+            .statusCode(200)
+            .body("name", hasItems("mask_data_by_domain", "format_phone_number"));
+        // @formatter:on
+
     }
 
 }


### PR DESCRIPTION
the MaskData action now declared itself applicable on any type that can be assignable to a String. It allows it to be accepted for the suggestion system and appear in phone (integer) typed columns suggested actions list.