### PR TITLE
feat(TDP-2048): display datastore form

### DIFF
--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/DataSetAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/DataSetAPITest.java
@@ -16,9 +16,11 @@ package org.talend.dataprep.api.service;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
 import static com.jayway.restassured.path.json.JsonPath.from;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
 import static org.talend.dataprep.test.SameJSONFile.sameJSONAsFile;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
@@ -29,6 +31,9 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.response.ValidatableResponse;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.assertj.core.api.Assertions;
@@ -36,8 +41,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
 import org.talend.daikon.exception.json.JsonErrorCode;
 import org.talend.dataprep.api.dataset.DataSetGovernance;
+import org.talend.dataprep.api.dataset.DataSetLocation;
 import org.talend.dataprep.api.dataset.DataSetMetadata;
 import org.talend.dataprep.api.preparation.Preparation;
 import org.talend.dataprep.exception.error.DataSetErrorCodes;
@@ -48,6 +55,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.jayway.restassured.path.json.JsonPath;
 import com.jayway.restassured.response.Response;
+import org.talend.dataprep.parameters.Parameter;
+import org.talend.dataprep.parameters.jsonschema.ComponentProperties;
+import org.talend.dataprep.schema.FormatFamily;
 
 /**
  * Unit test for Data Set API.
@@ -685,6 +695,57 @@ public class DataSetAPITest extends ApiServiceTestBase {
             .body("name", hasSize(4));
 
         // @formatter:on
+    }
+
+    @Test
+    public void testGetImportJsonSchemaParameters() throws JsonProcessingException {
+        String importType = "tcomp-toto";
+        given().accept(ContentType.JSON)
+                .port(port)
+                .when()
+                .get("/api/datasets/imports/{import}/parameters", importType)
+                .then()
+                .statusCode(200)
+                .content(equalTo(mapper.writeValueAsString(new TCOMPLocationTest().getParametersAsSchema())));
+    }
+
+    @Component
+    public static class TCOMPLocationTest implements DataSetLocation {
+
+        @Override
+        public boolean isDynamic() {
+            return false;
+        }
+
+        @Override
+        public String getLocationType() {
+            return "tcomp-toto";
+        }
+
+        @Override
+        public List<Parameter> getParameters() {
+            return null;
+        }
+
+        @Override
+        public ComponentProperties getParametersAsSchema() {
+            return new ComponentProperties();
+        }
+
+        @Override
+        public String getAcceptedContentType() {
+            return "accepted content type";
+        }
+
+        @Override
+        public String toMediaType(FormatFamily formatFamily) {
+            return "media type";
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
     }
 
 }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/DataSetLocation.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/DataSetLocation.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.talend.dataprep.api.dataset.location.LocalStoreLocation;
 import org.talend.dataprep.parameters.Parameter;
+import org.talend.dataprep.parameters.jsonschema.ComponentProperties;
 import org.talend.dataprep.schema.FormatFamily;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -41,11 +42,27 @@ public interface DataSetLocation extends Serializable {
     String getLocationType();
 
     /**
+     * All needed parameters to use this location. Returns {@code null} if not relevant, when {@link #getParametersAsSchema} should
+     * be used for instance.
+     *
      * @return All needed parameters for this location (data set id, url, job name...).
      */
     @JsonIgnore
-    // Ignored so it not stored in JSON
     List<Parameter> getParameters();
+
+    /**
+     * If available, the json schema representation of the parameters.
+     */
+    @JsonIgnore
+    ComponentProperties getParametersAsSchema();
+
+    /**
+     * Tell user if he should call the Dataprep internal {@link #getParameters()} or the TComp oriented {@link #getParametersAsSchema()}.
+     *
+     * @return true if {@link #getParametersAsSchema()} should be use, false for {@link #getParameters()}
+     */
+    @JsonIgnore
+    boolean isSchemaOriented();
 
     @JsonIgnore
     // Ignored so it not stored in JSON
@@ -61,4 +78,21 @@ public interface DataSetLocation extends Serializable {
      */
     @JsonIgnore
     boolean isEnabled();
+
+    /**
+     * @return the location title.
+     */
+    default String getTitle() {
+        // it's needed for some imports that hold their title, by default it's null
+        return null;
+    }
+
+    /**
+     * @return the location label.
+     */
+    default String getLabel() {
+        // it's needed for some imports that hold their label, by default it's null
+        return null;
+    }
+
 }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/location/LocalStoreLocation.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/location/LocalStoreLocation.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import org.talend.dataprep.api.dataset.DataSetLocation;
 import org.talend.dataprep.parameters.Parameter;
 import org.talend.dataprep.parameters.ParameterType;
+import org.talend.dataprep.parameters.jsonschema.ComponentProperties;
 import org.talend.dataprep.schema.FormatFamily;
 
 /**
@@ -35,9 +36,6 @@ public class LocalStoreLocation implements DataSetLocation {
         return false;
     }
 
-    /**
-     * @see DataSetLocation#getLocationType()
-     */
     @Override
     public String getLocationType() {
         return NAME;
@@ -47,6 +45,12 @@ public class LocalStoreLocation implements DataSetLocation {
     public List<Parameter> getParameters() {
         return Collections.singletonList(new Parameter("datasetFile", ParameterType.FILE, "", false, false, "*.csv"));
     }
+
+    @Override
+    public ComponentProperties getParametersAsSchema() { return null; }
+
+    @Override
+    public boolean isSchemaOriented() { return false; }
 
     @Override
     public String getAcceptedContentType() {
@@ -63,9 +67,6 @@ public class LocalStoreLocation implements DataSetLocation {
         return true;
     }
 
-    /**
-     * @see Object#equals(Object)
-     */
     @Override
     public boolean equals(Object o) {
 
@@ -77,9 +78,6 @@ public class LocalStoreLocation implements DataSetLocation {
         return !(o == null || getClass() != o.getClass());
     }
 
-    /**
-     * @see Object#hashCode()
-     */
     @Override
     public int hashCode() {
         return Objects.hash(getClass());

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/parameters/jsonschema/ComponentProperties.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/parameters/jsonschema/ComponentProperties.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ * https://github.com/Talend/data-prep/blob/master/LICENSE
+ *
+ * You should have received a copy of the agreement
+ * along with this program; if not, write to Talend SA
+ * 9 rue Pages 92150 Suresnes, France
+ */
+
+package org.talend.dataprep.parameters.jsonschema;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Representation of dynamic form structure.
+ */
+public class ComponentProperties {
+
+    /**
+     * Schema that describe the structure of the properties object.
+     */
+    private ObjectNode jsonSchema;
+
+    /**
+     * Data container describe by the schema. Can contains any structure of data but will be used by TComp to recreate a
+     * {@link org.talend.daikon.properties.Properties} object.
+     */
+    private ObjectNode properties;
+
+    /**
+     * Front-end behavior description.
+     */
+    private ObjectNode uiSchema;
+
+    public ObjectNode getJsonSchema() {
+        return jsonSchema;
+    }
+
+    public void setJsonSchema(ObjectNode jsonSchema) {
+        this.jsonSchema = jsonSchema;
+    }
+
+    public ObjectNode getProperties() {
+        return properties;
+    }
+
+    public void setProperties(ObjectNode properties) {
+        this.properties = properties;
+    }
+
+    public ObjectNode getUiSchema() {
+        return uiSchema;
+    }
+
+    public void setUiSchema(ObjectNode uiSchema) {
+        this.uiSchema = uiSchema;
+    }
+}

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/DataSetErrorCodes.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/DataSetErrorCodes.java
@@ -170,7 +170,11 @@ public enum DataSetErrorCodes implements ErrorCode {
     /**
      * Error thrown when an error occurs while adding or updating a dataset.
      */
-    UNABLE_TO_CREATE_OR_UPDATE_DATASET(INTERNAL_SERVER_ERROR.value());
+    UNABLE_TO_CREATE_OR_UPDATE_DATASET(INTERNAL_SERVER_ERROR.value()),
+    /**
+     * Error while interacting with TComp.
+     */
+    UNABLE_TO_CONNECT_WITH_TCOMP(INTERNAL_SERVER_ERROR.value());
 
     /**
      * The http status to use.

--- a/dataprep-backend-service/src/main/resources/org/talend/dataprep/error_messages.properties
+++ b/dataprep-backend-service/src/main/resources/org/talend/dataprep/error_messages.properties
@@ -118,6 +118,9 @@ UNABLE_TO_CREATE_DATASET.MESSAGE = An error occurred during import
 UNABLE_TO_CREATE_OR_UPDATE_DATASET.TITLE = Update error
 UNABLE_TO_CREATE_OR_UPDATE_DATASET.MESSAGE = An error occurred during update
 
+UNABLE_TO_CONNECT_WITH_TCOMP.TITLE = TComp error
+UNABLE_TO_CONNECT_WITH_TCOMP.MESSAGE = An error occurred while connecting to TComp server
+
 UNABLE_TO_CERTIFY_DATASET.TITLE = Certification error
 UNABLE_TO_CERTIFY_DATASET.MESSAGE = Dataset certification impossible
 

--- a/dataprep-backend-service/src/main/resources/org/talend/dataprep/messages.properties
+++ b/dataprep-backend-service/src/main/resources/org/talend/dataprep/messages.properties
@@ -28,8 +28,8 @@ import.hdfs.title=Add HDFS dataset
 
 import.job.label=From Talend Job
 import.job.title=Add Talend Job dataset
-import.tcomp/FullExampleDatastore.label=From TCOMP example
-import.tcomp/FullExampleDatastore.title=Add a TCOMP dataset !
+import.tcomp.title=Add a {0} dataset
+import.tcomp.label=From {0}
 
 parameter.name.desc=Name
 parameter.name.label=Dataset name

--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -267,6 +267,11 @@
                 <version>2.6</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jsonSchema</artifactId>
+                <version>2.5.2</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
                 <version>1.9.2</version>

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/api/dataset/location/HdfsLocation.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/api/dataset/location/HdfsLocation.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.dataset.DataSetLocation;
 import org.talend.dataprep.parameters.Parameter;
 import org.talend.dataprep.parameters.ParameterType;
+import org.talend.dataprep.parameters.jsonschema.ComponentProperties;
 import org.talend.dataprep.schema.FormatFamily;
 
 /**
@@ -40,9 +41,6 @@ public class HdfsLocation extends AbstractUrlLocation implements DataSetLocation
         return false;
     }
 
-    /**
-     * @see DataSetLocation#getLocationType()
-     */
     @Override
     public String getLocationType() {
         return NAME;
@@ -55,6 +53,12 @@ public class HdfsLocation extends AbstractUrlLocation implements DataSetLocation
                 new Parameter("url", ParameterType.STRING, "", false, false, "hdfs://host:port/file")
         );
     }
+
+    @Override
+    public ComponentProperties getParametersAsSchema() { return null; }
+
+    @Override
+    public boolean isSchemaOriented() { return false; }
 
     @Override
     public String getAcceptedContentType() {
@@ -71,17 +75,11 @@ public class HdfsLocation extends AbstractUrlLocation implements DataSetLocation
         return true;
     }
 
-    /**
-     * @see Object#toString()
-     */
     @Override
     public String toString() {
         return "HdfsLocation{" + "url='" + url + '\'' + '}';
     }
 
-    /**
-     * @see Object#equals(Object)
-     */
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -92,9 +90,6 @@ public class HdfsLocation extends AbstractUrlLocation implements DataSetLocation
         return Objects.equals(url, that.url);
     }
 
-    /**
-     * @see Object#hashCode()
-     */
     @Override
     public int hashCode() {
         return Objects.hash(url);

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/api/dataset/location/HttpLocation.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/api/dataset/location/HttpLocation.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.dataset.DataSetLocation;
 import org.talend.dataprep.parameters.Parameter;
 import org.talend.dataprep.parameters.ParameterType;
+import org.talend.dataprep.parameters.jsonschema.ComponentProperties;
 import org.talend.dataprep.schema.FormatFamily;
 
 /**
@@ -40,9 +41,6 @@ public class HttpLocation extends AbstractUrlLocation implements DataSetLocation
         return false;
     }
 
-    /**
-     * @see DataSetLocation#getLocationType()
-     */
     @Override
     public String getLocationType() {
         return NAME;
@@ -55,6 +53,12 @@ public class HttpLocation extends AbstractUrlLocation implements DataSetLocation
                 new Parameter("url", ParameterType.STRING, "", false, false, "http://")
         );
     }
+
+    @Override
+    public ComponentProperties getParametersAsSchema() { return null; }
+
+    @Override
+    public boolean isSchemaOriented() { return false; }
 
     @Override
     public String getAcceptedContentType() {
@@ -71,17 +75,11 @@ public class HttpLocation extends AbstractUrlLocation implements DataSetLocation
         return true;
     }
 
-    /**
-     * @see Object#toString()
-     */
     @Override
     public String toString() {
         return "HttpLocation{" + "url='" + url + '\'' + '}';
     }
 
-    /**
-     * @see Object#equals(Object)
-     */
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -92,9 +90,6 @@ public class HttpLocation extends AbstractUrlLocation implements DataSetLocation
         return Objects.equals(url, that.url);
     }
 
-    /**
-     * @see Object#hashCode()
-     */
     @Override
     public int hashCode() {
         return Objects.hash(url);

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/api/Import.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/api/Import.java
@@ -1,22 +1,47 @@
 package org.talend.dataprep.dataset.service.api;
 
+import static java.util.Collections.emptyList;
+
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.talend.dataprep.i18n.DataprepBundle;
 import org.talend.dataprep.parameters.Parameter;
 
+/**
+ * Bean that is used to display the supported import types for dataprep.
+ */
 public class Import {
+
 
     private final String locationType;
 
     private final String contentType;
 
+    /** If the import has some parameters to display by the front end. */
     private final List<Parameter> parameters;
 
+    /** If the import is dynamic, the parameters are provided by the backend via another rest call. */
     private final boolean dynamic;
 
+    /** True if it's the default import. */
     private final boolean defaultImport;
 
+    /** The import label. */
+    private String label = null;
+
+    /** The import form title. */
+    private String title = null;
+
+    /**
+     * Constructor.
+     *
+     * @param locationType the location type.
+     * @param contentType the content type.
+     * @param parameters the import parameters.
+     * @param dynamic if the import parameters are dynamic and need to sent from the backend.
+     * @param defaultImport if this import is the default one.
+     */
     public Import(String locationType, String contentType, List<Parameter> parameters, boolean dynamic, boolean defaultImport) {
         this.locationType = locationType;
         this.contentType = contentType;
@@ -46,10 +71,102 @@ public class Import {
     }
 
     public String getLabel() {
-        return DataprepBundle.message("import." + locationType + ".label");
+        if (StringUtils.isBlank(this.label)) {
+            return DataprepBundle.message("import." + locationType + ".label");
+        } else {
+            return this.label;
+        }
     }
 
     public String getTitle() {
-        return DataprepBundle.message("import." + locationType + ".title");
+        if (StringUtils.isBlank(this.title)) {
+            return DataprepBundle.message("import." + locationType + ".title");
+        } else {
+            return this.title;
+        }
+    }
+
+    private void setLabel(String label) {
+        this.label = label;
+    }
+
+    private void setTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * Import builder to ease the use of the huge constructor.
+     */
+    public static class ImportBuilder {
+
+        private String locationType;
+
+        private String contentType;
+
+        private List<Parameter> parameters = emptyList();
+
+        private boolean dynamic;
+
+        private boolean defaultImport;
+
+        private String label;
+
+        private String title;
+
+        private ImportBuilder() {
+            // nothing to do here
+        }
+
+        public static ImportBuilder builder() {
+            return new ImportBuilder();
+        }
+
+        public ImportBuilder locationType(String locationType) {
+            this.locationType = locationType;
+            return this;
+        }
+
+        public ImportBuilder contentType(String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public ImportBuilder label(String label) {
+            this.label = label;
+            return this;
+        }
+
+        public ImportBuilder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public ImportBuilder parameters(List<Parameter> parameters) {
+            if (parameters != null) {
+                this.parameters = parameters;
+            }
+            return this;
+        }
+
+        public ImportBuilder dynamic(boolean dynamic) {
+            this.dynamic = dynamic;
+            return this;
+        }
+
+        public ImportBuilder defaultImport(boolean defaultImport) {
+            this.defaultImport = defaultImport;
+            return this;
+        }
+
+        public Import build() {
+            Import result = new Import(locationType, contentType, parameters, dynamic, defaultImport);
+            if (StringUtils.isNotBlank(this.label)) {
+                result.setLabel(this.label);
+            }
+            if (StringUtils.isNotBlank(this.title)) {
+                result.setTitle(this.title);
+            }
+            return result;
+        }
     }
 }

--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -58,6 +58,7 @@
     "react-bootstrap": "^0.30.3",
     "react-dom": "^15.3.2",
     "react-talend-components": "0.15.0",
+    "react-talend-forms": "^0.7.0",
     "sunchoke": "git+https://github.com/Talend/sunchoke.git#1.0.0",
     "talend-icons": "0.5.5",
     "uuid": "^2.0.3"

--- a/dataprep-webapp/src/app/components/import/import-controller.spec.js
+++ b/dataprep-webapp/src/app/components/import/import-controller.spec.js
@@ -12,457 +12,484 @@
  ============================================================================*/
 
 describe('Import controller', () => {
-    'use strict';
-
-    let ctrl;
-    let createController;
-    let scope;
-    let StateMock;
-    const dataset = { id: 'ec4834d9bc2af8', name: 'Customers (50 lines)', draft: false };
-
-    beforeEach(angular.mock.module('data-prep.import', ($provide) => {
-        StateMock = {
-            inventory: {
-                currentFolder: { id: '', path: '', name: 'Home' },
-                currentFolderContent: {
-                    folders: [],
-                    datasets: [],
-                },
-            }, import: {
-                importTypes: [
-                    {
-                        locationType: 'hdfs',
-                        contentType: 'application/vnd.remote-ds.hdfs',
-                        parameters: [
-                            {
-                                name: 'name',
-                                type: 'string',
-                                implicit: false,
-                                canBeBlank: false,
-                                format: '',
-                                default: '',
-                                description: 'Name',
-                                label: 'Enter the dataset name:',
-                            },
-                            {
-                                name: 'url',
-                                type: 'string',
-                                implicit: false,
-                                canBeBlank: false,
-                                format: 'hdfs://host:port/file',
-                                default: '',
-                                description: 'URL',
-                                label: 'Enter the dataset URL:',
-                            },
-                        ],
-                        defaultImport: false,
-                        label: 'From HDFS',
-                        title: 'Add HDFS dataset',
-                    },
-                    {
-                        locationType: 'http',
-                        contentType: 'application/vnd.remote-ds.http',
-                        parameters: [
-                            {
-                                name: 'name',
-                                type: 'string',
-                                implicit: false,
-                                canBeBlank: false,
-                                format: '',
-                                default: '',
-                                description: 'Name',
-                                label: 'Enter the dataset name:',
-                            },
-                            {
-                                name: 'url',
-                                type: 'string',
-                                implicit: false,
-                                canBeBlank: false,
-                                format: 'http://',
-                                default: '',
-                                description: 'URL',
-                                label: 'Enter the dataset URL:',
-                            },
-                        ],
-                        defaultImport: false,
-                        label: 'From HTTP',
-                        title: 'Add HTTP dataset',
-                    },
-                    {
-                        locationType: 'local',
-                        contentType: 'text/plain',
-                        parameters: [
-                            {
-                                name: 'datasetFile',
-                                type: 'file',
-                                implicit: false,
-                                canBeBlank: false,
-                                format: '*.csv',
-                                default: '',
-                                description: 'File',
-                                label: 'File',
-                            },
-                        ],
-                        defaultImport: true,
-                        label: 'Local File',
-                        title: 'Add local file dataset',
-                    }, {
-                        locationType: 'job',
-                        contentType: 'application/vnd.remote-ds.job',
-                        parameters: [
-                            {
-                                name: 'name',
-                                type: 'string',
-                                implicit: false,
-                                canBeBlank: false,
-                                format: '',
-                                description: 'Name',
-                                label: 'Enter the dataset name:',
-                                default: '',
-                            },
-                            {
-                                name: 'jobId',
-                                type: 'select',
-                                implicit: false,
-                                canBeBlank: false,
-                                format: '',
-                                configuration: {
-                                    values: [
-                                        {
-                                            value: '1',
-                                            label: 'TestInput',
-                                        },
-                                    ],
-                                    multiple: false,
-                                },
-                                description: 'Talend Job',
-                                label: 'Select the Talend Job:',
-                                default: '',
-                            },
-                        ],
-                        defaultImport: false,
-                        label: 'From Talend Job',
-                        title: 'Add Talend Job dataset',
-                    },
-                ],
-            },
-        };
-        $provide.constant('state', StateMock);
-    }));
-
-    beforeEach(inject(($rootScope, $componentController) => {
-        scope = $rootScope.$new();
-
-        createController = () => {
-            return $componentController(
-                'import',
-                { $scope: scope }
-            );
-        };
-    }));
-
-    afterEach(inject(() => {
-        dataset.error = false;
-        dataset.progress = false;
-    }));
-
-    describe('startDefaultImport', () => {
-        it('should call the first import type if no defaultImportType', () => {
-            // given
-            StateMock.import.importTypes[2].defaultImport = false;
-
-            // when
-            ctrl = createController();
-            spyOn(ctrl, 'startImport');
-            ctrl.startDefaultImport();
-
-            // then
-            expect(ctrl.startImport).toHaveBeenCalledWith(StateMock.import.importTypes[0]);
-        });
-
-        it('should call the default import type', inject(() => {
-
-            // given
-            StateMock.import.importTypes[2].defaultImport = true;
-
-            // when
-            ctrl = createController();
-            spyOn(ctrl, 'startImport');
-            ctrl.startDefaultImport();
-
-            // then
-            expect(ctrl.startImport).toHaveBeenCalledWith(StateMock.import.importTypes[2]);
-        }));
-    });
-
-    describe('startImport', () => {
-        it('should start import from local file', () => {
-            // given
-            ctrl = createController();
-
-            // when
-            ctrl.startImport(StateMock.import.importTypes[2]);
-
-            // then
-            expect(ctrl.currentInputType).toEqual(StateMock.import.importTypes[2]);
-            expect(ctrl.showModal).toBe(false);
-        });
-
-        it('should start import from remote', inject(() => {
-            // given
-            ctrl = createController();
-
-            // when
-            ctrl.startImport(StateMock.import.importTypes[0]);
-
-            // then
-            expect(ctrl.currentInputType).toEqual(StateMock.import.importTypes[0]);
-            expect(ctrl.showModal).toBe(true);
-        }));
-
-        it('should start import from remote with dynamic parameters', inject((ImportRestService, $q) => {
-            // given
-            ctrl = createController();
-            StateMock.import.importTypes[0].dynamic = true;
-            spyOn(ImportRestService, 'importParameters').and.returnValue($q.when({ data: { name: 'url' } }));
-
-            // when
-            ctrl.startImport(StateMock.import.importTypes[0]);
-
-            // then
-            expect(ctrl.isFetchingParameters).toEqual(true);
-            expect(ImportRestService.importParameters).toHaveBeenCalledWith('hdfs');
-
-            scope.$digest();
-            expect(ctrl.currentInputType.parameters).toEqual({ name: 'url' });
-            expect(ctrl.isFetchingParameters).toEqual(false);
-        }));
-    });
-
-    describe('import', () => {
-        let uploadDefer;
-        beforeEach(inject((StateService, $q, DatasetService, UploadWorkflowService) => {
-            ctrl = createController();
-            ctrl.datasetFile = [{ name: 'my dataset.csv' }];
-            ctrl.datasetName = 'my cool dataset';
-
-            uploadDefer = $q.defer();
-            uploadDefer.promise.progress = (callback) => {
-                uploadDefer.progressCb = callback;
-                return uploadDefer.promise;
-            };
-
-            spyOn(DatasetService, 'getDatasetById').and.returnValue($q.when(dataset));
-            spyOn(UploadWorkflowService, 'openDataset').and.returnValue();
-            spyOn(DatasetService, 'createDatasetInfo').and.callFake(() => {
-                return dataset;
-            });
-            spyOn(DatasetService, 'create').and.returnValue(uploadDefer.promise);
-            spyOn(DatasetService, 'update').and.returnValue(uploadDefer.promise);
-
-            spyOn(StateService, 'startUploadingDataset').and.returnValue();
-            spyOn(StateService, 'finishUploadingDataset').and.returnValue();
-
-            ctrl.currentInputType = StateMock.import.importTypes[0];
-        }));
-
-        it('should show dataset name popup when name already exists', inject(($q, DatasetService) => {
-            // given
-            const dataset = {
-                name: 'my dataset',
-            };
-            spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.reject());
-            expect(ctrl.datasetNameModal).toBeFalsy();
-
-            // when
-            ctrl.import(StateMock.import.importTypes[0]);
-            scope.$digest();
-
-            // then
-            expect(ctrl.datasetNameModal).toBe(true);
-        }));
-
-        it('should create dataset if unique', inject(($q, DatasetService) => {
-            // given
-            spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.when());
-            expect(ctrl.datasetNameModal).toBeFalsy();
-
-            // when
-            ctrl.import(StateMock.import.importTypes[0]);
-            scope.$digest();
-
-            // then
-            expect(ctrl.datasetNameModal).toBeFalsy();
-            const paramsExpected = { name: 'my dataset', url: '', type: 'hdfs' };
-            expect(DatasetService.create).toHaveBeenCalledWith(paramsExpected, 'application/vnd.remote-ds.hdfs', { name: 'my dataset.csv' });
-        }));
-
-        it('should close modal if import is successful', inject(($q, DatasetService) => {
-            // given
-            spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.when());
-            expect(ctrl.datasetNameModal).toBeFalsy();
-
-            // when
-            ctrl.import(StateMock.import.importTypes[0]);
-            scope.$digest();
-
-            // then
-            expect(ctrl.showModal).toBe(false);
-        }));
-    });
-
-    describe('onImportNameValidation', () => {
-        let uploadDefer;
-
-        beforeEach(inject((StateService, $q, DatasetService, UploadWorkflowService) => {
-            ctrl = createController();
-            ctrl.datasetFile = [{ name: 'my dataset.csv' }];
-            ctrl.datasetName = 'my cool dataset';
-
-            uploadDefer = $q.defer();
-            uploadDefer.promise.progress = (callback) => {
-                uploadDefer.progressCb = callback;
-                return uploadDefer.promise;
-            };
-
-            spyOn(DatasetService, 'getDatasetById').and.returnValue($q.when(dataset));
-            spyOn(UploadWorkflowService, 'openDataset').and.returnValue();
-            spyOn(DatasetService, 'createDatasetInfo').and.callFake(() => {
-                return dataset;
-            });
-            spyOn(DatasetService, 'create').and.returnValue(uploadDefer.promise);
-            spyOn(DatasetService, 'update').and.returnValue(uploadDefer.promise);
-
-            spyOn(StateService, 'startUploadingDataset').and.returnValue();
-            spyOn(StateService, 'finishUploadingDataset').and.returnValue();
-        }));
-
-        describe('with unique name', () => {
-            beforeEach(inject(($q, $rootScope, DatasetService) => {
-                spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.when());
-                ctrl.currentInputType = StateMock.import.importTypes[0];
-            }));
-
-            it('should create dataset if name is unique', inject((StateService, $q, $rootScope, DatasetService, UploadWorkflowService) => {
-                // given
-                const paramsExpected = { name: 'my cool dataset', url: '', type: 'hdfs' };
-
-                // when
-                ctrl.onImportNameValidation();
-                uploadDefer.resolve({ data: dataset.id });
-                scope.$digest();
-
-                // then
-                expect(StateService.startUploadingDataset).toHaveBeenCalled();
-                expect(DatasetService.create).toHaveBeenCalledWith(paramsExpected, 'application/vnd.remote-ds.hdfs', { name: 'my dataset.csv' });
-                expect(DatasetService.getDatasetById).toHaveBeenCalledWith(dataset.id);
-                expect(UploadWorkflowService.openDataset).toHaveBeenCalled();
-                expect(StateService.finishUploadingDataset).toHaveBeenCalled();
-            }));
-
-            it('should update progress on create', inject((state, StateService, DatasetService) => {
-                // given
-                ctrl.onImportNameValidation();
-                scope.$digest();
-                expect(dataset.progress).toBeFalsy();
-
-                const event = {
-                    loaded: 140,
-                    total: 200,
-                };
-
-                // when
-                uploadDefer.progressCb(event);
-                scope.$digest();
-
-                // then
-                expect(DatasetService.create).toHaveBeenCalled();
-                expect(dataset.progress).toBe(70);
-            }));
-
-            it('should set error flag and show error toast', inject((StateService, DatasetService) => {
-                // given
-                ctrl.onImportNameValidation();
-                scope.$digest();
-                expect(dataset.error).toBeFalsy();
-
-                // when
-                uploadDefer.reject();
-                scope.$digest();
-
-                // then
-                expect(DatasetService.create).toHaveBeenCalled();
-                expect(dataset.error).toBe(true);
-            }));
-        });
-
-        describe('with existing name', () => {
-            const dataset = {
-                name: 'my cool dataset',
-            };
-            const existingDataset = { id: '2', name: 'my cool dataset' };
-            let confirmDefer;
-
-            beforeEach(inject(($rootScope, $q, StateService, DatasetService, UpdateWorkflowService, TalendConfirmService) => {
-                confirmDefer = $q.defer();
-
-                spyOn(StateService, 'resetPlayground').and.returnValue();
-                spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.reject(existingDataset));
-                spyOn(TalendConfirmService, 'confirm').and.returnValue(confirmDefer.promise);
-                spyOn(UpdateWorkflowService, 'updateDataset').and.returnValue($q.when());
-
-                ctrl.currentInputType = StateMock.import.importTypes[0];
-                ctrl.datasetName = dataset.name;
-            }));
-
-            it('should do nothing on confirm modal dismiss', inject(($q, TalendConfirmService, DatasetService) => {
-                // given
-                spyOn(DatasetService, 'getUniqueName').and.returnValue($q.when('my cool dataset (1)'));
-                ctrl.onImportNameValidation();
-                scope.$digest();
-
-                // when
-                confirmDefer.reject('dismiss');
-                scope.$digest();
-
-                // then
-                expect(DatasetService.checkNameAvailability).toHaveBeenCalledWith(ctrl.datasetName);
-                expect(TalendConfirmService.confirm).toHaveBeenCalledWith(null, ['UPDATE_EXISTING_DATASET'], { dataset: 'my cool dataset' });
-                expect(DatasetService.create).not.toHaveBeenCalled();
-                expect(DatasetService.update).not.toHaveBeenCalled();
-            }));
-
-            it('should create dataset with modified name', inject(($q, TalendConfirmService, DatasetService) => {
-                // given
-                spyOn(DatasetService, 'getUniqueName').and.returnValue($q.when('my cool dataset (1)'));
-                ctrl.onImportNameValidation();
-                scope.$digest();
-
-                // when
-                confirmDefer.reject();
-                scope.$digest();
-                uploadDefer.resolve({ data: 'dataset_id_XYZ' });
-                scope.$digest();
-
-                // then
-                expect(DatasetService.createDatasetInfo).toHaveBeenCalledWith({ name: 'my dataset.csv' }, 'my cool dataset (1)');
-            }));
-
-            it('should update existing dataset', inject(($q, DatasetService, UpdateWorkflowService) => {
-                // given
-                spyOn(DatasetService, 'getUniqueName').and.returnValue($q.reject('my cool dataset (1)'));
-                ctrl.onImportNameValidation();
-                scope.$digest();
-
-                // when
-                confirmDefer.resolve();
-                scope.$digest();
-                uploadDefer.resolve();
-                scope.$digest();
-
-                // then
-                expect(UpdateWorkflowService.updateDataset).toHaveBeenCalledWith({ name: 'my dataset.csv' }, existingDataset);
-            }));
-        });
-    });
+	'use strict';
+
+	let ctrl;
+	let createController;
+	let scope;
+	let StateMock;
+	const dataset = { id: 'ec4834d9bc2af8', name: 'Customers (50 lines)', draft: false };
+
+	beforeEach(angular.mock.module('data-prep.import', ($provide) => {
+		StateMock = {
+			inventory: {
+				currentFolder: { id: '', path: '', name: 'Home' },
+				currentFolderContent: {
+					folders: [],
+					datasets: [],
+				},
+			}, import: {
+				importTypes: [
+					{
+						locationType: 'hdfs',
+						contentType: 'application/vnd.remote-ds.hdfs',
+						parameters: [
+							{
+								name: 'name',
+								type: 'string',
+								implicit: false,
+								canBeBlank: false,
+								format: '',
+								default: '',
+								description: 'Name',
+								label: 'Enter the dataset name:',
+							},
+							{
+								name: 'url',
+								type: 'string',
+								implicit: false,
+								canBeBlank: false,
+								format: 'hdfs://host:port/file',
+								default: '',
+								description: 'URL',
+								label: 'Enter the dataset URL:',
+							},
+						],
+						defaultImport: false,
+						label: 'From HDFS',
+						title: 'Add HDFS dataset',
+					},
+					{
+						locationType: 'http',
+						contentType: 'application/vnd.remote-ds.http',
+						parameters: [
+							{
+								name: 'name',
+								type: 'string',
+								implicit: false,
+								canBeBlank: false,
+								format: '',
+								default: '',
+								description: 'Name',
+								label: 'Enter the dataset name:',
+							},
+							{
+								name: 'url',
+								type: 'string',
+								implicit: false,
+								canBeBlank: false,
+								format: 'http://',
+								default: '',
+								description: 'URL',
+								label: 'Enter the dataset URL:',
+							},
+						],
+						defaultImport: false,
+						label: 'From HTTP',
+						title: 'Add HTTP dataset',
+					},
+					{
+						locationType: 'local',
+						contentType: 'text/plain',
+						parameters: [
+							{
+								name: 'datasetFile',
+								type: 'file',
+								implicit: false,
+								canBeBlank: false,
+								format: '*.csv',
+								default: '',
+								description: 'File',
+								label: 'File',
+							},
+						],
+						defaultImport: true,
+						label: 'Local File',
+						title: 'Add local file dataset',
+					},
+					{
+						locationType: 'job',
+						contentType: 'application/vnd.remote-ds.job',
+						parameters: [
+							{
+								name: 'name',
+								type: 'string',
+								implicit: false,
+								canBeBlank: false,
+								format: '',
+								description: 'Name',
+								label: 'Enter the dataset name:',
+								default: '',
+							},
+							{
+								name: 'jobId',
+								type: 'select',
+								implicit: false,
+								canBeBlank: false,
+								format: '',
+								configuration: {
+									values: [
+										{
+											value: '1',
+											label: 'TestInput',
+										},
+									],
+									multiple: false,
+								},
+								description: 'Talend Job',
+								label: 'Select the Talend Job:',
+								default: '',
+							},
+						],
+						defaultImport: false,
+						label: 'From Talend Job',
+						title: 'Add Talend Job dataset',
+					},
+					{
+						contentType: 'application/vnd.tcomp-ds.FullExampleDatastore',
+						defaultImport: false,
+						dynamic: true,
+						label: 'From TCOMP example',
+						locationType: 'tcomp-FullExampleDatastore',
+						parameters: [],
+						title: 'Add a TCOMP dataset',
+					},
+				],
+			},
+		};
+		$provide.constant('state', StateMock);
+	}));
+
+	beforeEach(inject(($rootScope, $componentController) => {
+		scope = $rootScope.$new();
+
+		createController = () => {
+			return $componentController(
+				'import',
+				{ $scope: scope }
+			);
+		};
+	}));
+
+	afterEach(inject(() => {
+		dataset.error = false;
+		dataset.progress = false;
+	}));
+
+	describe('startDefaultImport', () => {
+		it('should call the first import type if no defaultImportType', () => {
+			// given
+			StateMock.import.importTypes[2].defaultImport = false;
+
+			// when
+			ctrl = createController();
+			spyOn(ctrl, 'startImport');
+			ctrl.startDefaultImport();
+
+			// then
+			expect(ctrl.startImport).toHaveBeenCalledWith(StateMock.import.importTypes[0]);
+		});
+
+		it('should call the default import type', inject(() => {
+
+			// given
+			StateMock.import.importTypes[2].defaultImport = true;
+
+			// when
+			ctrl = createController();
+			spyOn(ctrl, 'startImport');
+			ctrl.startDefaultImport();
+
+			// then
+			expect(ctrl.startImport).toHaveBeenCalledWith(StateMock.import.importTypes[2]);
+		}));
+	});
+
+	describe('startImport', () => {
+		it('should start import from local file', () => {
+			// given
+			ctrl = createController();
+
+			// when
+			ctrl.startImport(StateMock.import.importTypes[2]);
+
+			// then
+			expect(ctrl.currentInputType).toEqual(StateMock.import.importTypes[2]);
+			expect(ctrl.showModal).toBe(false);
+		});
+
+		it('should start import from remote', inject(() => {
+			// given
+			ctrl = createController();
+
+			// when
+			ctrl.startImport(StateMock.import.importTypes[0]);
+
+			// then
+			expect(ctrl.currentInputType).toEqual(StateMock.import.importTypes[0]);
+			expect(ctrl.showModal).toBe(true);
+		}));
+
+		it('should start import from remote with dynamic parameters', inject((ImportRestService, $q) => {
+			// given
+			ctrl = createController();
+			StateMock.import.importTypes[0].dynamic = true;
+			spyOn(ImportRestService, 'importParameters').and.returnValue($q.when({ data: { name: 'url' } }));
+
+			// when
+			ctrl.startImport(StateMock.import.importTypes[0]);
+
+			// then
+			expect(ctrl.isFetchingParameters).toEqual(true);
+			expect(ImportRestService.importParameters).toHaveBeenCalledWith('hdfs');
+
+			scope.$digest();
+			expect(ctrl.currentInputType.parameters).toEqual({ name: 'url' });
+			expect(ctrl.isFetchingParameters).toEqual(false);
+		}));
+
+		it('should start import from tcomp', inject((ImportRestService, $q) => {
+			// given
+			ctrl = createController();
+			spyOn(ImportRestService, 'importParameters').and.returnValue($q.when({ data: { name: 'tcomp' } }));
+
+			// when
+			ctrl.startImport(StateMock.import.importTypes[4]);
+
+			// then
+			expect(ctrl.isFetchingParameters).toEqual(true);
+			expect(ImportRestService.importParameters).toHaveBeenCalledWith('tcomp-FullExampleDatastore');
+
+			scope.$digest();
+			expect(ctrl.currentInputType.datastoreForm).toEqual({ name: 'tcomp' });
+			expect(ctrl.isFetchingParameters).toEqual(false);
+		}));
+	});
+
+	describe('import', () => {
+		let uploadDefer;
+		beforeEach(inject((StateService, $q, DatasetService, UploadWorkflowService) => {
+			ctrl = createController();
+			ctrl.datasetFile = [{ name: 'my dataset.csv' }];
+			ctrl.datasetName = 'my cool dataset';
+
+			uploadDefer = $q.defer();
+			uploadDefer.promise.progress = (callback) => {
+				uploadDefer.progressCb = callback;
+				return uploadDefer.promise;
+			};
+
+			spyOn(DatasetService, 'getDatasetById').and.returnValue($q.when(dataset));
+			spyOn(UploadWorkflowService, 'openDataset').and.returnValue();
+			spyOn(DatasetService, 'createDatasetInfo').and.callFake(() => {
+				return dataset;
+			});
+			spyOn(DatasetService, 'create').and.returnValue(uploadDefer.promise);
+			spyOn(DatasetService, 'update').and.returnValue(uploadDefer.promise);
+
+			spyOn(StateService, 'startUploadingDataset').and.returnValue();
+			spyOn(StateService, 'finishUploadingDataset').and.returnValue();
+
+			ctrl.currentInputType = StateMock.import.importTypes[0];
+		}));
+
+		it('should show dataset name popup when name already exists', inject(($q, DatasetService) => {
+			// given
+			const dataset = {
+				name: 'my dataset',
+			};
+			spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.reject());
+			expect(ctrl.datasetNameModal).toBeFalsy();
+
+			// when
+			ctrl.import(StateMock.import.importTypes[0]);
+			scope.$digest();
+
+			// then
+			expect(ctrl.datasetNameModal).toBe(true);
+		}));
+
+		it('should create dataset if unique', inject(($q, DatasetService) => {
+			// given
+			spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.when());
+			expect(ctrl.datasetNameModal).toBeFalsy();
+
+			// when
+			ctrl.import(StateMock.import.importTypes[0]);
+			scope.$digest();
+
+			// then
+			expect(ctrl.datasetNameModal).toBeFalsy();
+			const paramsExpected = { name: 'my dataset', url: '', type: 'hdfs' };
+			expect(DatasetService.create).toHaveBeenCalledWith(paramsExpected, 'application/vnd.remote-ds.hdfs', { name: 'my dataset.csv' });
+		}));
+
+		it('should close modal if import is successful', inject(($q, DatasetService) => {
+			// given
+			spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.when());
+			expect(ctrl.datasetNameModal).toBeFalsy();
+
+			// when
+			ctrl.import(StateMock.import.importTypes[0]);
+			scope.$digest();
+
+			// then
+			expect(ctrl.showModal).toBe(false);
+		}));
+	});
+
+	describe('onImportNameValidation', () => {
+		let uploadDefer;
+
+		beforeEach(inject((StateService, $q, DatasetService, UploadWorkflowService) => {
+			ctrl = createController();
+			ctrl.datasetFile = [{ name: 'my dataset.csv' }];
+			ctrl.datasetName = 'my cool dataset';
+
+			uploadDefer = $q.defer();
+			uploadDefer.promise.progress = (callback) => {
+				uploadDefer.progressCb = callback;
+				return uploadDefer.promise;
+			};
+
+			spyOn(DatasetService, 'getDatasetById').and.returnValue($q.when(dataset));
+			spyOn(UploadWorkflowService, 'openDataset').and.returnValue();
+			spyOn(DatasetService, 'createDatasetInfo').and.callFake(() => {
+				return dataset;
+			});
+			spyOn(DatasetService, 'create').and.returnValue(uploadDefer.promise);
+			spyOn(DatasetService, 'update').and.returnValue(uploadDefer.promise);
+
+			spyOn(StateService, 'startUploadingDataset').and.returnValue();
+			spyOn(StateService, 'finishUploadingDataset').and.returnValue();
+		}));
+
+		describe('with unique name', () => {
+			beforeEach(inject(($q, $rootScope, DatasetService) => {
+				spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.when());
+				ctrl.currentInputType = StateMock.import.importTypes[0];
+			}));
+
+			it('should create dataset if name is unique', inject((StateService, $q, $rootScope, DatasetService, UploadWorkflowService) => {
+				// given
+				const paramsExpected = { name: 'my cool dataset', url: '', type: 'hdfs' };
+
+				// when
+				ctrl.onImportNameValidation();
+				uploadDefer.resolve({ data: dataset.id });
+				scope.$digest();
+
+				// then
+				expect(StateService.startUploadingDataset).toHaveBeenCalled();
+				expect(DatasetService.create).toHaveBeenCalledWith(paramsExpected, 'application/vnd.remote-ds.hdfs', { name: 'my dataset.csv' });
+				expect(DatasetService.getDatasetById).toHaveBeenCalledWith(dataset.id);
+				expect(UploadWorkflowService.openDataset).toHaveBeenCalled();
+				expect(StateService.finishUploadingDataset).toHaveBeenCalled();
+			}));
+
+			it('should update progress on create', inject((state, StateService, DatasetService) => {
+				// given
+				ctrl.onImportNameValidation();
+				scope.$digest();
+				expect(dataset.progress).toBeFalsy();
+
+				const event = {
+					loaded: 140,
+					total: 200,
+				};
+
+				// when
+				uploadDefer.progressCb(event);
+				scope.$digest();
+
+				// then
+				expect(DatasetService.create).toHaveBeenCalled();
+				expect(dataset.progress).toBe(70);
+			}));
+
+			it('should set error flag and show error toast', inject((StateService, DatasetService) => {
+				// given
+				ctrl.onImportNameValidation();
+				scope.$digest();
+				expect(dataset.error).toBeFalsy();
+
+				// when
+				uploadDefer.reject();
+				scope.$digest();
+
+				// then
+				expect(DatasetService.create).toHaveBeenCalled();
+				expect(dataset.error).toBe(true);
+			}));
+		});
+
+		describe('with existing name', () => {
+			const dataset = {
+				name: 'my cool dataset',
+			};
+			const existingDataset = { id: '2', name: 'my cool dataset' };
+			let confirmDefer;
+
+			beforeEach(inject(($rootScope, $q, StateService, DatasetService, UpdateWorkflowService, TalendConfirmService) => {
+				confirmDefer = $q.defer();
+
+				spyOn(StateService, 'resetPlayground').and.returnValue();
+				spyOn(DatasetService, 'checkNameAvailability').and.returnValue($q.reject(existingDataset));
+				spyOn(TalendConfirmService, 'confirm').and.returnValue(confirmDefer.promise);
+				spyOn(UpdateWorkflowService, 'updateDataset').and.returnValue($q.when());
+
+				ctrl.currentInputType = StateMock.import.importTypes[0];
+				ctrl.datasetName = dataset.name;
+			}));
+
+			it('should do nothing on confirm modal dismiss', inject(($q, TalendConfirmService, DatasetService) => {
+				// given
+				spyOn(DatasetService, 'getUniqueName').and.returnValue($q.when('my cool dataset (1)'));
+				ctrl.onImportNameValidation();
+				scope.$digest();
+
+				// when
+				confirmDefer.reject('dismiss');
+				scope.$digest();
+
+				// then
+				expect(DatasetService.checkNameAvailability).toHaveBeenCalledWith(ctrl.datasetName);
+				expect(TalendConfirmService.confirm).toHaveBeenCalledWith(null, ['UPDATE_EXISTING_DATASET'], { dataset: 'my cool dataset' });
+				expect(DatasetService.create).not.toHaveBeenCalled();
+				expect(DatasetService.update).not.toHaveBeenCalled();
+			}));
+
+			it('should create dataset with modified name', inject(($q, TalendConfirmService, DatasetService) => {
+				// given
+				spyOn(DatasetService, 'getUniqueName').and.returnValue($q.when('my cool dataset (1)'));
+				ctrl.onImportNameValidation();
+				scope.$digest();
+
+				// when
+				confirmDefer.reject();
+				scope.$digest();
+				uploadDefer.resolve({ data: 'dataset_id_XYZ' });
+				scope.$digest();
+
+				// then
+				expect(DatasetService.createDatasetInfo).toHaveBeenCalledWith({ name: 'my dataset.csv' }, 'my cool dataset (1)');
+			}));
+
+			it('should update existing dataset', inject(($q, DatasetService, UpdateWorkflowService) => {
+				// given
+				spyOn(DatasetService, 'getUniqueName').and.returnValue($q.reject('my cool dataset (1)'));
+				ctrl.onImportNameValidation();
+				scope.$digest();
+
+				// when
+				confirmDefer.resolve();
+				scope.$digest();
+				uploadDefer.resolve();
+				scope.$digest();
+
+				// then
+				expect(UpdateWorkflowService.updateDataset).toHaveBeenCalledWith({ name: 'my dataset.csv' }, existingDataset);
+			}));
+		});
+	});
 });

--- a/dataprep-webapp/src/app/components/import/import.html
+++ b/dataprep-webapp/src/app/components/import/import.html
@@ -3,10 +3,12 @@
             button-text="{{'IMPORT_DATASET' | translate }}"
             button-additional-class="btn btn-success"
             button-action="$ctrl.startDefaultImport()"
+            dropdown-menu-direction="left"
             close-on-select="true">
         <div class="list-group">
-            <button  type="button" class="list-group-item" ng-repeat="importType in $ctrl.importTypes track by importType.locationType"
-                ng-click="$ctrl.startImport(importType)"> {{importType.label}}
+            <button type="button" class="list-group-item"
+                    ng-repeat="importType in $ctrl.importTypes track by importType.locationType"
+                    ng-click="$ctrl.startImport(importType)"> {{importType.label}}
             </button>
         </div>
     </talend-button-dropdown>
@@ -28,7 +30,9 @@
     <div ng-show="$ctrl.isFetchingParameters === false">
         <div class="modal-title">{{$ctrl.currentInputType.title}}</div>
         <br/>
-        <form name="$ctrl.datasetForm" ng-submit="$ctrl.datasetForm.$valid && $ctrl.import($ctrl.currentInputType)">
+        <form name="$ctrl.datasetForm"
+              ng-if="!$ctrl.currentInputType.datastoreForm"
+              ng-submit="$ctrl.datasetForm.$valid && $ctrl.import($ctrl.currentInputType)">
 
             <transform-params parameters="$ctrl.currentInputType.parameters"></transform-params>
 
