### PR TITLE
Bugfix/tdp 2480

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/ChangeDatePattern.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/ChangeDatePattern.java
@@ -57,7 +57,7 @@ public class ChangeDatePattern extends AbstractDate implements ColumnAction, Dat
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ChangeDatePattern.class);
 
-    private static final String FROM_MODE_BEST_GUESS = "unknown_separators"; //$NON-NLS-1$
+    protected static final String FROM_MODE_BEST_GUESS = "unknown_separators"; //$NON-NLS-1$
     /**
      * Keys for action context:
      */

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ChangeDatePatternTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ChangeDatePatternTest.java
@@ -226,6 +226,23 @@ public class ChangeDatePatternTest extends BaseDateTests {
     }
 
     @Test
+    public void test_TDP_2480() throws Exception {
+        // given
+        DataSetRow row = getRow("toto", "APR-25-09", "tata");
+        setStatistics(row, "0001", getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"));
+
+        parameters.put(ChangeDatePattern.FROM_MODE, ChangeDatePattern.FROM_MODE_CUSTOM);
+        parameters.put(ChangeDatePattern.FROM_CUSTOM_PATTERN, "MMM-dd-yy");
+
+        // when
+        ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
+
+        // then
+        final DataSetRow expectedRow = getRow("toto", "25 - Apr - 2009", "tata");
+        assertEquals(expectedRow.values(), row.values());
+    }
+
+    @Test
     public void test_TDP_2255_not_working_with_timezone_in_format() throws Exception {
         // given
         DataSetRow row = getRow("toto", "Apr-25-09", "tata");

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ChangeDatePatternTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ChangeDatePatternTest.java
@@ -251,7 +251,7 @@ public class ChangeDatePatternTest extends BaseDateTests {
         // row 1
         Map<String, String> rowContent = new HashMap<>();
         rowContent.put("0000", "David");
-        rowContent.put("0001", "6/12/2015 0:01");
+        rowContent.put("0001", "6/12/2015 0:01"); // Test nominal case
         final DataSetRow row1 = new DataSetRow(rowContent);
         row1.setTdpId(rowId++);
         setStatistics(row1, "0001", getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"));
@@ -259,10 +259,18 @@ public class ChangeDatePatternTest extends BaseDateTests {
         // row 2
         rowContent = new HashMap<>();
         rowContent.put("0000", "John");
-        rowContent.put("0001", "12/14/2015 1:18 AM");
+        rowContent.put("0001", "12/14/2015 1:18 AM"); // Test with AM
         final DataSetRow row2 = new DataSetRow(rowContent);
         row2.setTdpId(rowId++);
         setStatistics(row2, "0001", getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"));
+
+        // row 3
+        rowContent = new HashMap<>();
+        rowContent.put("0000", "James");
+        rowContent.put("0001", "9-oct-2016"); // Test with MMM invalid case
+        final DataSetRow row3 = new DataSetRow(rowContent);
+        row3.setTdpId(rowId++);
+        setStatistics(row3, "0001", getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"));
 
         final Map<String, String> parameters = new HashMap<>();
         parameters.put(ImplicitParameters.SCOPE.getKey().toLowerCase(), "column");
@@ -271,11 +279,12 @@ public class ChangeDatePatternTest extends BaseDateTests {
         parameters.put("column_id", "0001");
 
         // when
-        ActionTestWorkbench.test(Arrays.asList(row1, row2), actionRegistry, factory.create(action, parameters));
+        ActionTestWorkbench.test(Arrays.asList(row1, row2, row3), actionRegistry, factory.create(action, parameters));
 
         // then
         assertEquals("2015-06-12", row1.get("0001"));
         assertEquals("2015-12-14", row2.get("0001"));
+        assertEquals("2016-10-09", row3.get("0001"));
     }
 
     @Test

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ChangeDatePatternTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ChangeDatePatternTest.java
@@ -32,6 +32,7 @@ import org.talend.dataprep.api.type.Type;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.transformation.actions.ActionMetadataTestUtils;
 import org.talend.dataprep.transformation.actions.category.ActionCategory;
+import org.talend.dataprep.transformation.actions.common.ImplicitParameters;
 import org.talend.dataprep.transformation.api.action.ActionTestWorkbench;
 
 /**
@@ -240,6 +241,41 @@ public class ChangeDatePatternTest extends BaseDateTests {
         // then
         final DataSetRow expectedRow = getRow("toto", "25 - Apr - 2009", "tata");
         assertEquals(expectedRow.values(), row.values());
+    }
+
+    @Test
+    public void test_TDP_2636() throws Exception {
+        // given
+        long rowId = 120;
+
+        // row 1
+        Map<String, String> rowContent = new HashMap<>();
+        rowContent.put("0000", "David");
+        rowContent.put("0001", "6/12/2015 0:01");
+        final DataSetRow row1 = new DataSetRow(rowContent);
+        row1.setTdpId(rowId++);
+        setStatistics(row1, "0001", getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"));
+
+        // row 2
+        rowContent = new HashMap<>();
+        rowContent.put("0000", "John");
+        rowContent.put("0001", "12/14/2015 1:18 AM");
+        final DataSetRow row2 = new DataSetRow(rowContent);
+        row2.setTdpId(rowId++);
+        setStatistics(row2, "0001", getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"));
+
+        final Map<String, String> parameters = new HashMap<>();
+        parameters.put(ImplicitParameters.SCOPE.getKey().toLowerCase(), "column");
+        parameters.put(ChangeDatePattern.FROM_MODE, ChangeDatePattern.FROM_MODE_BEST_GUESS);
+        parameters.put(ChangeDatePattern.NEW_PATTERN, "yyyy-MM-dd");
+        parameters.put("column_id", "0001");
+
+        // when
+        ActionTestWorkbench.test(Arrays.asList(row1, row2), actionRegistry, factory.create(action, parameters));
+
+        // then
+        assertEquals("2015-06-12", row1.get("0001"));
+        assertEquals("2015-12-14", row2.get("0001"));
     }
 
     @Test

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
@@ -93,6 +93,33 @@ public class ExtractDateTokensTest extends BaseDateTests {
     }
 
     @Test
+    public void test_TDP_2480() throws Exception {
+        // given
+        final Map<String, String> values = new HashMap<>();
+        values.put("0000", "toto");
+        values.put("0001", "Apr-25-1999");
+        values.put("0002", "tata");
+
+        final DataSetRow row = new DataSetRow(values);
+        setStatistics(row, "0001", getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"));
+
+        final Map<String, String> expectedValues = new HashMap<>();
+        expectedValues.put("0000", "toto");
+        expectedValues.put("0001", "Apr-25-1999");
+        expectedValues.put("0003", "1999");
+        expectedValues.put("0004", "4");
+        expectedValues.put("0005", "0");
+        expectedValues.put("0006", "0");
+        expectedValues.put("0002", "tata");
+
+        //when
+        ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
+
+        // then
+        assertEquals(expectedValues, row.values());
+    }
+
+    @Test
     public void should_process_row_with_time() throws Exception {
         // given
         final Map<String, String> values = new HashMap<>();

--- a/dataprep-actions/src/test/resources/org/talend/dataprep/transformation/actions/date/statistics_MM_dd_yyyy.json
+++ b/dataprep-actions/src/test/resources/org/talend/dataprep/transformation/actions/date/statistics_MM_dd_yyyy.json
@@ -81,6 +81,10 @@
       "occurrences": 27
     },
     {
+      "pattern": "MMM-dd-yyyy",
+      "occurrences": 1
+    },
+    {
       "pattern": "",
       "occurrences": 18
     }

--- a/dataprep-actions/src/test/resources/org/talend/dataprep/transformation/actions/date/statistics_MM_dd_yyyy.json
+++ b/dataprep-actions/src/test/resources/org/talend/dataprep/transformation/actions/date/statistics_MM_dd_yyyy.json
@@ -85,6 +85,10 @@
       "occurrences": 1
     },
     {
+      "pattern": "d-MMM-yyyy",
+      "occurrences": 1
+    },
+    {
       "pattern": "M/d/yyyy H:mm",
       "occurrences": 1
     },

--- a/dataprep-actions/src/test/resources/org/talend/dataprep/transformation/actions/date/statistics_MM_dd_yyyy.json
+++ b/dataprep-actions/src/test/resources/org/talend/dataprep/transformation/actions/date/statistics_MM_dd_yyyy.json
@@ -85,6 +85,14 @@
       "occurrences": 1
     },
     {
+      "pattern": "M/d/yyyy H:mm",
+      "occurrences": 1
+    },
+    {
+      "pattern": "M/d/yyyy h:mm a",
+      "occurrences": 1
+    },
+    {
       "pattern": "",
       "occurrences": 18
     }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/actions/date/DateParser.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/actions/date/DateParser.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.WordUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -159,12 +160,12 @@ public class DateParser {
 
             // first try to parse directly as LocalDateTime
             try {
-                return LocalDateTime.parse(value, formatter);
+                return LocalDateTime.parse(WordUtils.capitalizeFully(value), formatter);
             } catch (DateTimeException e) {
                 LOGGER.trace("Unable to parse date '{}' using LocalDateTime.", value, e);
                 // if it fails, let's try the LocalDate first
                 try {
-                    LocalDate temp = LocalDate.parse(value, formatter);
+                    LocalDate temp = LocalDate.parse(WordUtils.capitalizeFully(value), formatter);
                     return temp.atStartOfDay();
                 } catch (DateTimeException e2) {
                     LOGGER.trace("Unable to parse date '{}' using LocalDate.", value, e2);

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/actions/date/DateParser.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/actions/date/DateParser.java
@@ -20,6 +20,7 @@ import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.*;
 
 import org.apache.commons.lang.StringUtils;
@@ -64,8 +65,8 @@ public class DateParser {
     /**
      * Parse the date time out of the given value based on the column date pattern.
      * <p>
-     * At first uses the known date patterns from the column statistics. If it fails, the DQ library is called to try to
-     * get the pattern.
+     * At first uses the known date patterns from the column statistics. If it fails, the DQ library is called to try to get the
+     * pattern.
      *
      * @param value the value to get the date time from. Value can't be be empty or null/
      * @param column the column to get the date patterns from.
@@ -156,16 +157,19 @@ public class DateParser {
         }
 
         for (DatePattern pattern : patterns) {
-            final DateTimeFormatter formatter = pattern.getFormatter();
+                final DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                    .parseCaseInsensitive()
+                    .append(pattern.getFormatter())
+                    .toFormatter(Locale.ENGLISH);
 
             // first try to parse directly as LocalDateTime
             try {
-                return LocalDateTime.parse(WordUtils.capitalizeFully(value), formatter);
+                return LocalDateTime.parse(value, formatter);
             } catch (DateTimeException e) {
                 LOGGER.trace("Unable to parse date '{}' using LocalDateTime.", value, e);
                 // if it fails, let's try the LocalDate first
                 try {
-                    LocalDate temp = LocalDate.parse(WordUtils.capitalizeFully(value), formatter);
+                    LocalDate temp = LocalDate.parse(value, formatter);
                     return temp.atStartOfDay();
                 } catch (DateTimeException e2) {
                     LOGGER.trace("Unable to parse date '{}' using LocalDate.", value, e2);


### PR DESCRIPTION
2480 first fix has caused regressions: 2636 & 2638.
2638 is closed as a duplicate of 2636.

Things did on this PR:

1. revert the revert of 2480 (redo the previous fix)
2. add a junit for 2636 to reproduce the problem (in ChangeDatePatternTest/test_TDP_2636())
3. fix the both tests test_TDP_2636() and test_TDP_2480() by using DateTimeFormatterBuilder and parseCaseInsensitive in DateParser

Problem still to be fixed: This solution works only for month in english...