### PR TITLE
fix(lookup): add-to-dataset font size

### DIFF
--- a/dataprep-webapp/src/app/components/lookup/grid/header/_lookup-datagrid-header.scss
+++ b/dataprep-webapp/src/app/components/lookup/grid/header/_lookup-datagrid-header.scss
@@ -14,61 +14,60 @@
 $datagrid-header-bkg: $dark-gray;
 
 .grid-header {
-  $datagrid-header: #266092;
-  $datagrid-header-bkg-active: darken($datagrid-header-bkg, 10%);
+	$datagrid-header: #266092;
+	$datagrid-header-bkg-active: darken($datagrid-header-bkg, 10%);
 
-  $datagrid-headercell-font-size: .95em;
+	$datagrid-headercell-font-size: .95em;
 
-  background-color: $datagrid-header-bkg;
-  border: 1px solid transparent; /*rgb(221, 221, 221);*/
-  color: $white;
-  text-transform: uppercase;
-  font-family: $monospace;
-  font-weight: 700;
-  font-size: $datagrid-headercell-font-size;
-  cursor: default;
-  padding: 5px 5px 0;
+	background-color: $datagrid-header-bkg;
+	border: 1px solid transparent; /*rgb(221, 221, 221);*/
+	color: $white;
+	text-transform: uppercase;
+	font-family: $monospace;
+	font-weight: 700;
+	font-size: $datagrid-headercell-font-size;
+	cursor: default;
+	padding: 5px 5px 0;
 
-  &:hover {
-    background-color: $datagrid-header-bkg-active;
-    border: 1px solid gray;
-    cursor: default;
-  }
+	&:hover {
+		background-color: $datagrid-header-bkg-active;
+		border: 1px solid gray;
+		cursor: default;
+	}
 
-  .grid-header-type {
-    @include ellipsis();
-    height: 100%;
-    text-transform: lowercase;
-    font-size: 0.75em;
-    font-weight: 300;
-    text-align: right;
-    display: block;
-  }
+	.grid-header-type {
+		@include ellipsis();
+		height: 100%;
+		text-transform: lowercase;
+		font-size: 0.75em;
+		font-weight: 300;
+		text-align: right;
+		display: block;
+	}
 
-  .talend-dropdown-text-div {
-    overflow: hidden;
-    max-width: 90%;
-    height: 23px;
-    .grid-header-title {
-      width: 100%;
-      height: 100%
-    }
-  }
+	.talend-dropdown-text-div {
+		overflow: hidden;
+		max-width: 90%;
+		height: 23px;
+		.grid-header-title {
+			width: 100%;
+			height: 100%
+		}
+	}
 }
 
-.add-to-lookup{
-  background-color: $white;
-  font-weight: 700;
-  font-size: .75rem;
-  color: $dark-blue;
-  input[type="checkbox"]{
-    margin-left: 5px;
-    margin-right: 0px;
-  }
+.add-to-lookup {
+	background-color: $white;
+	font-weight: 700;
+	color: $dark-blue;
+	input[type="checkbox"] {
+		margin-left: 5px;
+		margin-right: 0;
+	}
 }
 
 .lookup-grid-header {
-  .quality-bar {
-    border-bottom: 1px solid silver;
-  }
+	.quality-bar {
+		border-bottom: 1px solid silver;
+	}
 }


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-XXXX
None

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)

**(Optional) What is the current behavior?**
(Additional information to the Jira)
After bootstrap integration, the font size changed and introduced some regression. The `add to dataset` label in lookup panel is a regression that has not been fixed.

**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:

