### PR TITLE
fix: remove ":" in horizontal barchart labels

### DIFF
--- a/dataprep-webapp/src/app/components/widgets/charts/horizontal-barchart/horizontal-barchart.scss
+++ b/dataprep-webapp/src/app/components/widgets/charts/horizontal-barchart/horizontal-barchart.scss
@@ -12,96 +12,101 @@
   ============================================================================*/
 
 .horizontal-barchart-cls {
-  font-family: $inconsolota;
-  .bg-rect {
-    fill: $medium-gray;
-    cursor: pointer;
-  }
+	font-family: $inconsolota;
+	.bg-rect {
+		fill: $medium-gray;
+		cursor: pointer;
+	}
 
-  .primaryBar,
-  .secondaryBar {
-    rect {
-      &.transparentBar {
-        fill: $light-blue;
-      }
-      &.blueBar {
-        fill: $dark-blue;
-      }
-      &.brownBar {
-        fill: $brown;
-      }
-    }
-  }
+	.primaryBar,
+	.secondaryBar {
+		rect {
+			&.transparentBar {
+				fill: $light-blue;
+			}
+			&.blueBar {
+				fill: $dark-blue;
+			}
+			&.brownBar {
+				fill: $brown;
+			}
+		}
+	}
 
-  .label {
-    @include ellipsis();
-    background-color: rgba(255, 255, 255, 0);
-    font-size: .8em;
-    padding-top: 3px;
-    padding-left: 10px;
-    font-family: $inconsolota;
+	.label {
+		@include ellipsis();
+		background-color: rgba(255, 255, 255, 0);
+		font-size: .8em;
+		padding-top: 3px;
+		padding-left: 10px;
+		font-family: $inconsolota;
 
-    &.blueBar {
-      color: $dark-green;
-    }
-    &.brownBar {
-      color: $dark-brown;
-    }
-  }
+		&.blueBar {
+			color: $dark-green;
+		}
 
-  .grid {
-    shape-rendering: crispEdges;
+		&.brownBar {
+			color: $dark-brown;
+		}
 
-    path {
-      fill: none;
-    }
+		&::after {
+			content: none;
+		}
+	}
 
-    line {
-      stroke: #6c6769;
-      stroke-opacity: .1;
-    }
+	.grid {
+		shape-rendering: crispEdges;
 
-    text {
-      font-size: .8em;
-      fill: $medium-gray;
-    }
-  }
+		path {
+			fill: none;
+		}
 
-  .hiddenChars {
-    background-color: #E9E9E9;
-    border: 1px dotted #BABABA;
-    white-space: pre;
-  }
+		line {
+			stroke: #6c6769;
+			stroke-opacity: .1;
+		}
 
-  &.d3-tip {
-    line-height: 1;
-    font-size: .8em;
-    font-weight: 400;
-    padding: 12px;
-    background: rgba(0, 0, 0, 0.6);
-    color: $white;
-    border-radius: 2px;
-    z-index: 100000;
-    right: 15px;
+		text {
+			font-size: .8em;
+			fill: $medium-gray;
+		}
+	}
 
-    &:after {
-      /* Creates a small triangle extender for the tooltip */
-      box-sizing: border-box;
-      display: inline;
-      width: 100%;
-      line-height: 1;
-      color: rgba(0, 0, 0, 0.8);
-      content: "\25BC";
-      position: absolute;
-      text-align: center;
-    }
-  }
+	.hiddenChars {
+		background-color: #E9E9E9;
+		border: 1px dotted #BABABA;
+		white-space: pre;
+	}
 
-  /* Style northward tooltips differently */
-  &.d3-tip.n:after {
-    margin: -1px 0 0 0;
-    top: 100%;
-    left: 0;
-  }
+	&.d3-tip {
+		line-height: 1;
+		font-size: .8em;
+		font-weight: 400;
+		padding: 12px;
+		background: rgba(0, 0, 0, 0.6);
+		color: $white;
+		border-radius: 2px;
+		z-index: 100000;
+		right: 15px;
+
+		&:after {
+			/* Creates a small triangle extender for the tooltip */
+			box-sizing: border-box;
+			display: inline;
+			width: 100%;
+			line-height: 1;
+			color: rgba(0, 0, 0, 0.8);
+			content: "\25BC";
+			position: absolute;
+			text-align: center;
+		}
+	}
+
+	/* Style northward tooltips differently */
+	&.d3-tip.n:after {
+		margin: -1px 0 0 0;
+		top: 100%;
+		left: 0;
+	}
 
 }


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2895

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)

**(Optional) What is the current behavior?**
(Additional information to the Jira)
The bootstrap theme add `:` after label class. Unfortunally, the horizontal barchart labels have a `label` class.

**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:

