### PR TITLE
TDP-2754: made the root step PreparationActions ID constant to the value generated by the old code

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/configuration/BaseContent.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/configuration/BaseContent.java
@@ -13,6 +13,9 @@
 
 package org.talend.dataprep.configuration;
 
+import java.io.IOException;
+import java.util.Collections;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,14 +28,14 @@ import org.talend.dataprep.api.service.info.VersionService;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
 
-import java.io.IOException;
-import java.util.Collections;
-
 /**
  * Provide instance for root/initial content with current application version.
  */
 @Configuration
 public class BaseContent {
+
+    /** Kept here for compatibility between versions. **/
+    private static final String CONSTANT_ROOT_STEP_PREPARATION_ACTIONS_ID = "cdcd5c9a3a475f2298b5ee3f4258f8207ba10879";
 
     /** The version service. */
     @Autowired
@@ -59,7 +62,10 @@ public class BaseContent {
      */
     @Bean(name = "rootContent")
     public PreparationActions initRootContent() {
-        return new PreparationActions(Collections.emptyList(), versionService.version().getVersionId());
+        PreparationActions preparationActions = new PreparationActions(Collections.emptyList(),
+                versionService.version().getVersionId());
+        preparationActions.setId(CONSTANT_ROOT_STEP_PREPARATION_ACTIONS_ID);
+        return preparationActions;
     }
 
     /**

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/preparation/PreparationTest.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/preparation/PreparationTest.java
@@ -14,7 +14,6 @@
 package org.talend.dataprep.preparation;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Resource;
@@ -70,13 +69,14 @@ public class PreparationTest {
 
     @Test
     public void rootObjects() throws Exception {
-        PreparationActions rootPreparationActions = new PreparationActions(Collections.emptyList(),
-                versionService.version().getVersionId());
-        assertThat(repository.get(rootPreparationActions.getId(), PreparationActions.class), notNullValue());
-        assertThat(repository.get("cdcd5c9a3a475f2298b5ee3f4258f8207ba10879", Step.class), nullValue());
-        assertThat(repository.get("f6e172c33bdacbc69bca9d32b2bd78174712a171", PreparationActions.class), nullValue());
-        Step rootStep = new Step(null, rootPreparationActions.id(), versionService.version().getVersionId());
+        assertThat(repository.get(rootContent.getId(), PreparationActions.class), notNullValue());
+        assertThat(repository.get(rootContent.getId(), PreparationActions.class).getId(),
+                is("cdcd5c9a3a475f2298b5ee3f4258f8207ba10879"));
+        assertThat(repository.get(rootContent.getId(), Step.class), nullValue());
+
+        assertThat(repository.get(rootStep.getId(), PreparationActions.class), nullValue());
         assertThat(repository.get(rootStep.getId(), Step.class), notNullValue());
+        assertThat(repository.get(rootStep.getId(), Step.class).getId(), is("f6e172c33bdacbc69bca9d32b2bd78174712a171"));
     }
 
     @Test

--- a/dataprep-backend-common/src/test/resources/org/talend/dataprep/preparation/preparationDetailsSteps.json
+++ b/dataprep-backend-common/src/test/resources/org/talend/dataprep/preparation/preparationDetailsSteps.json
@@ -4,7 +4,7 @@
   "author": "myAuthor",
   "name": null,
   "steps": [
-    "82dd02de41717cec1cd234fdbd9edb64f5fe2fc0"
+    "f6e172c33bdacbc69bca9d32b2bd78174712a171"
   ],
   "actions": [],
   "metadata": []

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
@@ -20,8 +20,6 @@ import java.util.List;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -41,8 +39,6 @@ import static org.springframework.web.bind.annotation.RequestMethod.*;
 @RestController
 @Api(value = "preparations", basePath = "/preparations", description = "Operations on preparations")
 public class PreparationController {
-
-    private static final Logger log = LoggerFactory.getLogger(PreparationController.class);
 
     @Autowired
     private PreparationService preparationService;

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -861,15 +861,6 @@ public class PreparationService {
         }
     }
 
-    private List<Action> extractActionsAtStep(final Step step) {
-
-        Step parentStep = getStep(step.getParent());
-        List<Action> current = getActions(step);
-        int numberOfActionsBeforeStep = getActions(parentStep).size();
-
-        return current.subList(numberOfActionsBeforeStep, current.size());
-    }
-
     /**
      * Get the steps ids from a specific step to the head. The specific step MUST be defined as an existing step of the
      * preparation

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/service/PreparationControllerTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/service/PreparationControllerTest.java
@@ -90,7 +90,7 @@ public class PreparationControllerTest extends BasePreparationTest {
                 .body(sameJSONAs("[{\"id\":\"#548425458\"," + "\"dataSetId\":\"1234\"," + "\"author\":null," + "\"name\":null,"
                         + "\"creationDate\":0," + "\"lastModificationDate\":12345,"
                         + "\"owner\":null,"
-                        + "\"steps\":[\"82dd02de41717cec1cd234fdbd9edb64f5fe2fc0\"]," + "\"diff\":[]," + "\"actions\":[],"
+                        + "\"steps\":[\"f6e172c33bdacbc69bca9d32b2bd78174712a171\"]," + "\"diff\":[]," + "\"actions\":[],"
                         + "\"metadata\":[]" + "}]"));
 
         // given
@@ -116,7 +116,7 @@ public class PreparationControllerTest extends BasePreparationTest {
                                 "\"creationDate\":0," +
                                 "\"lastModificationDate\":12345," +
                                 "\"owner\":null," +
-                                "\"steps\":[\"82dd02de41717cec1cd234fdbd9edb64f5fe2fc0\"]," +
+                                "\"steps\":[\"f6e172c33bdacbc69bca9d32b2bd78174712a171\"]," +
                                 "\"diff\":[]," +
                                 "\"actions\":[]," +
                                 "\"metadata\":[]" +
@@ -128,7 +128,7 @@ public class PreparationControllerTest extends BasePreparationTest {
                                 "\"creationDate\":500," +
                                 "\"lastModificationDate\":456789," +
                                 "\"owner\":null," +
-                                "\"steps\":[\"82dd02de41717cec1cd234fdbd9edb64f5fe2fc0\"]," +
+                                "\"steps\":[\"f6e172c33bdacbc69bca9d32b2bd78174712a171\"]," +
                                 "\"diff\":[]," +
                                 "\"actions\":[]," +
                                 "\"metadata\":[]" +

--- a/dataprep-preparation/src/test/resources/org/talend/dataprep/preparation/service/preparation_1234.json
+++ b/dataprep-preparation/src/test/resources/org/talend/dataprep/preparation/service/preparation_1234.json
@@ -4,6 +4,6 @@
   "author": null,
   "creationDate": 0,
   "lastModificationDate": 12345,
-  "steps": ["82dd02de41717cec1cd234fdbd9edb64f5fe2fc0"],
+  "steps": ["f6e172c33bdacbc69bca9d32b2bd78174712a171"],
   "actions": []
 }

--- a/dataprep-preparation/src/test/resources/org/talend/dataprep/preparation/service/preparation_beer.json
+++ b/dataprep-preparation/src/test/resources/org/talend/dataprep/preparation/service/preparation_beer.json
@@ -4,6 +4,6 @@
   "author": null,
   "creationDate": 1,
   "lastModificationDate": 6789,
-  "steps": ["82dd02de41717cec1cd234fdbd9edb64f5fe2fc0"],
+  "steps": ["f6e172c33bdacbc69bca9d32b2bd78174712a171"],
   "actions": []
 }]


### PR DESCRIPTION
As the PreparationActions id generation changed, the root has its id forced to the 1.3 one to keep compatibility.