@@ -41,12 +45,27 @@
                         translate-once="OK"></button>
             </div>
         </form>
+        <div class="tcomp">
+            <div class="datastore"
+                 ng-if="$ctrl.currentInputType.datastoreForm">
+                <talend-form data="$ctrl.currentInputType.datastoreForm"
+                                   buttonBlockClass="form-actions"
+                                   actions="$ctrl.datastoreFormActions"
+                                   on-change="$ctrl.onDatastoreFormChange"
+                                   on-submit="$ctrl.onDatastoreFormSubmit"/>
+            </div>
+            <p class="text-center text-success"
+               ng-if="$ctrl.currentInputType.datasetForm"
+               translate-once="IMPORT_DATASTORE_CONNECTION_SUCCESSFUL">
+            </p>
+        </div>
+    </div>
     </div>
     <div id="import-ghost"
          ng-show="$ctrl.isFetchingParameters === true"
          class="loading-container">
         <div class="loading-msg">
-            <span class="wait-icon continuous-rotate" ><i data-icon="c" class="icon"></i></span>
+            <span class="wait-icon continuous-rotate"><i data-icon="c" class="icon"></i></span>
             <span class="wait-text" translate-once="IMPORT_WAIT"></span>
         </div>
     </div>

--- a/dataprep-webapp/src/app/components/import/import.scss
+++ b/dataprep-webapp/src/app/components/import/import.scss
@@ -11,32 +11,63 @@
 
   ============================================================================*/
 #help-import {
