### PR TITLE
feat(TDP-2802): add home global insertion point

### DIFF
--- a/dataprep-webapp/src/app/components/home/home-component.spec.js
+++ b/dataprep-webapp/src/app/components/home/home-component.spec.js
@@ -67,4 +67,12 @@ describe('Home component', () => {
 		//then
 		expect(element.find('preparation-creator').length).toBe(1);
 	});
+	
+	it('should inject home insertion point', () => {
+		//when
+		createElement();
+
+		//then
+		expect(element.find('insertion-home').length).toBe(1);
+	});
 });

--- a/dataprep-webapp/src/app/components/home/home.html
+++ b/dataprep-webapp/src/app/components/home/home.html
@@ -46,3 +46,4 @@
 
 <dataset-xls-preview></dataset-xls-preview>
 <preparation-creator></preparation-creator>
+<insertion-home></insertion-home>

--- a/dataprep-webapp/src/app/components/home/react-home-component.js
+++ b/dataprep-webapp/src/app/components/home/react-home-component.js
@@ -13,12 +13,14 @@
 
 const HomeComponent = {
 	template: `
-		<dataset-xls-preview></dataset-xls-preview>
-		<preparation-copy-move></preparation-copy-move>
-		<preparation-creator></preparation-creator>
 		<layout>
 			<ui-view name="home-content"></ui-view>
 		</layout>
+		
+		<dataset-xls-preview></dataset-xls-preview>
+		<preparation-copy-move></preparation-copy-move>
+		<preparation-creator></preparation-creator>
+		<insertion-home></insertion-home>
 	`,
 };
 

--- a/dataprep-webapp/src/app/components/home/react-home-component.spec.js
+++ b/dataprep-webapp/src/app/components/home/react-home-component.spec.js
@@ -57,6 +57,14 @@ describe('Home component', () => {
 		expect(element.find('preparation-creator').length).toBe(1);
 	});
 
+	it('should inject home insertion point', () => {
+		//when
+		createElement();
+
+		//then
+		expect(element.find('insertion-home').length).toBe(1);
+	});
+	
 	it('should instanciate app layout with an ui insertion point', () => {
 		//when
 		createElement();


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2802

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
(Additional information to the Jira)
No way to inject things in the home page root

**(Optional) What is the new behavior?**
(Additional information to the Jira)
Allow to inject components to be available in the home page

**(Optional) Other information**:

