### PR TITLE
TDP-2385: default to "Col X" for column name when empty cell in "make…

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/actions/common/ActionFactory.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/actions/common/ActionFactory.java
@@ -1,12 +1,5 @@
 package org.talend.dataprep.transformation.actions.common;
 
-import static org.talend.dataprep.api.preparation.Action.Builder.builder;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Predicate;
-
-import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +14,13 @@ import org.talend.dataprep.transformation.api.action.DataSetMetadataAction;
 import org.talend.dataprep.transformation.api.action.DataSetRowAction;
 import org.talend.dataprep.transformation.api.action.context.ActionContext;
 import org.talend.dataprep.transformation.api.action.validation.ActionMetadataValidation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import static org.talend.dataprep.api.preparation.Action.Builder.builder;
 
 @Component
 public class ActionFactory {
@@ -96,7 +96,7 @@ public class ActionFactory {
             } else {
                 rowId = null;
             }
-            final Predicate<DataSetRow> rowFilter = r -> ObjectUtils.equals(r.getTdpId(), rowId);
+            final Predicate<DataSetRow> rowFilter = r -> Objects.equals(r.getTdpId(), rowId);
             return predicate.and(rowFilter);
         } else {
             return predicate;

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/api/action/context/ActionContext.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/api/action/context/ActionContext.java
@@ -180,13 +180,12 @@ public class ActionContext {
      * @return the object (stored in the context).
      */
     public <T> T get(String key, Function<Map<String, String>, T> supplier) {
-        if (context.containsKey(key)) {
-            return (T) context.get(key);
+        T value = (T) context.get(key);
+        if (value == null) {
+            value = supplier.apply(parameters);
+            context.put(key, value);
+            LOGGER.debug("adding {}->{} in this context {}", key, value, this);
         }
-
-        final T value = supplier.apply(parameters);
-        context.put(key, value);
-        LOGGER.debug("adding {}->{} in this context {}", key, value, this);
         return value;
     }
 


### PR DESCRIPTION
… as header" actions

In the MakeLineHeader action, when a cell is empty, it is not used as new column name, instead the column is named "Col X" with "X" as column index starting from 1.