### PR TITLE
TDP-2469: authentication errors are now handled

### DIFF
--- a/dataprep-backend-common/src/main/resources/org/talend/dataprep/error_messages.properties
+++ b/dataprep-backend-common/src/main/resources/org/talend/dataprep/error_messages.properties
@@ -106,6 +106,9 @@ FORBIDDEN_ACCESS.TITLE=Forbidden
 FORBIDDEN_ACCESS.MESSAGE=You cannot access {0}
 
 ######################################### API ERROR_CODES #########################################
+TAC_UNAVAILABLE.TITLE = Authentication error
+TAC_UNAVAILABLE.MESSAGE = Unable to reach Talend Administration Console, maybe TAC URL is not correct or TAC is down.
+
 UNABLE_TO_DELETE_PREPARATION.TITLE = Deletion error
 UNABLE_TO_DELETE_PREPARATION.MESSAGE = Unable to delete the preparation
 
@@ -425,3 +428,4 @@ PREPARATION_NOT_EMPTY.MESSAGE=Preparation {0} is not empty
 
 FORBIDDEN_PREPARATION_CREATION.TITLE=Preparation error
 FORBIDDEN_PREPARATION_CREATION.MESSAGE=You are not allowed to create a preparation in this folder
+


### PR DESCRIPTION
- when a TDP exception is thrown during authentication process it is now used to build the error message
- when the TAC is not reachable, there is an error message that clearly states it