-  padding: 0 10px;
-  .dropdown-menu {
-    padding: 0;
-    .list-group {
-      margin: 0;
-    }
-  }
+	padding: 0 10px;
+	.dropdown-menu {
+		padding: 0;
+		.list-group {
+			margin: 0;
+		}
+	}
 }
 
 .loading-container {
-  .loading-msg {
-    position: absolute;
-    top: 15px;
-    left: 35px;
-    right: 35px;
-    padding: 15px 5px 15px 5px;
+	.loading-msg {
+		position: absolute;
+		top: 15px;
+		left: 35px;
+		right: 35px;
+		padding: 15px 5px 15px 5px;
 
-    background: transparent;
-    color: $dark-gray;
-    opacity: 0.8;
-  }
+		background: transparent;
+		color: $dark-gray;
+		opacity: 0.8;
+	}
 
-  .wait-icon {
-    position: absolute;
-  }
-  .wait-text {
-    padding-left: 40px;
-  }
+	.wait-icon {
+		position: absolute;
+	}
+	.wait-text {
+		padding-left: 40px;
+	}
+}
+
+.tcomp {
+	fieldset {
+
+		input,
+		textarea {
+			// Material-UI deals by itself with focus style
+			&,
+			&:focus {
+				box-shadow: none;
+			}
+		}
+	}
+
+	.datastore {
+		text-align: center;
+
+		legend,
+		.field-description {
+			text-align: left;
+		}
+
+		fieldset fieldset legend {
+			display: none;
+		}
+		fieldset > div > div {
+			// !important is needed to override element style attr
+			width: 75% !important;
+		}
+	}
 }

--- a/dataprep-webapp/src/app/components/widgets-containers/widgets-containers-module.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/widgets-containers-module.js
@@ -14,6 +14,7 @@
 import angular from 'angular';
 
 import { AppHeaderBar, Breadcrumbs,	IconsProvider, SidePanel, List } from 'react-talend-components';
+import Form from 'react-talend-forms';
 import AppHeaderBarContainer from './app-header-bar/app-header-bar-container';
 import BreadcrumbContainer from './breadcrumb/breadcrumb-container';
 import LayoutContainer from './layout/layout-container';
@@ -37,7 +38,8 @@ angular.module(MODULE_NAME,
 	.directive('pureList', ['reactDirective', reactDirective => reactDirective(List)])
 	.directive('pureAppSidePanel', ['reactDirective', reactDirective => reactDirective(SidePanel)])
 	.directive('iconsProvider', ['reactDirective', reactDirective => reactDirective(IconsProvider)])
-	.component('appHeaderBar', AppHeaderBarContainer)
+	.directive('talendForm', ['reactDirective', reactDirective => reactDirective(Form)])
+    .component('appHeaderBar', AppHeaderBarContainer)
 	.component('breadcrumbs', BreadcrumbContainer)
 	.component('reactPreparationList', PreparationListContainer) // TODO rename this when preparation-list is removed
 	.component('sidePanel', SidePanelContainer)

--- a/dataprep-webapp/src/app/components/widgets/button-dropdown/button-dropdown.html
+++ b/dataprep-webapp/src/app/components/widgets/button-dropdown/button-dropdown.html
@@ -32,7 +32,7 @@
         <span class="caret"></span>
         <span class="sr-only">{{::buttonDropdownCtrl.buttonDropdownTitle}}</span>
     </a>
-    <ul class="dropdown-menu dropdown-menu-right"
+    <ul class="dropdown-menu dropdown-menu-{{::(buttonDropdownCtrl.dropdownMenuDirection) || 'right'}}"
         role="menu"
         aria-labelledby="{{buttonDropdownCtrl.buttonId}}"
         uib-dropdown-menu>
@@ -60,7 +60,7 @@
         <span class="caret"></span>
         <span class="sr-only">{{::buttonDropdownCtrl.buttonDropdownTitle}}</span>
     </a>
-    <ul class="dropdown-menu dropdown-menu-right"
+    <ul class="dropdown-menu dropdown-menu-{{::(buttonDropdownCtrl.dropdownMenuDirection) || 'right'}}"
         role="menu"
         aria-labelledby="{{buttonDropdownCtrl.buttonId}}"
         uib-dropdown-menu>

--- a/dataprep-webapp/src/app/components/widgets/button-dropdown/widget-button-dropdown-directive.js
+++ b/dataprep-webapp/src/app/components/widgets/button-dropdown/widget-button-dropdown-directive.js
@@ -50,6 +50,7 @@ export default function TalendButtonDropdown($window, $timeout) {
 			buttonAction: '&',
 			closeOnSelect: '<',
 			appendToBody: '<',
+			dropdownMenuDirection: '@',
 		},
 		bindToController: true,
 		controller: () => {
@@ -62,9 +63,9 @@ export default function TalendButtonDropdown($window, $timeout) {
 						const action = iElement.find('.dropdown-action').eq(0);
 
 						iElement.find('.button-dropdown-main')
-                            .on('click', function () {
-	action.click();
-});
+							.on('click', function () {
+								action.click();
+							});
 					});
 				}
 			},

--- a/dataprep-webapp/src/app/components/widgets/button-dropdown/widget-button-dropdown-directive.spec.js
+++ b/dataprep-webapp/src/app/components/widgets/button-dropdown/widget-button-dropdown-directive.spec.js
@@ -1,83 +1,105 @@
 /*  ============================================================================
 
-  Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+ Copyright (C) 2006-2016 Talend Inc. - www.talend.com
 
-  This source code is available under agreement available at
-  https://github.com/Talend/data-prep/blob/master/LICENSE
+ This source code is available under agreement available at
+ https://github.com/Talend/data-prep/blob/master/LICENSE
 
-  You should have received a copy of the agreement
-  along with this program; if not, write to Talend SA
-  9 rue Pages 92150 Suresnes, France
+ You should have received a copy of the agreement
+ along with this program; if not, write to Talend SA
+ 9 rue Pages 92150 Suresnes, France
 
-  ============================================================================*/
+ ============================================================================*/
 
-'use strict';
+describe('Button Dropdown directive', () => {
 
-describe('Button Dropdown directive', function () {
-    var scope;
-    var element;
-    var createElementWithAction;
-    var createElementWithoutAction;
+	let scope;
+	let element;
+	let createElement;
 
-    beforeEach(angular.mock.module('talend.widget'));
+	beforeEach(angular.mock.module('talend.widget'));
 
-    afterEach(function () {
-        scope.$destroy();
-        element.remove();
-        jasmine.clock().uninstall();
-    });
+	afterEach(() => {
+		scope.$destroy();
+		element.remove();
+		jasmine.clock().uninstall();
+	});
 
-    beforeEach(inject(function ($rootScope, $compile, $timeout) {
-        jasmine.clock().install();
-        scope = $rootScope.$new();
+	beforeEach(inject(($rootScope, $compile, $timeout) => {
+		jasmine.clock().install();
+		scope = $rootScope.$new();
 
-        createElementWithAction = function () {
-            scope.buttonAction = jasmine.createSpy('buttonAction');
-
-            var html = `
+		createElement = () => {
+			scope.buttonAction = jasmine.createSpy('buttonAction');
+			element = angular.element(`
                 <talend-button-dropdown button-icon="m" 
                                         button-text="Click Me" 
                                         button-action="buttonAction()" 
-                                        button-title="test">
+                                        button-title="test"
+                                        dropdown-menu-direction="{{dropdownMenuDirection}}">
                    <li>Menu 1</li>
                    <li>Menu 2</li>
                 </talend-button-dropdown>
-            `;
-            element = $compile(html)(scope);
-            $timeout.flush();
-            scope.$digest();
-        };
+            `);
+			$compile(element)(scope);
+			$timeout.flush();
+			scope.$digest();
+		};
+	}));
 
-        createElementWithoutAction = function () {
-            var html = '<talend-button-dropdown button-icon="m" button-text="Click Me" button-action="">' +
-                '   <ul>' +
-                '       <li>Menu 1</li>' +
-                '       <li>Menu 2</li>' +
-                '   </ul>' +
-                '</talend-button-dropdown>';
-            element = $compile(html)(scope);
-            $timeout.flush();
-            scope.$digest();
-        };
-    }));
+	it('should call action on main button click', () => {
+		// given
+		createElement();
 
-    it('should call action on main button click', function () {
-        //given
-        createElementWithAction();
+		// when
+		element.find('.button-dropdown-main').eq(0).click();
 
-        //when
-        element.find('.button-dropdown-main').eq(0).click();
+		// then
+		expect(scope.buttonAction).toHaveBeenCalled();
+	});
 
-        //then
-        expect(scope.buttonAction).toHaveBeenCalled();
-    });
+	it('should render button title', () => {
+		// when
+		createElement();
 
-    it('should render button title', () => {
-        // when
-        createElementWithAction();
+		// then
+		const button = element.find('.btn').eq(0);
+		expect(button[0].title).toBe('test');
+	});
 
-        // then
-        const button = element.find('.btn').eq(0);
-        expect(button[0].title).toBe('test');
-    });
+	it('should render dropdown menu at right by default', () => {
+		// when
+		createElement();
+
+		// then
+		const dropdownMenu = element.find('.dropdown-menu').eq(0);
+		expect(dropdownMenu.hasClass('dropdown-menu-right')).toBeTruthy();
+		expect(dropdownMenu.hasClass('dropdown-menu-left')).toBeFalsy();
+	});
+
+	it('should render dropdown menu at right', () => {
+		// given
+		scope.dropdownMenuDirection = 'right';
+
+		// when
+		createElement();
+
+		// then
+		const dropdownMenu = element.find('.dropdown-menu').eq(0);
+		expect(dropdownMenu.hasClass('dropdown-menu-right')).toBeTruthy();
+		expect(dropdownMenu.hasClass('dropdown-menu-left')).toBeFalsy();
+	});
+
+	it('should render dropdown menu at left', () => {
+		// given
+		scope.dropdownMenuDirection = 'left';
+
+		// when
+		createElement();
+
+		// then
+		const dropdownMenu = element.find('.dropdown-menu').eq(0);
+		expect(dropdownMenu.hasClass('dropdown-menu-right')).toBeFalsy();
+		expect(dropdownMenu.hasClass('dropdown-menu-left')).toBeTruthy();
+	});
 });

--- a/dataprep-webapp/src/app/components/widgets/modal/_modal.scss
+++ b/dataprep-webapp/src/app/components/widgets/modal/_modal.scss
@@ -36,7 +36,6 @@
   $navigation-item-space: 10px;
 
   p {
-    color: $base-font-color;
     line-height: $base-line-height;
   }
   //////////////////////////////////////////////////////////////////////////////////
@@ -48,6 +47,8 @@
   $modal-image-height: 135px;
   $modal-image-width: $modal-image-height;
   $modal-trigger-image-width: 300px;
+
+  color: $base-font-color;
 
   label {
     cursor: pointer;
@@ -333,22 +334,18 @@
 }
 
 .modal-open {
-  overflow: hidden;
-
   .modal {
     display: block;
 
-    .modal-window {
+    &-window {
       margin: 0;
       padding: 0;
+      width: auto;
+      overflow: auto;
     }
 
-    .modal-dialog {
-      width: auto;
+    &-content {
+      margin: 1rem auto;
     }
   }
-}
-
-.modal-closed {
-  overflow: auto;
 }

--- a/dataprep-webapp/src/app/css/vendors/libs/base/_forms.scss
+++ b/dataprep-webapp/src/app/css/vendors/libs/base/_forms.scss
@@ -1,8 +1,5 @@
 fieldset {
-  background-color: lighten($base-border-color, 10%);
-  border: $base-border;
   margin: 0 0 $small-spacing;
-  padding: $base-spacing;
 }
 
 input,

--- a/dataprep-webapp/src/app/services/import/import-rest-service.spec.js
+++ b/dataprep-webapp/src/app/services/import/import-rest-service.spec.js
@@ -11,168 +11,167 @@
 
  ============================================================================*/
 
-describe('Import REST Service', function () {
-    'use strict';
+describe('Import REST Service', () => {
 
-    var $httpBackend;
-    const importTypes = [
-        {
-            locationType: 'hdfs',
-            contentType: 'application/vnd.remote-ds.hdfs',
-            parameters: [
-                {
-                    name: 'name',
-                    type: 'string',
-                    implicit: false,
-                    canBeBlank: false,
-                    format: '',
-                    default: '',
-                    description: 'Name',
-                    label: 'Enter the dataset name:',
-                },
-                {
-                    name: 'url',
-                    type: 'string',
-                    implicit: false,
-                    canBeBlank: false,
-                    format: 'hdfs://host:port/file',
-                    default: '',
-                    description: 'URL',
-                    label: 'Enter the dataset URL:',
-                },
-            ],
-            defaultImport: false,
-            label: 'From HDFS',
-            title: 'Add HDFS dataset',
-        },
-        {
-            locationType: 'http',
-            contentType: 'application/vnd.remote-ds.http',
-            parameters: [
-                {
-                    name: 'name',
-                    type: 'string',
-                    implicit: false,
-                    canBeBlank: false,
-                    format: '',
-                    default: '',
-                    description: 'Name',
-                    label: 'Enter the dataset name:',
-                },
-                {
-                    name: 'url',
-                    type: 'string',
-                    implicit: false,
-                    canBeBlank: false,
-                    format: 'http://',
-                    default: '',
-                    description: 'URL',
-                    label: 'Enter the dataset URL:',
-                },
-            ],
-            defaultImport: false,
-            label: 'From HTTP',
-            title: 'Add HTTP dataset',
-        },
-        {
-            locationType: 'local',
-            contentType: 'text/plain',
-            parameters: [
-                {
-                    name: 'datasetFile',
-                    type: 'file',
-                    implicit: false,
-                    canBeBlank: false,
-                    format: '*.csv',
-                    default: '',
-                    description: 'File',
-                    label: 'File',
-                },
-            ],
-            defaultImport: true,
-            label: 'Local File',
-            title: 'Add local file dataset',
-        }, {
-            locationType: 'job',
-            contentType: 'application/vnd.remote-ds.job',
-            parameters: [
-                {
-                    name: 'name',
-                    type: 'string',
-                    implicit: false,
-                    canBeBlank: false,
-                    format: '',
-                    description: 'Name',
-                    label: 'Enter the dataset name:',
-                    default: '',
-                },
-                {
-                    name: 'jobId',
-                    type: 'select',
-                    implicit: false,
-                    canBeBlank: false,
-                    format: '',
-                    configuration: {
-                        values: [
-                            {
-                                value: '1',
-                                label: 'TestInput',
-                            },
-                        ],
-                        multiple: false,
-                    },
-                    description: 'Talend Job',
-                    label: 'Select the Talend Job:',
-                    default: '',
-                },
-            ],
-            defaultImport: false,
-            label: 'From Talend Job',
-            title: 'Add Talend Job dataset',
-        },
-    ];
+	let $httpBackend;
+	const importTypes = [
+		{
+			locationType: 'hdfs',
+			contentType: 'application/vnd.remote-ds.hdfs',
+			parameters: [
+				{
+					name: 'name',
+					type: 'string',
+					implicit: false,
+					canBeBlank: false,
+					format: '',
+					default: '',
+					description: 'Name',
+					label: 'Enter the dataset name:',
+				},
+				{
+					name: 'url',
+					type: 'string',
+					implicit: false,
+					canBeBlank: false,
+					format: 'hdfs://host:port/file',
+					default: '',
+					description: 'URL',
+					label: 'Enter the dataset URL:',
+				},
+			],
+			defaultImport: false,
+			label: 'From HDFS',
+			title: 'Add HDFS dataset',
+		},
+		{
+			locationType: 'http',
+			contentType: 'application/vnd.remote-ds.http',
+			parameters: [
+				{
+					name: 'name',
+					type: 'string',
+					implicit: false,
+					canBeBlank: false,
+					format: '',
+					default: '',
+					description: 'Name',
+					label: 'Enter the dataset name:',
+				},
+				{
+					name: 'url',
+					type: 'string',
+					implicit: false,
+					canBeBlank: false,
+					format: 'http://',
+					default: '',
+					description: 'URL',
+					label: 'Enter the dataset URL:',
+				},
+			],
+			defaultImport: false,
+			label: 'From HTTP',
+			title: 'Add HTTP dataset',
+		},
+		{
+			locationType: 'local',
+			contentType: 'text/plain',
+			parameters: [
+				{
+					name: 'datasetFile',
+					type: 'file',
+					implicit: false,
+					canBeBlank: false,
+					format: '*.csv',
+					default: '',
+					description: 'File',
+					label: 'File',
+				},
+			],
+			defaultImport: true,
+			label: 'Local File',
+			title: 'Add local file dataset',
+		}, {
+			locationType: 'job',
+			contentType: 'application/vnd.remote-ds.job',
+			parameters: [
+				{
+					name: 'name',
+					type: 'string',
+					implicit: false,
+					canBeBlank: false,
+					format: '',
+					description: 'Name',
+					label: 'Enter the dataset name:',
+					default: '',
+				},
+				{
+					name: 'jobId',
+					type: 'select',
+					implicit: false,
+					canBeBlank: false,
+					format: '',
+					configuration: {
+						values: [
+							{
+								value: '1',
+								label: 'TestInput',
+							},
+						],
+						multiple: false,
+					},
+					description: 'Talend Job',
+					label: 'Select the Talend Job:',
+					default: '',
+				},
+			],
+			defaultImport: false,
+			label: 'From Talend Job',
+			title: 'Add Talend Job dataset',
+		},
+	];
 
-    beforeEach(angular.mock.module('data-prep.services.import'));
+	beforeEach(angular.mock.module('data-prep.services.import'));
 
-    beforeEach(inject(($injector) => {
-        $httpBackend = $injector.get('$httpBackend');
-    }));
+	beforeEach(inject(($injector) => {
+		$httpBackend = $injector.get('$httpBackend');
+	}));
 
-    it('should get all import types', inject(($rootScope, RestURLs, ImportRestService) => {
-        //given
-        let types = null;
-        $httpBackend
-            .expectGET(RestURLs.exportUrl + '/imports')
-            .respond(200, importTypes);
+	it('should get all import types', inject(($rootScope, RestURLs, ImportRestService) => {
+		// given
+		let types = null;
+		$httpBackend
+			.expectGET(RestURLs.exportUrl + '/imports')
+			.respond(200, importTypes);
 
-        //when
-        ImportRestService.importTypes()
-            .then((response) => {
-                types = response.data;
-            });
-        $httpBackend.flush();
-        $rootScope.$digest();
+		// when
+		ImportRestService.importTypes()
+			.then((response) => {
+				types = response.data;
+			});
+		$httpBackend.flush();
+		$rootScope.$digest();
 
-        //then
-        expect(types).toEqual(importTypes);
-    }));
+		// then
+		expect(types).toEqual(importTypes);
+	}));
 
-    it('should get all import parameters', inject(($rootScope, RestURLs, ImportRestService) => {
-        //given
-        let params = null;
-        $httpBackend
-            .expectGET(RestURLs.exportUrl + '/imports/http/parameters')
-            .respond(200, { name: 'url' });
+	it('should get all import parameters', inject(($rootScope, RestURLs, ImportRestService) => {
+		// given
+		let params = null;
+		$httpBackend
+			.expectGET(RestURLs.exportUrl + '/imports/http/parameters')
+			.respond(200, { name: 'url' });
 
-        //when
-        ImportRestService.importParameters('http')
-            .then((response) => {
-                params = response.data;
-            });
-        $httpBackend.flush();
-        $rootScope.$digest();
+		// when
+		ImportRestService.importParameters('http')
+			.then((response) => {
+				params = response.data;
+			});
+		$httpBackend.flush();
+		$rootScope.$digest();
 
-        //then
-        expect(params).toEqual({ name: 'url' });
-    }));
+		// then
+		expect(params).toEqual({ name: 'url' });
+	}));
 });

--- a/dataprep-webapp/src/i18n/en.json
+++ b/dataprep-webapp/src/i18n/en.json
@@ -155,8 +155,8 @@
   "IMPORT_WAIT": "Fetching import parameters, please wait...",
   "DATASET_NAME": "Dataset Name:",
   "PREPARATION": "Preparation",
-
-
+  "DATASTORE_TEST_CONNECTION": "Test connection",
+  "DATASTORE_CONNECTION_SUCCESSFUL": "Connection successful",
 
   "_comment": "Common",
   "LOADING": "Loading...",


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2048

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !

**(Optional) Other information**:

* TDP-2965: add wiring for tcomp properties fetching

- wire API to dataset for tcomp properties on /api/datasets/imports/{import}/jsonschemaparameters
- wire Dataset to TComp to fetch json-schema params through DatasetLocation.getParametersAsSchema()
- adds basic TComp exceptions and datamodel deserializers to adapt when TComp is usable

linked to TDP-2048

* TDP-2048 TDP-2965: add react-talend-forms dependency

* TDP-2048 TDP-2965: add react-talend-forms ngReact directive

* TDP-2048 TDP-2965: fix too large modal display

* TDP-2048 TDP-2965: Fix some form style

* TDP-2048 TDP-2965: Display datastore creation generic form

* feat TDP-2965: wiring TComp properties to the front

- remove endpoint "jsonschemaparameters" to merge it with parameters
- update the TComp data store list location
- change the TComp dataset sources prefix to "tcomp-"

* feat TDP-2965: updates properties to new "tcomp-" prefix

* feat TDP-2965: add a TComp enable switch for location (isSchemaOriented)

* feat TDP-2965: quick fix to read JDBC JSonSchema

* TDP-2048 TDP-2965: Define more generic modal text color

* TDP-2048 TDP-2965: Add translation

* TDP-2048 TDP-2965: Be able to change dropdown menu direction

* TDP-2048 TDP-2965: Display datastore creation form

* TDP-2048 TDP-2965: Be able to change dropdown menu direction

* TDP-2048 TDP-2965: add unit test for TCOMP datastore form creation

* TDP-2048 TDP-2965: Retrieve UI specs from backend

* TDP-2048 TDP-2965: Improve JSDoc

* feat TDP-2965: quick fix to read JDBC UISchema

* feat(TDP-2965): I18N tcomp datastore supported

* TDP-2048 TDP-2965: Remove useless unit test

* TDP-2048 TDP-2965: Rename react-talend-form directive

* TDP-2048 TDP-2965: Add i18n message for test connection button

* TDP-2048 TDP-2965: DRY

* TDP-2048 TDP-2965: Lighten CSS

* TDP-2048 TDP-2965: Remove useless dependency

* feat TDP-2965: changes after review

- remove dead code
- remove dependency on json schema
- back to default to emptyList() when no location is found on properties dataset enpoint
- remove experimental exceptions
- document the Supplier<ComponentProperties> for TCompLocation
- add error messages for TComp error