### PR TITLE
(fix) Fix missing row metadata in serialized preparation details.

### DIFF
--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITestClient.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITestClient.java
@@ -1,19 +1,21 @@
 package org.talend.dataprep.api.service;
 
+import static com.jayway.restassured.RestAssured.given;
+
 import java.util.List;
 import java.util.Map;
+
+import org.talend.dataprep.api.dataset.RowMetadata;
+import org.talend.dataprep.api.preparation.Action;
+import org.talend.dataprep.api.preparation.AppendStep;
+import org.talend.dataprep.api.preparation.Preparation;
+import org.talend.dataprep.api.preparation.StepDiff;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.parsing.Parser;
 import com.jayway.restassured.response.Response;
-import org.talend.dataprep.api.preparation.Action;
-import org.talend.dataprep.api.preparation.AppendStep;
-import org.talend.dataprep.api.preparation.Preparation;
-import org.talend.dataprep.api.preparation.StepDiff;
-
-import static com.jayway.restassured.RestAssured.given;
 
 /**
  * Java client for testings.
@@ -68,6 +70,8 @@ public class PreparationAPITestClient {
         public String lastModificationDate;
 
         public String owner;
+
+        public RowMetadata rowMetadata;
 
         public List<String> steps;
 

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/api/preparation/json/PreparationDetailsJsonSerializer.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/api/preparation/json/PreparationDetailsJsonSerializer.java
@@ -80,6 +80,7 @@ public class PreparationDetailsJsonSerializer extends JsonSerializer<Preparation
             generator.writeNumberField("creationDate", preparation.getCreationDate()); //$NON-NLS-1$
             generator.writeNumberField("lastModificationDate", preparation.getLastModificationDate()); //$NON-NLS-1$
             generator.writeObjectField("owner", preparation.getOwner());
+            generator.writeObjectField("rowMetadata", preparation.getRowMetadata());
             if (preparation.getHeadId() != null && versionRepository != null) {
                 final List<Step> steps = preparationUtils.listSteps(preparation.getHeadId(), versionRepository);
 

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/service/PreparationControllerTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/service/PreparationControllerTest.java
@@ -91,6 +91,7 @@ public class PreparationControllerTest extends BasePreparationTest {
                 .body(sameJSONAs("[{\"id\":\"#548425458\"," + "\"dataSetId\":\"1234\"," + "\"author\":null," + "\"name\":null,"
                         + "\"creationDate\":0," + "\"lastModificationDate\":12345,"
                         + "\"owner\":null,"
+                        + "\"rowMetadata\":null,"
                         + "\"steps\":[\"f6e172c33bdacbc69bca9d32b2bd78174712a171\"]," + "\"diff\":[]," + "\"actions\":[],"
                         + "\"metadata\":[]" + "}]"));
 
@@ -117,6 +118,7 @@ public class PreparationControllerTest extends BasePreparationTest {
                                 "\"creationDate\":0," +
                                 "\"lastModificationDate\":12345," +
                                 "\"owner\":null," +
+                                "\"rowMetadata\":null," +
                                 "\"steps\":[\"f6e172c33bdacbc69bca9d32b2bd78174712a171\"]," +
                                 "\"diff\":[]," +
                                 "\"actions\":[]," +
@@ -129,6 +131,7 @@ public class PreparationControllerTest extends BasePreparationTest {
                                 "\"creationDate\":500," +
                                 "\"lastModificationDate\":456789," +
                                 "\"owner\":null," +
+                                "\"rowMetadata\":null," +
                                 "\"steps\":[\"f6e172c33bdacbc69bca9d32b2bd78174712a171\"]," +
                                 "\"diff\":[]," +
                                 "\"actions\":[]," +


### PR DESCRIPTION
No Jira

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] No, that's bad, this PR should not be merged... but it's backend-only

**What is the current behavior?**
The added row metadata information in a preparation wasn't serialized to JSON, leaving the feeling this information would be sent to clients.

**What is the new behavior?**
Row metadata is correctly included in JSON response.
