### PR TITLE
fix(TDP-2802): base preparation owner on owner display name

### DIFF
--- a/dataprep-webapp/src/app/services/folder/folder-service.js
+++ b/dataprep-webapp/src/app/services/folder/folder-service.js
@@ -95,7 +95,7 @@ export default function FolderService($q, state, StateService, FolderRestService
 		return preparations.map(item => ({
 			id: item.id,
 			name: item.name,
-			author: item.owner.displayName,
+			author: item.owner && item.owner.displayName,
 			creationDate: moment(item.creationDate).fromNow(),
 			lastModificationDate: moment(item.lastModificationDate).fromNow(),
 			dataset: item.dataset.dataSetName,
@@ -119,7 +119,7 @@ export default function FolderService($q, state, StateService, FolderRestService
 		return folders.map(item => ({
 			id: item.id,
 			name: item.name,
-			author: item.owner.displayName,
+			author: item.owner && item.owner.displayName,
 			creationDate: moment(item.creationDate).fromNow(),
 			lastModificationDate: moment(item.lastModificationDate).fromNow(),
 			icon: 'talend-folder',

--- a/dataprep-webapp/src/app/services/folder/folder-service.js
+++ b/dataprep-webapp/src/app/services/folder/folder-service.js
@@ -95,7 +95,7 @@ export default function FolderService($q, state, StateService, FolderRestService
 		return preparations.map(item => ({
 			id: item.id,
 			name: item.name,
-			author: item.author,
+			author: item.owner.displayName,
 			creationDate: moment(item.creationDate).fromNow(),
 			lastModificationDate: moment(item.lastModificationDate).fromNow(),
 			dataset: item.dataset.dataSetName,

--- a/dataprep-webapp/src/app/services/folder/folder-service.spec.js
+++ b/dataprep-webapp/src/app/services/folder/folder-service.spec.js
@@ -18,7 +18,7 @@ const preparation = {
 		dataSetNbRow: 400,
 	},
 	name: 'JSO prep 1',
-	author: 'anonymousUser',
+	owner: { displayName: 'toto' },
 	creationDate: new Date().getTime(),
 	lastModificationDate: new Date().getTime(),
 	steps: [
@@ -31,7 +31,7 @@ const preparation = {
 const adaptedPreparation = {
 	id: '1',
 	name: 'JSO prep 1',
-	author: 'anonymousUser',
+	author: 'toto',
 	creationDate: 'a few seconds ago',
 	lastModificationDate: 'a few seconds ago',
 	dataset: 'US states',


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2802

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
(Additional information to the Jira)
The preparation owner display was based on `author` property from backend.

**(Optional) What is the new behavior?**
(Additional information to the Jira)
The preparation owner display was based on `owner.displayName` property from backend.


**(Optional) Other information**:

