### PR TITLE
TDP-2670: do not compute filtered stats when we dont have stats

### DIFF
--- a/dataprep-webapp/src/app/components/playground/playground-controller.js
+++ b/dataprep-webapp/src/app/components/playground/playground-controller.js
@@ -208,6 +208,7 @@ export default function PlaygroundCtrl($timeout, $state, $stateParams, state, St
      * @description Playground close callback. It reset the playground and redirect to the previous page
      */
     vm.close = function close() {
+        $timeout.cancel(vm.fetchStatsTimeout);
         $timeout(StateService.resetPlayground, 500, false);
         $state.go(state.route.previous, state.route.previousOptions);
     };
@@ -255,7 +256,9 @@ export default function PlaygroundCtrl($timeout, $state, $stateParams, state, St
         StateService.setIsFetchingStats(true);
         PlaygroundService.updateStatistics()
             .then(() => StateService.setIsFetchingStats(false))
-            .catch(() => $timeout(fetchStatistics, 1500, false));
+            .catch(() => {
+                vm.fetchStatsTimeout = $timeout(fetchStatistics, 1500, false);
+            });
     }
 
     //--------------------------------------------------------------------------------------------------------------

--- a/dataprep-webapp/src/app/services/statistics/statistics-service.js
+++ b/dataprep-webapp/src/app/services/statistics/statistics-service.js
@@ -810,7 +810,9 @@ export default function StatisticsService($q, $log, $filter, state, StateService
 
         if (!aggregationName) {
             const column = state.playground.grid.selectedColumns[0];
-            if (!column) {
+            const numberOrDateHistogram = column.statistics.histogram;
+            const frequencyTable = column.statistics.frequencyTable;
+            if (!column || (!numberOrDateHistogram && !frequencyTable.length)) {
                 return;
             }
             const simplifiedType = ConverterService.simplifyType(column.type);

--- a/dataprep-webapp/src/app/services/statistics/statistics-service.spec.js
+++ b/dataprep-webapp/src/app/services/statistics/statistics-service.spec.js
@@ -729,7 +729,10 @@ describe('Statistics service', () => {
         it('should create a function that do nothing when the selected column is NOT the same', inject(function (StatisticsService, StateService) {
             //given
             stateMock.playground.statistics.histogram = {};
-            stateMock.playground.grid.selectedColumns = [{ id: '0000', statistics: { min: 5, max: 55 } }];
+            stateMock.playground.grid.selectedColumns = [{
+                id: '0000',
+                statistics: { min: 5, max: 55 }
+            }];
 
             const removeCallback = StatisticsService.getRangeFilterRemoveFn();
 
@@ -1123,7 +1126,10 @@ describe('Statistics service', () => {
             });
             expect(StateService.setStatisticsFilteredHistogram).toHaveBeenCalledWith({
                 data: [
-                    { formattedValue: '<span class="hiddenChars">   </span>toto', filteredOccurrences: 3 },
+                    {
+                        formattedValue: '<span class="hiddenChars">   </span>toto',
+                        filteredOccurrences: 3
+                    },
                     { formattedValue: 'titi', filteredOccurrences: 2 },
                     { formattedValue: 'coucou', filteredOccurrences: 0 },
                     { formattedValue: 'cici', filteredOccurrences: 0 },
@@ -1176,7 +1182,10 @@ describe('Statistics service', () => {
             });
             expect(StateService.setStatisticsFilteredHistogram).toHaveBeenCalledWith({
                 data: [
-                    { formattedValue: '<span class="hiddenChars">   </span>toto', filteredOccurrences: 3 },
+                    {
+                        formattedValue: '<span class="hiddenChars">   </span>toto',
+                        filteredOccurrences: 3
+                    },
                     { formattedValue: 'titi', filteredOccurrences: 2 },
                     { formattedValue: 'coucou', filteredOccurrences: 0 },
                     { formattedValue: 'cici', filteredOccurrences: 0 },
@@ -1755,7 +1764,10 @@ describe('Statistics service', () => {
                 });
                 expect(StateService.setStatisticsFilteredHistogram).toHaveBeenCalledWith({
                     data: [
-                        { formattedValue: '<span class="hiddenChars">   </span>toto', filteredOccurrences: 3 },
+                        {
+                            formattedValue: '<span class="hiddenChars">   </span>toto',
+                            filteredOccurrences: 3
+                        },
                         { formattedValue: 'titi', filteredOccurrences: 2 },
                         { formattedValue: 'coucou', filteredOccurrences: 0 },
                         { formattedValue: 'cici', filteredOccurrences: 0 },
@@ -1772,7 +1784,12 @@ describe('Statistics service', () => {
             it('should set the frequency data with formatted value when column type is "string" without filter', inject(function (StatisticsService, StateService) {
                 //given
                 stateMock.playground.grid.selectedColumns = [barChartStrCol2];
-                stateMock.playground.grid.filteredOccurences = { '   toto': 1, coucou: 1, cici: 1, titi: 1 };
+                stateMock.playground.grid.filteredOccurences = {
+                    '   toto': 1,
+                    coucou: 1,
+                    cici: 1,
+                    titi: 1
+                };
                 expect(StatisticsService.histogram).toBeFalsy();
 
                 //when
@@ -1799,7 +1816,10 @@ describe('Statistics service', () => {
                 });
                 expect(StateService.setStatisticsFilteredHistogram).toHaveBeenCalledWith({
                     data: [
-                        { formattedValue: '<span class="hiddenChars">   </span>toto', filteredOccurrences: 1 },
+                        {
+                            formattedValue: '<span class="hiddenChars">   </span>toto',
+                            filteredOccurrences: 1
+                        },
                         { formattedValue: 'titi', filteredOccurrences: 1 },
                         { formattedValue: 'coucou', filteredOccurrences: 1 },
                         { formattedValue: 'cici', filteredOccurrences: 1 },
@@ -2633,6 +2653,30 @@ describe('Statistics service', () => {
             _StateService = StateService;
         }));
 
+        it('should do nothing when there is no statistics yet', () => {
+            //given
+            stateMock.playground.grid.selectedColumns = [{
+                statistics: {
+                    frequencyTable: [],
+                    histogram: null,
+                }
+            }];
+            stateMock.playground.statistics.histogram = {};
+            stateMock.playground.grid.filteredOccurences = {
+                1: 2,
+                3: 1,
+                11: 6,
+            };
+            spyOn(_StorageService, 'getAggregation').and.returnValue();
+
+            //when
+            _StatisticsService.updateFilteredStatistics();
+            _$rootScope.$digest();
+
+            //then
+            expect(_StateService.setStatisticsFilteredHistogram).not.toHaveBeenCalled();
+        });
+
         it('should update filtered Numeric column', () => {
             //given
             stateMock.playground.grid.selectedColumns = [barChartNumCol];
@@ -2775,7 +2819,10 @@ describe('Statistics service', () => {
             //then
             expect(_StateService.setStatisticsFilteredHistogram).toHaveBeenCalledWith({
                 data: [
-                    { formattedValue: '<span class="hiddenChars">   </span>toto', filteredOccurrences: 3 },
+                    {
+                        formattedValue: '<span class="hiddenChars">   </span>toto',
+                        filteredOccurrences: 3
+                    },
                     { formattedValue: 'titi', filteredOccurrences: 2 },
                     { formattedValue: 'coucou', filteredOccurrences: 0 },
                     { formattedValue: 'cici', filteredOccurrences: 0 },
@@ -2791,9 +2838,10 @@ describe('Statistics service', () => {
 
         it('should update filtered Patterns Frequency', (done) => {
             //given
-            stateMock.playground.grid.selectedColumns[0].statistics.patternFrequencyTable = [
-                { pattern: '', occurrences: 1 },
-            ];
+            stateMock.playground.grid.selectedColumns[0].statistics = {
+                patternFrequencyTable: [{ pattern: '', occurrences: 1 }],
+                frequencyTable: [{}],
+            };
             stateMock.playground.grid.filteredRecords = [{ '0001': 'toto' }];
 
             //when


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
1. Import a BIG dataset. Wait for the playground to open
2. The playground is still trying to fetch the stats. Add a filter.
3. Close the playground
4. Open the dataset again (before the stats are fully computed)

We have an error in console during filtered statistics computation (no stats yet).
The previous filters are not set du to the error.


**What is the new behavior?**
We don't compute filtered stats when we dont have stats


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
