### PR TITLE
Feature/tdp 1788 evict cache on prep deletion

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
@@ -172,7 +172,8 @@ public class PreparationAPI extends APIService {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Deleting preparation (pool: {} )...", getConnectionStats());
         }
-        PreparationDelete preparationDelete = getCommand(PreparationDelete.class, id);
+        final CachePreparationEviction evictPreparationCache = getCommand(CachePreparationEviction.class, id);
+        final PreparationDelete preparationDelete = getCommand(PreparationDelete.class, id, evictPreparationCache);
         final String preparationId = preparationDelete.execute();
         if (LOG.isDebugEnabled()) {
             LOG.debug("Deleted preparation (pool: {} )...", getConnectionStats());

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/CachePreparationEviction.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/CachePreparationEviction.java
@@ -13,32 +13,23 @@
 
 package org.talend.dataprep.api.service.command.preparation;
 
-import com.netflix.hystrix.HystrixCommand;
 import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpRequestBase;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.talend.dataprep.api.service.command.common.ChainedCommand;
+import org.talend.dataprep.command.GenericCommand;
 import org.talend.dataprep.exception.TDPException;
 
 import static org.talend.dataprep.command.Defaults.asNull;
-import static org.talend.dataprep.exception.error.APIErrorCodes.UNABLE_TO_DELETE_PREPARATION;
+import static org.talend.dataprep.exception.error.APIErrorCodes.UNABLE_TO_DELETE_PREPARATION_CACHE;
 
 @Component
 @Scope("request")
-public class PreparationDelete extends ChainedCommand<String, Void> {
-
-    private PreparationDelete(final String id, final HystrixCommand<Void> evictCacheOnPrep) {
-        super(PREPARATION_GROUP, evictCacheOnPrep);
-        execute(() -> onExecute(id));
-        onError(e -> new TDPException(UNABLE_TO_DELETE_PREPARATION, e));
+public class CachePreparationEviction extends GenericCommand<String> {
+    private CachePreparationEviction(final String preparationId) {
+        super(TRANSFORM_GROUP);
+        execute(() -> new HttpDelete(transformationServiceUrl + "/preparation/" + preparationId + "/cache")); //$NON-NLS-1$
+        onError(e ->  new TDPException(UNABLE_TO_DELETE_PREPARATION_CACHE, e));
         on(HttpStatus.OK).then(asNull());
     }
-
-    private HttpRequestBase onExecute(final String id) {
-        getInput(); // evict cache on preparation
-        return new HttpDelete(preparationServiceUrl + "/preparations/" + id); //$NON-NLS-1$
-    }
-
 }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/ContentCache.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/ContentCache.java
@@ -60,7 +60,7 @@ public interface ContentCache {
     OutputStream put(ContentCacheKey key, TimeToLive timeToLive);
 
     /**
-     * Mark cache entry as invalid for given <code>preparationId</code> at step <code>stepId</code>. After this method
+     * Mark cache entry as invalid for given key. After this method
      * completes, {@link #has(ContentCacheKey)} must immediately return <code>false</code>.
      *
      * The eviction is performed gradually according to the given key : the more precise the key is, the finer the
@@ -73,6 +73,16 @@ public interface ContentCache {
      * @param key content cache key.
      */
     void evict(ContentCacheKey key);
+
+    /**
+     * Mark cache entry as invalid for the provided partial key. After this method
+     * completes, {@link #has(ContentCacheKey)} must immediately return <code>false</code>.
+     *
+     * The eviction is performed when the entry's key match the partial key.
+     *
+     * @param key partial content cache key.
+     */
+    void evictMatch(ContentCacheKey key);
 
     /**
      * <p>

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/ContentCache.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/ContentCache.java
@@ -81,6 +81,7 @@ public interface ContentCache {
      * The eviction is performed when the entry's key match the partial key.
      *
      * @param key partial content cache key.
+     * @see ContentCacheKey#getMatcher()
      */
     void evictMatch(ContentCacheKey key);
 

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/ContentCacheKey.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/ContentCacheKey.java
@@ -1,15 +1,15 @@
-//  ============================================================================
+// ============================================================================
 //
-//  Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
 //
-//  This source code is available under agreement available at
-//  https://github.com/Talend/data-prep/blob/master/LICENSE
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
 //
-//  You should have received a copy of the agreement
-//  along with this program; if not, write to Talend SA
-//  9 rue Pages 92150 Suresnes, France
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
 //
-//  ============================================================================
+// ============================================================================
 
 package org.talend.dataprep.cache;
 
@@ -29,11 +29,20 @@ public interface ContentCacheKey {
     String getKey();
 
     /**
-     * Create a predicate that match the potentially partial key
-     * @return The predicate that match the key
+     * <p>
+     * Create a predicate that allows to compare another content cache key (as returned by {@link #getKey()}) with this
+     * current cache key.
+     * </p>
+     * <p>
+     * Each implementation may decide to match on partial key or on full key.
+     * </p>
+     *
+     * @return A predicate that match another content cache key
+     * @see #getKey()
+     * @see ContentCache#evictMatch(ContentCacheKey)
      */
     default Predicate<String> getMatcher() {
-        throw new UnsupportedOperationException("Matcher is not implemented, it is not usable");
+        throw new UnsupportedOperationException("Matcher is not implemented");
     }
 
 }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/ContentCacheKey.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/ContentCacheKey.java
@@ -13,6 +13,8 @@
 
 package org.talend.dataprep.cache;
 
+import java.util.function.Predicate;
+
 /**
  * Content cache key used to group all information needed by the cache.
  */
@@ -25,5 +27,13 @@ public interface ContentCacheKey {
      * @return the key for this cache content as a string.
      */
     String getKey();
+
+    /**
+     * Create a predicate that match the potentially partial key
+     * @return The predicate that match the key
+     */
+    default Predicate<String> getMatcher() {
+        throw new UnsupportedOperationException("Matcher is not implemented, it is not usable");
+    }
 
 }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/file/FileSystemContentCache.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/file/FileSystemContentCache.java
@@ -23,6 +23,8 @@ import java.io.OutputStream;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -38,16 +40,6 @@ import org.talend.dataprep.cache.ContentCache;
 import org.talend.dataprep.cache.ContentCacheKey;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 
 /**
  * File system cache implementation.
@@ -112,7 +104,7 @@ public class FileSystemContentCache implements ContentCache {
     /**
      * Compute the path for the given key.
      *
-     * @param key        the cache key entry.
+     * @param key the cache key entry.
      * @param timeToLive an optional time to live when performing content cache lookup (<code>null</code> allowed).
      * @return the HDFS path for the entry key.
      */
@@ -336,6 +328,7 @@ public class FileSystemContentCache implements ContentCache {
     private class FileSystemVisitor extends SimpleFileVisitor<Path> {
 
         private final BiConsumer<Path, String> consumer;
+
         private final boolean skipPermanent;
 
         FileSystemVisitor(final BiConsumer<Path, String> consumer) {

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/noop/NoOpContentCache.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/cache/noop/NoOpContentCache.java
@@ -76,6 +76,14 @@ public class NoOpContentCache implements ContentCache {
         // Nothing to do.
     }
 
+    /**
+     * @see ContentCache#evictMatch(ContentCacheKey)
+     */
+    @Override
+    public void evictMatch(ContentCacheKey key) {
+        // Nothing to do.
+    }
+
     @Override
     public void move(ContentCacheKey from, ContentCacheKey to, TimeToLive toTimeToLive) {
         // Nothing to do.

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/exception/error/APIErrorCodes.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/exception/error/APIErrorCodes.java
@@ -22,6 +22,7 @@ import org.talend.daikon.exception.error.ErrorCode;
 
 public enum APIErrorCodes implements ErrorCode {
     UNABLE_TO_DELETE_PREPARATION(400),
+    UNABLE_TO_DELETE_PREPARATION_CACHE(500),
     UNABLE_TO_CREATE_DATASET(400),
     UNABLE_TO_CREATE_OR_UPDATE_DATASET(400),
     UNABLE_TO_CERTIFY_DATASET(400),

--- a/dataprep-backend-common/src/main/resources/org/talend/dataprep/error_messages.properties
+++ b/dataprep-backend-common/src/main/resources/org/talend/dataprep/error_messages.properties
@@ -109,6 +109,9 @@ FORBIDDEN_ACCESS.MESSAGE=You cannot access {0}
 UNABLE_TO_DELETE_PREPARATION.TITLE = Deletion error
 UNABLE_TO_DELETE_PREPARATION.MESSAGE = Unable to delete the preparation
 
+UNABLE_TO_DELETE_PREPARATION_CACHE.TITLE = Deletion error
+UNABLE_TO_DELETE_PREPARATION_CACHE.MESSAGE = Unable to delete the preparation contents
+
 UNABLE_TO_CREATE_DATASET.TITLE = Import error
 UNABLE_TO_CREATE_DATASET.MESSAGE = An error occurred during import
 

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/cache/file/DummyCacheKey.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/cache/file/DummyCacheKey.java
@@ -16,6 +16,7 @@ package org.talend.dataprep.cache.file;
 import java.util.Objects;
 import java.util.Random;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import org.talend.dataprep.cache.ContentCacheKey;
 
@@ -56,6 +57,7 @@ public class DummyCacheKey implements ContentCacheKey {
                 + '_'
                 + (name == null ? ".*" : name)
                 + "_.*";
-        return (key) -> key.matches(regex);
+        final Pattern pattern = Pattern.compile(regex);
+        return key -> pattern.matcher(key).matches();
     }
 }

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/cache/file/DummyCacheKey.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/cache/file/DummyCacheKey.java
@@ -15,6 +15,7 @@ package org.talend.dataprep.cache.file;
 
 import java.util.Objects;
 import java.util.Random;
+import java.util.function.Predicate;
 
 import org.talend.dataprep.cache.ContentCacheKey;
 
@@ -46,6 +47,15 @@ public class DummyCacheKey implements ContentCacheKey {
      */
     @Override
     public String getKey() {
-        return this.getClass().getSimpleName() + '_' + Objects.hash(name, random);
+        return this.getClass().getSimpleName() + '_' + name + '_' + Objects.hash(name, random);
+    }
+
+    @Override
+    public Predicate<String> getMatcher() {
+        final String regex = this.getClass().getSimpleName()
+                + '_'
+                + (name == null ? ".*" : name)
+                + "_.*";
+        return (key) -> key.matches(regex);
     }
 }

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/cache/file/FileSystemContentCacheTest.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/cache/file/FileSystemContentCacheTest.java
@@ -14,6 +14,9 @@
 package org.talend.dataprep.cache.file;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.talend.dataprep.cache.ContentCache.TimeToLive.DEFAULT;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -97,6 +100,24 @@ public class FileSystemContentCacheTest {
         cache.evict(key);
         // ... has() must immediately return false
         Assert.assertThat(cache.has(key), is(false));
+    }
+
+    @Test
+    public void testEvictMatch() throws Exception {
+        // given
+        final ContentCacheKey key = new DummyCacheKey("youpala");
+        final ContentCacheKey keyMatch = new DummyCacheKey("youpala");
+        assertThat(cache.has(key), not(is(keyMatch.getKey()))); // not the same key because of random + hash
+
+        // Put a content in cache...
+        addCacheEntry(key, "content", DEFAULT);
+        assertThat(cache.has(key), is(true));
+
+        // when
+        cache.evictMatch(key);
+
+        // then
+        assertThat(cache.has(key), is(false));
     }
 
     @Test

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/CacheKeyGenerator.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/CacheKeyGenerator.java
@@ -43,7 +43,7 @@ public class CacheKeyGenerator {
                                                      final String parameters) {
         final String actualParameters = parameters == null ? StringUtils.EMPTY : parameters;
         final ExportParameters.SourceType actualSourceType = sourceType == null ? HEAD : sourceType;
-        final String actualUserId = actualSourceType == HEAD ? null : getUser();
+        final String actualUserId = actualSourceType == HEAD ? null : security.getUserId();
 
         return new TransformationCacheKey(
                 preparationId,
@@ -62,7 +62,7 @@ public class CacheKeyGenerator {
      */
     public TransformationMetadataCacheKey generateMetadataKey(final String preparationId, final String stepId, final ExportParameters.SourceType sourceType) {
         final ExportParameters.SourceType actualSourceType = sourceType == null ? HEAD : sourceType;
-        final String actualUserId = actualSourceType == HEAD ? null : getUser();
+        final String actualUserId = actualSourceType == HEAD ? null : security.getUserId();
 
         return new TransformationMetadataCacheKey(
                 preparationId,
@@ -72,7 +72,95 @@ public class CacheKeyGenerator {
         );
     }
 
-    private String getUser() {
-        return security.getUserId();
+    /**
+     * @return a builder for metadata cache key
+     */
+    public MetadataCacheKeyBuilder metadataBuilder() {
+        return new MetadataCacheKeyBuilder(this);
+    }
+
+    /**
+     * @return a builder for content cache key
+     */
+    public ContentCacheKeyBuilder contentBuilder() {
+        return new ContentCacheKeyBuilder(this);
+    }
+
+    public class MetadataCacheKeyBuilder {
+        private String preparationId;
+        private String stepId;
+        private ExportParameters.SourceType sourceType;
+        private CacheKeyGenerator cacheKeyGenerator;
+
+        private MetadataCacheKeyBuilder(final CacheKeyGenerator cacheKeyGenerator) {
+            this.cacheKeyGenerator = cacheKeyGenerator;
+        }
+
+        public MetadataCacheKeyBuilder preparationId(final String preparationId) {
+            this.preparationId = preparationId;
+            return this;
+        }
+
+        public MetadataCacheKeyBuilder stepId(final String stepId) {
+            this.stepId = stepId;
+            return this;
+        }
+
+        public MetadataCacheKeyBuilder sourceType(final ExportParameters.SourceType sourceType) {
+            this.sourceType = sourceType;
+            return this;
+        }
+
+        public TransformationMetadataCacheKey build() {
+            return cacheKeyGenerator.generateMetadataKey(preparationId, stepId, sourceType);
+        }
+    }
+
+    public class ContentCacheKeyBuilder {
+        private String datasetId;
+        private String format;
+        private String parameters;
+        private String preparationId;
+        private String stepId;
+        private ExportParameters.SourceType sourceType;
+        private CacheKeyGenerator cacheKeyGenerator;
+
+        private ContentCacheKeyBuilder(final CacheKeyGenerator cacheKeyGenerator) {
+            this.cacheKeyGenerator = cacheKeyGenerator;
+        }
+
+        public ContentCacheKeyBuilder preparationId(final String preparationId) {
+            this.preparationId = preparationId;
+            return this;
+        }
+
+        public ContentCacheKeyBuilder stepId(final String stepId) {
+            this.stepId = stepId;
+            return this;
+        }
+
+        public ContentCacheKeyBuilder sourceType(final ExportParameters.SourceType sourceType) {
+            this.sourceType = sourceType;
+            return this;
+        }
+
+        public ContentCacheKeyBuilder datasetId(final String datasetId) {
+            this.datasetId = datasetId;
+            return this;
+        }
+
+        public ContentCacheKeyBuilder format(final String format) {
+            this.format = format;
+            return this;
+        }
+
+        public ContentCacheKeyBuilder parameters(final String parameters) {
+            this.parameters = parameters;
+            return this;
+        }
+
+        public TransformationCacheKey build() {
+            return cacheKeyGenerator.generateContentKey(datasetId, preparationId, stepId, format, sourceType, parameters);
+        }
     }
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/CacheKeyGenerator.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/CacheKeyGenerator.java
@@ -1,75 +1,54 @@
 package org.talend.dataprep.transformation.cache;
 
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
+
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.export.ExportParameters;
-import org.talend.dataprep.cache.ContentCacheKey;
 import org.talend.dataprep.security.Security;
-
-import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 
 /**
  * Generate cache key
  */
 @Component
 public class CacheKeyGenerator {
+
     @Autowired
     private Security security;
 
     /**
      * Build a cache key to identify the transformation result content
      */
-    public TransformationCacheKey generateContentKey(final String datasetId, final String preparationId,
-                                                     final String stepId, final String format,
-                                                     final ExportParameters.SourceType sourceType) {
-        return this.generateContentKey(
-                datasetId,
-                preparationId,
-                stepId,
-                format,
-                sourceType,
-                null
-        );
+    public TransformationCacheKey generateContentKey(final String datasetId, final String preparationId, final String stepId,
+            final String format, final ExportParameters.SourceType sourceType) {
+        return this.generateContentKey(datasetId, preparationId, stepId, format, sourceType, null);
     }
 
     /**
      * Build a cache key with additional parameters
      * When source type is HEAD, the user id is not included in cache key, as the HEAD sample is common for all users
      */
-    public TransformationCacheKey generateContentKey(final String datasetId, final String preparationId,
-                                                     final String stepId, final String format,
-                                                     final ExportParameters.SourceType sourceType,
-                                                     final String parameters) {
+    public TransformationCacheKey generateContentKey(final String datasetId, final String preparationId, final String stepId,
+            final String format, final ExportParameters.SourceType sourceType, final String parameters) {
         final String actualParameters = parameters == null ? StringUtils.EMPTY : parameters;
         final ExportParameters.SourceType actualSourceType = sourceType == null ? HEAD : sourceType;
         final String actualUserId = actualSourceType == HEAD ? null : security.getUserId();
 
-        return new TransformationCacheKey(
-                preparationId,
-                datasetId,
-                format,
-                stepId,
-                actualParameters,
-                actualSourceType,
-                actualUserId
-        );
+        return new TransformationCacheKey(preparationId, datasetId, format, stepId, actualParameters, actualSourceType,
+                actualUserId);
     }
 
     /**
      * Build a metadata cache key to identify the transformation result content
      * When source type is HEAD, the user id is not included in cache key, as the HEAD sample is common for all users
      */
-    public TransformationMetadataCacheKey generateMetadataKey(final String preparationId, final String stepId, final ExportParameters.SourceType sourceType) {
+    public TransformationMetadataCacheKey generateMetadataKey(final String preparationId, final String stepId,
+            final ExportParameters.SourceType sourceType) {
         final ExportParameters.SourceType actualSourceType = sourceType == null ? HEAD : sourceType;
         final String actualUserId = actualSourceType == HEAD ? null : security.getUserId();
 
-        return new TransformationMetadataCacheKey(
-                preparationId,
-                stepId,
-                actualSourceType,
-                actualUserId
-        );
+        return new TransformationMetadataCacheKey(preparationId, stepId, actualSourceType, actualUserId);
     }
 
     /**
@@ -87,9 +66,13 @@ public class CacheKeyGenerator {
     }
 
     public class MetadataCacheKeyBuilder {
+
         private String preparationId;
+
         private String stepId;
+
         private ExportParameters.SourceType sourceType;
+
         private CacheKeyGenerator cacheKeyGenerator;
 
         private MetadataCacheKeyBuilder(final CacheKeyGenerator cacheKeyGenerator) {
@@ -117,12 +100,19 @@ public class CacheKeyGenerator {
     }
 
     public class ContentCacheKeyBuilder {
+
         private String datasetId;
+
         private String format;
+
         private String parameters;
+
         private String preparationId;
+
         private String stepId;
+
         private ExportParameters.SourceType sourceType;
+
         private CacheKeyGenerator cacheKeyGenerator;
 
         private ContentCacheKeyBuilder(final CacheKeyGenerator cacheKeyGenerator) {

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationCacheKey.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationCacheKey.java
@@ -13,13 +13,13 @@
 
 package org.talend.dataprep.transformation.cache;
 
-import java.io.IOException;
-import java.util.Objects;
-
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.StringUtils;
 import org.talend.dataprep.api.export.ExportParameters;
 import org.talend.dataprep.cache.ContentCacheKey;
+
+import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Content cache key used to cache transformation.
@@ -100,7 +100,13 @@ public class TransformationCacheKey implements ContentCacheKey {
      */
     @Override
     public String getKey() {
-        return "transformation_" + DigestUtils.sha1Hex(
-                preparationId + datasetId + stepId + format + Objects.hash(parameters) + sourceType + userId);
+        return "transformation_" + preparationId + "_"
+                + DigestUtils.sha1Hex(datasetId + stepId + format + Objects.hash(parameters) + sourceType + userId);
+    }
+
+    @Override
+    public Predicate<String> getMatcher() {
+        final String regex = "transformation_" + preparationId + "_.*";
+        return (str) -> str.matches(regex);
     }
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationCacheKey.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationCacheKey.java
@@ -20,6 +20,7 @@ import org.talend.dataprep.cache.ContentCacheKey;
 
 import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * Content cache key used to cache transformation.
@@ -107,6 +108,7 @@ public class TransformationCacheKey implements ContentCacheKey {
     @Override
     public Predicate<String> getMatcher() {
         final String regex = "transformation_" + preparationId + "_.*";
-        return (str) -> str.matches(regex);
+        final Pattern pattern = Pattern.compile(regex);
+        return str -> pattern.matcher(str).matches();
     }
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationMetadataCacheKey.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationMetadataCacheKey.java
@@ -53,7 +53,7 @@ public class TransformationMetadataCacheKey implements ContentCacheKey {
                 + (preparationId == null ? ".*" : preparationId) + "_"
                 + (stepId == null ? ".*" : stepId) + "_"
                 + (sourceType == null ? ".*" : sourceType) + "_"
-                + (userId == null ? ".*" : userId);
+                + (userId == null ? ".*" : userId) + "([.].*)?";
         return (str) -> str.matches(regex);
     }
 

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationMetadataCacheKey.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationMetadataCacheKey.java
@@ -17,6 +17,8 @@ import org.apache.commons.lang.StringUtils;
 import org.talend.dataprep.api.export.ExportParameters;
 import org.talend.dataprep.cache.ContentCacheKey;
 
+import java.util.function.Predicate;
+
 /**
  * Content cache key used to cache transformation.
  */
@@ -43,6 +45,16 @@ public class TransformationMetadataCacheKey implements ContentCacheKey {
     @Override
     public String getKey() {
         return "transformation-metadata_" + preparationId + "_" + stepId + "_" + sourceType + "_" + userId;
+    }
+
+    @Override
+    public Predicate<String> getMatcher() {
+        final String regex = "transformation-metadata_"
+                + (preparationId == null ? ".*" : preparationId) + "_"
+                + (stepId == null ? ".*" : stepId) + "_"
+                + (sourceType == null ? ".*" : sourceType) + "_"
+                + (userId == null ? ".*" : userId);
+        return (str) -> str.matches(regex);
     }
 
     public String getPreparationId() {

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationMetadataCacheKey.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationMetadataCacheKey.java
@@ -18,6 +18,7 @@ import org.talend.dataprep.api.export.ExportParameters;
 import org.talend.dataprep.cache.ContentCacheKey;
 
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 /**
  * Content cache key used to cache transformation.
@@ -54,7 +55,8 @@ public class TransformationMetadataCacheKey implements ContentCacheKey {
                 + (stepId == null ? ".*" : stepId) + "_"
                 + (sourceType == null ? ".*" : sourceType) + "_"
                 + (userId == null ? ".*" : userId) + "([.].*)?";
-        return (str) -> str.matches(regex);
+        final Pattern pattern = Pattern.compile(regex);
+        return str -> pattern.matcher(str).matches();
     }
 
     public String getPreparationId() {

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -19,16 +19,14 @@ import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static org.talend.daikon.exception.ExceptionContext.build;
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 import static org.talend.dataprep.transformation.actions.category.ScopeCategory.COLUMN;
 import static org.talend.dataprep.transformation.actions.category.ScopeCategory.LINE;
 import static org.talend.dataprep.transformation.format.JsonFormat.JSON;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -430,11 +428,19 @@ public class TransformationService extends BaseTransformationService {
     @ApiOperation(value = "Evict content entries related to the preparation", notes = "This operation remove content entries related to the preparation.")
     @VolumeMetered
     public void evictCache(@ApiParam(value = "Preparation Id.") @PathVariable(value = "preparationId") final String preparationId) {
+        for(final ExportParameters.SourceType sourceType : ExportParameters.SourceType.values()) {
+            evictCache(preparationId, sourceType);
+        }
+    }
+
+    private void evictCache(final String preparationId, final ExportParameters.SourceType sourceType) {
         final ContentCacheKey metadataKey = cacheKeyGenerator.metadataBuilder()
                 .preparationId(preparationId)
+                .sourceType(sourceType)
                 .build();
         final ContentCacheKey contentKey = cacheKeyGenerator.contentBuilder()
                 .preparationId(preparationId)
+                .sourceType(sourceType)
                 .build();
         contentCache.evictMatch(metadataKey);
         contentCache.evictMatch(contentKey);

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -15,6 +15,7 @@ package org.talend.dataprep.transformation.service;
 
 import static java.util.stream.Collectors.toList;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static org.talend.daikon.exception.ExceptionContext.build;
@@ -423,6 +424,20 @@ public class TransformationService extends BaseTransformationService {
     @VolumeMetered
     public List<StepDiff> getCreatedColumns(@ApiParam(name = "body", value = "Preview parameters list in json.") @RequestBody final List<PreviewParameters> previewParameters) {
         return previewParameters.stream().map(this::getCreatedColumns).collect(toList());
+    }
+
+    @RequestMapping(value = "/preparation/{preparationId}/cache", method = DELETE)
+    @ApiOperation(value = "Evict content entries related to the preparation", notes = "This operation remove content entries related to the preparation.")
+    @VolumeMetered
+    public void evictCache(@ApiParam(value = "Preparation Id.") @PathVariable(value = "preparationId") final String preparationId) {
+        final ContentCacheKey metadataKey = cacheKeyGenerator.metadataBuilder()
+                .preparationId(preparationId)
+                .build();
+        final ContentCacheKey contentKey = cacheKeyGenerator.contentBuilder()
+                .preparationId(preparationId)
+                .build();
+        contentCache.evictMatch(metadataKey);
+        contentCache.evictMatch(contentKey);
     }
 
     /**

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/cache/TransformationCacheKeyTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/cache/TransformationCacheKeyTest.java
@@ -80,32 +80,13 @@ public class TransformationCacheKeyTest {
     public void getMatcher_should_return_matcher_for_partial_key() throws Exception {
         // given
         final ContentCacheKey prepKey = new TransformationCacheKey("prep1", null, null, null, null, null, null);
-        final ContentCacheKey datasetKey = new TransformationCacheKey( null, "dataset1",  null, null, null, null, null);
-        final ContentCacheKey formatKey = new TransformationCacheKey( null, null, "JSON",  null, null, null, null);
-        final ContentCacheKey stepKey = new TransformationCacheKey( null, null, null, "step1",  null, null, null);
-        final ContentCacheKey paramKey = new TransformationCacheKey( null, null, null, null, "param1",  null, null);
-        final ContentCacheKey sourceKey = new TransformationCacheKey( null, null, null, null, null, HEAD,  null);
-        final ContentCacheKey userKey = new TransformationCacheKey( null, null, null, null, null, null, "user1");
 
         final ContentCacheKey matchingKey = new TransformationCacheKey("prep1", "dataset1", "JSON", "step1", "param1", HEAD, "user1");
         final ContentCacheKey nonMatchingKey = new TransformationCacheKey("prep2", "dataset2", "XLS", "step2", "param2", FILTER, "user2");
 
         // when / then
         assertThat(prepKey.getMatcher().test(matchingKey.getKey()), is(true));
-        assertThat(datasetKey.getMatcher().test(matchingKey.getKey()), is(true));
-        assertThat(formatKey.getMatcher().test(matchingKey.getKey()), is(true));
-        assertThat(stepKey.getMatcher().test(matchingKey.getKey()), is(true));
-        assertThat(paramKey.getMatcher().test(matchingKey.getKey()), is(true));
-        assertThat(sourceKey.getMatcher().test(matchingKey.getKey()), is(true));
-        assertThat(userKey.getMatcher().test(matchingKey.getKey()), is(true));
-
         assertThat(prepKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
-        assertThat(datasetKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
-        assertThat(formatKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
-        assertThat(stepKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
-        assertThat(paramKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
-        assertThat(sourceKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
-        assertThat(userKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
     }
 
     private TransformationCacheKey createTestDefaultKey() {

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/cache/TransformationCacheKeyTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/cache/TransformationCacheKeyTest.java
@@ -13,11 +13,15 @@
 
 package org.talend.dataprep.transformation.cache;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 
 import org.junit.Test;
+import org.talend.dataprep.cache.ContentCacheKey;
 import org.talend.dataprep.transformation.TransformationBaseTest;
 
 /**
@@ -25,7 +29,7 @@ import org.talend.dataprep.transformation.TransformationBaseTest;
  *
  * @see TransformationCacheKey
  */
-public class TransformationCacheKeyTest extends TransformationBaseTest {
+public class TransformationCacheKeyTest {
 
     @Test
     public void shouldGenerateKey() throws Exception {
@@ -58,6 +62,50 @@ public class TransformationCacheKeyTest extends TransformationBaseTest {
                 FILTER,
                 "user 1"
         );
+    }
+
+    @Test
+    public void getKey_should_generate_serialized_key() throws Exception {
+        // given
+        final ContentCacheKey key = new TransformationCacheKey("prep1", "dataset1", "JSON", "step1", "param1", HEAD, "user1");
+
+        // when
+        final String keyStr = key.getKey();
+
+        // then
+        assertThat(keyStr, is("transformation_prep1_223ec8d45bd185281992fae16a612fb60a9a0d16"));
+    }
+
+    @Test
+    public void getMatcher_should_return_matcher_for_partial_key() throws Exception {
+        // given
+        final ContentCacheKey prepKey = new TransformationCacheKey("prep1", null, null, null, null, null, null);
+        final ContentCacheKey datasetKey = new TransformationCacheKey( null, "dataset1",  null, null, null, null, null);
+        final ContentCacheKey formatKey = new TransformationCacheKey( null, null, "JSON",  null, null, null, null);
+        final ContentCacheKey stepKey = new TransformationCacheKey( null, null, null, "step1",  null, null, null);
+        final ContentCacheKey paramKey = new TransformationCacheKey( null, null, null, null, "param1",  null, null);
+        final ContentCacheKey sourceKey = new TransformationCacheKey( null, null, null, null, null, HEAD,  null);
+        final ContentCacheKey userKey = new TransformationCacheKey( null, null, null, null, null, null, "user1");
+
+        final ContentCacheKey matchingKey = new TransformationCacheKey("prep1", "dataset1", "JSON", "step1", "param1", HEAD, "user1");
+        final ContentCacheKey nonMatchingKey = new TransformationCacheKey("prep2", "dataset2", "XLS", "step2", "param2", FILTER, "user2");
+
+        // when / then
+        assertThat(prepKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(datasetKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(formatKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(stepKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(paramKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(sourceKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(userKey.getMatcher().test(matchingKey.getKey()), is(true));
+
+        assertThat(prepKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(datasetKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(formatKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(stepKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(paramKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(sourceKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(userKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
     }
 
     private TransformationCacheKey createTestDefaultKey() {

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/cache/TransformationMetadataCacheKeyTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/cache/TransformationMetadataCacheKeyTest.java
@@ -1,0 +1,47 @@
+package org.talend.dataprep.transformation.cache;
+
+import org.junit.Test;
+import org.talend.dataprep.cache.ContentCacheKey;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
+
+public class TransformationMetadataCacheKeyTest {
+    @Test
+    public void getKey_should_generate_serialized_key() throws Exception {
+        // given
+        final ContentCacheKey key = new TransformationMetadataCacheKey("prep1", "step1", HEAD, "user1");
+
+        // when
+        final String keyStr = key.getKey();
+
+        // then
+        assertThat(keyStr, is("transformation-metadata_prep1_step1_HEAD_user1"));
+    }
+
+    @Test
+    public void getMatcher_should_return_matcher_for_partial_key() throws Exception {
+        // given
+        final ContentCacheKey prepKey = new TransformationMetadataCacheKey("prep1", null, null, null);
+        final ContentCacheKey stepKey = new TransformationMetadataCacheKey(null, "step1", null, null);
+        final ContentCacheKey sourceKey = new TransformationMetadataCacheKey(null, null, HEAD, null);
+        final ContentCacheKey userKey = new TransformationMetadataCacheKey(null, null, null, "user1");
+
+        final ContentCacheKey matchingKey = new TransformationMetadataCacheKey("prep1", "step1", HEAD, "user1");
+        final ContentCacheKey nonMatchingKey = new TransformationMetadataCacheKey("prep2", "step2", FILTER, "user2");
+
+        // when / then
+        assertThat(prepKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(stepKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(sourceKey.getMatcher().test(matchingKey.getKey()), is(true));
+        assertThat(userKey.getMatcher().test(matchingKey.getKey()), is(true));
+
+        assertThat(prepKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(stepKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(sourceKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+        assertThat(userKey.getMatcher().test(nonMatchingKey.getKey()), is(false));
+    }
+
+}

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformTests.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformTests.java
@@ -13,34 +13,36 @@
 
 package org.talend.dataprep.transformation.service;
 
-import static com.jayway.restassured.RestAssured.given;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
-import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
-import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
-import static org.talend.dataprep.transformation.format.JsonFormat.JSON;
-
+import com.jayway.restassured.response.Response;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.talend.dataprep.api.dataset.DataSetMetadata;
 import org.talend.dataprep.api.preparation.Preparation;
 import org.talend.dataprep.cache.ContentCache;
+import org.talend.dataprep.cache.ContentCacheKey;
 import org.talend.dataprep.transformation.cache.CacheKeyGenerator;
 import org.talend.dataprep.transformation.cache.TransformationCacheKey;
 
-import com.jayway.restassured.response.Response;
-import org.talend.dataprep.transformation.format.JsonFormat;
+import java.io.OutputStream;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
+import static org.talend.dataprep.cache.ContentCache.TimeToLive.PERMANENT;
+import static org.talend.dataprep.transformation.format.JsonFormat.JSON;
 
 /**
  * Integration tests on actions.
  */
 public class TransformTests extends TransformationServiceBaseTests {
 
-    /** Content cache for the tests. */
+    /**
+     * Content cache for the tests.
+     */
     @Autowired
     private ContentCache contentCache;
 
@@ -194,6 +196,49 @@ public class TransformTests extends TransformationServiceBaseTests {
                 .get("/apply/preparation/{prepId}/dataset/{datasetId}/{format}", prepId, dsId, "JSON");
         assertThat(response.getStatusCode(), is(200));
     }
+    
+    @Test
+    public void testEvictPreparationCache() throws Exception {
+        // given
+        final String preparationId = "prepId";
+        final ContentCacheKey metadataKey = cacheKeyGenerator
+                .metadataBuilder()
+                .preparationId(preparationId)
+                .stepId("step1")
+                .sourceType(HEAD)
+                .build();
+        final ContentCacheKey contentKey = cacheKeyGenerator
+                .contentBuilder()
+                .datasetId("datasetId")
+                .preparationId(preparationId)
+                .stepId("step1")
+                .format(JSON)
+                .parameters("")
+                .sourceType(HEAD)
+                .build();
+        try (final OutputStream entry = contentCache.put(metadataKey, PERMANENT)) {
+            entry.write("metadata".getBytes());
+            entry.flush();
+        }
+        try (final OutputStream entry = contentCache.put(contentKey, PERMANENT)) {
+            entry.write("content".getBytes());
+            entry.flush();
+        }
+
+        assertThat(contentCache.has(metadataKey), is(true));
+        assertThat(contentCache.has(contentKey), is(true));
+
+        // when
+        given() //
+                .expect().statusCode(200).log().ifError()//
+                .when() //
+                .delete("/preparation/{preparationId}/cache", preparationId) //
+                .asString();
+
+        // then
+        assertThat(contentCache.has(metadataKey), is(false));
+        assertThat(contentCache.has(contentKey), is(false));
+    }
 
     @Test
     public void exportDataSet() throws Exception {
@@ -221,9 +266,9 @@ public class TransformTests extends TransformationServiceBaseTests {
 
         // when
         given() //
-            .when() //
-            .get("/apply/preparation/{preparationId}/dataset/{datasetId}/{format}", preparationId, dataSetId, "JSON") //
-            .asString();
+                .when() //
+                .get("/apply/preparation/{preparationId}/dataset/{datasetId}/{format}", preparationId, dataSetId, "JSON") //
+                .asString();
 
         // then
         // Transformation failure

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformTests.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformTests.java
@@ -31,6 +31,7 @@ import static com.jayway.restassured.RestAssured.given;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 import static org.talend.dataprep.cache.ContentCache.TimeToLive.PERMANENT;
 import static org.talend.dataprep.transformation.format.JsonFormat.JSON;
@@ -205,7 +206,7 @@ public class TransformTests extends TransformationServiceBaseTests {
                 .metadataBuilder()
                 .preparationId(preparationId)
                 .stepId("step1")
-                .sourceType(HEAD)
+                .sourceType(FILTER)
                 .build();
         final ContentCacheKey contentKey = cacheKeyGenerator
                 .contentBuilder()
@@ -214,7 +215,7 @@ public class TransformTests extends TransformationServiceBaseTests {
                 .stepId("step1")
                 .format(JSON)
                 .parameters("")
-                .sourceType(HEAD)
+                .sourceType(FILTER)
                 .build();
         try (final OutputStream entry = contentCache.put(metadataKey, PERMANENT)) {
             entry.write("metadata".getBytes());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**

- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Bugfix
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When removing a preparation, the permanent caches (introduced with custom sampling) are not removed


**What is the new behavior?**
Now before removing the preparation, the cache entries on this preparation are removed.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Other information**:
