### PR TITLE
chore: set NODE_ENV in webpack to enable production mode on react

### DIFF
--- a/dataprep-webapp/config/webpack.config.js
+++ b/dataprep-webapp/config/webpack.config.js
@@ -56,6 +56,14 @@ function getDefaultConfig(options) {
 	};
 }
 
+function addProdEnvPlugin(config) {
+	config.plugins.push(new webpack.DefinePlugin({
+		'process.env': {
+			NODE_ENV: JSON.stringify("production")
+		}
+	}));
+}
+
 function addDevServerConfig(config) {
 	config.devServer = {
 		port: appConf.port,
@@ -182,6 +190,10 @@ function addLinterConfig(config) {
  */
 module.exports = (options) => {
 	const config = getDefaultConfig(options);
+
+	if (options.env === 'prod') {
+		addProdEnvPlugin(config);
+	}
 
 	if (options.devServer) {
 		addDevServerConfig(config);


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-XXXX

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !

**(Optional) What is the current behavior?**
(Additional information to the Jira)
In production mode, the react lib was the one from development mode, just minified. That includes a great loss of performance compared to the react production mode.

**(Optional) What is the new behavior?**
(Additional information to the Jira)
Webpack set the NODE_ENV to enable production mode in react.

**(Optional) Other information**:

