### PR TITLE
replaced <a> tag by <span> in the grid header menus

### DIFF
--- a/dataprep-webapp/src/app/components/datagrid/index-header/datagrid-index-header-component.spec.js
+++ b/dataprep-webapp/src/app/components/datagrid/index-header/datagrid-index-header-component.spec.js
@@ -42,8 +42,8 @@ describe('Datagrid index header Component', () => {
         expect(element.find('sc-dropdown').size()).toBe(1);
         expect(element.find('sc-dropdown li').size()).toBe(3);
 
-        expect(element.find('sc-dropdown li a[translate-once="DISPLAY_ROWS_INVALID_VALUES"]').length).toBe(1);
-        expect(element.find('sc-dropdown li a[translate-once="DISPLAY_ROWS_EMPTY_VALUES"]').length).toBe(1);
-        expect(element.find('sc-dropdown li a[translate-once="DISPLAY_ROWS_INVALID_EMPTY_VALUES"]').length).toBe(1);
+        expect(element.find('sc-dropdown li[translate-once="DISPLAY_ROWS_INVALID_VALUES"]').length).toBe(1);
+        expect(element.find('sc-dropdown li[translate-once="DISPLAY_ROWS_EMPTY_VALUES"]').length).toBe(1);
+        expect(element.find('sc-dropdown li[translate-once="DISPLAY_ROWS_INVALID_EMPTY_VALUES"]').length).toBe(1);
     });
 });

--- a/dataprep-webapp/src/app/components/datagrid/index-header/datagrid-index-header.html
+++ b/dataprep-webapp/src/app/components/datagrid/index-header/datagrid-index-header.html
@@ -20,9 +20,9 @@
             <sc-dropdown-content class="grid-header-menu">
                 <span class="grid-header-menu-title" translate-once="FILTER_TITLE"></span>
                 <ul>
-                    <li><a translate-once-title="DISPLAY_ROWS_INVALID_VALUES" translate-once="DISPLAY_ROWS_INVALID_VALUES" ng-click="$ctrl.createFilter($ctrl.INVALID_RECORDS)"></a></li>
-                    <li><a translate-once-title="DISPLAY_ROWS_EMPTY_VALUES" translate-once="DISPLAY_ROWS_EMPTY_VALUES" ng-click="$ctrl.createFilter($ctrl.EMPTY_RECORDS)"></a></li>
-                    <li><a translate-once-title="DISPLAY_ROWS_INVALID_EMPTY_VALUES" translate-once="DISPLAY_ROWS_INVALID_EMPTY_VALUES" ng-click="$ctrl.createFilter($ctrl.INVALID_EMPTY_RECORDS)"></a></li>
+                    <li translate-once-title="DISPLAY_ROWS_INVALID_VALUES" translate-once="DISPLAY_ROWS_INVALID_VALUES" ng-click="$ctrl.createFilter($ctrl.INVALID_RECORDS)"></li>
+                    <li translate-once-title="DISPLAY_ROWS_EMPTY_VALUES" translate-once="DISPLAY_ROWS_EMPTY_VALUES" ng-click="$ctrl.createFilter($ctrl.EMPTY_RECORDS)"></li>
+                    <li translate-once-title="DISPLAY_ROWS_INVALID_EMPTY_VALUES" translate-once="DISPLAY_ROWS_INVALID_EMPTY_VALUES" ng-click="$ctrl.createFilter($ctrl.INVALID_EMPTY_RECORDS)"></li>
                 </ul>
             </sc-dropdown-content>
         </sc-dropdown>

--- a/dataprep-webapp/src/app/components/transformation/menu/transformation-menu.html
+++ b/dataprep-webapp/src/app/components/transformation/menu/transformation-menu.html
@@ -21,7 +21,7 @@
     <li ng-repeat="menu in menuCtrl.menuItems track by menu.name"
         ng-click="menuCtrl.select(menu, 'column')">
 
-        <a>{{ menu.label }}</a>
+        <span>{{ menu.label }}</span>
     </li>
 
 </ul>

--- a/dataprep-webapp/src/app/components/transformation/menu/type/type-transformation-menu-directive.spec.js
+++ b/dataprep-webapp/src/app/components/transformation/menu/type/type-transformation-menu-directive.spec.js
@@ -76,7 +76,7 @@ describe('Transformation menu directive', function () {
 
         //then (beware of the space char between "is a " and "CITY" which is not exactly a space)
         expect(element.find('>li >span').eq(0).text()).toBe('This column is a ');
-        expect(element.find('>li >a').text().trim()).toBe('CITY');
+        expect(element.find('>li >.info').text().trim()).toBe('CITY');
     });
 
     it('should display simplified type when there is no domain', function () {
@@ -90,7 +90,7 @@ describe('Transformation menu directive', function () {
 
         //then (beware of the space char between "is a " and "text which is not exactly a space)
         expect(element.find('>li >span').eq(0).text()).toBe('This column is a ');
-        expect(element.find('>li >a').text().trim()).toBe('text');
+        expect(element.find('>li >.info').text().trim()).toBe('text');
     });
 
     it('should render domain items with percentages', function () {

--- a/dataprep-webapp/src/app/components/transformation/menu/type/type-transformation-menu.html
+++ b/dataprep-webapp/src/app/components/transformation/menu/type/type-transformation-menu.html
@@ -14,7 +14,8 @@
   -->
 
 <li class="more">
-   <span class="itemText" translate-once="COLUMN_TYPE_IS"></span><a><span class="info">{{ typeMenuCtrl.currentSimplifiedDomain }}</span></a>
+    <span translate-once="COLUMN_TYPE_IS"></span>
+    <span class="info"> {{ typeMenuCtrl.currentSimplifiedDomain }}</span>
     <ul class="submenu">
         <li ng-repeat="semanticDomain in typeMenuCtrl.domains track by semanticDomain.id"
             ng-click="typeMenuCtrl.changeDomain(semanticDomain)">

--- a/dataprep-webapp/src/app/css/utils/_menu_list.scss
+++ b/dataprep-webapp/src/app/css/utils/_menu_list.scss
@@ -49,16 +49,9 @@
       right: 5px;
     }
 
-    a {
-      display: block;
-      color: #333;
-
-      >.info {
-        float: right;
-        color: $medium-gray;
-        text-transform: lowercase;
-        padding: 0 3px;
-      }
+    .info {
+      color: $medium-gray;
+      text-transform: lowercase;
     }
 
     &.coming-soon {
@@ -68,7 +61,6 @@
       }
       cursor: default;
     }
-
 
     >.submenu {
       @include menu-shape;
@@ -93,10 +85,6 @@
       overflow: hidden;
       background-color: #e5e5e5;
       padding: 0;
-    }
-
-    .itemText{
-      float: left;
     }
   }
 }


### PR DESCRIPTION
The <a> tag is useless, so I replaced it with a "span" tag