### PR TITLE
TDP-2784: fix bootstrap theme to version 0.6.x as quick fix

### DIFF
--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -38,7 +38,7 @@
     "angular-ui-router": "^0.2.15",
     "angularjs-toaster": "^0.4.10",
     "animate.css": "^3.5.1",
-    "bootstrap-talend-theme": "^0.x.x",
+    "bootstrap-talend-theme": "^0.6.x",
     "bourbon": "^4.2.7",
     "bourbon-neat": "^1.8.0",
     "d3": "^3.5.5",


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-XXXX
[TDP-2784](https://jira.talendforge.org/browse/TDP-2784)

**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)

**(Optional) What is the current behavior?**
(Additional information to the Jira)
Bootstrap-theme version that we pull was 0.x.x but in 0.7, there is a provided font packaged with it and our build system do not package it --> problem when it try to get the font.

**(Optional) What is the new behavior?**
(Additional information to the Jira)
`This is a quick fix to unblock the build !`
We pull a version 0.6.x instead, but a new PR will come to package the font and remove the font definition defined in data-prep

**(Optional) Other information**:

