### PR TITLE
feat(TDP-2802):  folder icons

### DIFF
--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -58,7 +58,7 @@
     "react-autowhatever": "^7.0.0",
     "react-bootstrap": "^0.30.3",
     "react-dom": "^15.4.1",
-    "react-talend-components": "0.24.0",
+    "react-talend-components": "0.26.0",
     "react-talend-forms": "0.7.1",
     "sunchoke": "git+https://github.com/Talend/sunchoke.git#1.0.0",
     "talend-icons": "0.10.0",

--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -61,7 +61,7 @@
     "react-talend-components": "0.24.0",
     "react-talend-forms": "0.7.1",
     "sunchoke": "git+https://github.com/Talend/sunchoke.git#1.0.0",
-    "talend-icons": "0.5.5",
+    "talend-icons": "0.10.0",
     "uuid": "^2.0.3"
   },
   "devDependencies": {

--- a/dataprep-webapp/src/app/components/widgets-containers/preparation-list/preparation-list-container.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/preparation-list/preparation-list-container.js
@@ -12,6 +12,7 @@
  ============================================================================*/
 
 import PreparationListCtrl from './preparation-list-controller';
+import './preparation-list-container.scss';
 
 /**
  * Preparation list container

--- a/dataprep-webapp/src/app/components/widgets-containers/preparation-list/preparation-list-container.scss
+++ b/dataprep-webapp/src/app/components/widgets-containers/preparation-list/preparation-list-container.scss
@@ -1,0 +1,17 @@
+.list-item-preparation {
+	.tc-list-icon {
+		fill: #005393;
+	}
+}
+
+.list-item-folder {
+	.tc-list-icon {
+		fill: #EAC282;
+	}
+}
+
+.list-item-shared-folder {
+	.tc-list-icon {
+		fill: #00A6CE;
+	}
+}

--- a/dataprep-webapp/src/app/components/widgets-containers/preparation-list/preparation-list-controller.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/preparation-list/preparation-list-controller.js
@@ -30,7 +30,13 @@ export default class PreparationListCtrl {
 	}
 
 	$onInit() {
-		this.didMountAction();
+		const didMountActionCreator = this.appSettings
+			.views['listview:preparations']
+			.didMountActionCreator;
+		if (didMountActionCreator) {
+			const action = this.appSettings.actions[didMountActionCreator];
+			this.SettingsActionsService.dispatch(action);
+		}
 	}
 
 	$postLink() {
@@ -54,21 +60,9 @@ export default class PreparationListCtrl {
 			};
 		}
 		if (changes.sortBy) {
-			const currentValue = changes.sortBy.currentValue;
-			const sortBy = this.toolbarProps.sortBy.map((sort) => {
-				const isSelected = sort.selected;
-				const shouldBeSelected = sort.id === currentValue;
-				if (isSelected === shouldBeSelected) {
-					return sort;
-				}
-				return {
-					...sort,
-					selected: shouldBeSelected,
-				};
-			});
 			this.toolbarProps = {
 				...this.toolbarProps,
-				sortBy,
+				sortBy: changes.sortBy.currentValue,
 			};
 		}
 		if (changes.sortDesc) {
@@ -76,16 +70,6 @@ export default class PreparationListCtrl {
 				...this.toolbarProps,
 				sortDesc: changes.sortDesc.currentValue,
 			};
-		}
-	}
-
-	didMountAction() {
-		const didMountActionCreator = this.appSettings
-			.views['listview:preparations']
-			.didMountActionCreator;
-		if (didMountActionCreator) {
-			const action = this.appSettings.actions[didMountActionCreator];
-			this.SettingsActionsService.dispatch(action);
 		}
 	}
 

--- a/dataprep-webapp/src/app/services/folder/folder-service.js
+++ b/dataprep-webapp/src/app/services/folder/folder-service.js
@@ -104,7 +104,7 @@ export default function FolderService($q, state, StateService, FolderRestService
 			nbSteps: item.steps.length - 1, // remove root step
 			icon: 'talend-dataprep',
 			displayMode: 'text',
-			className: 'list-item-folder',
+			className: 'list-item-preparation',
 			actions: this.getPreparationActions(item),
 			model: item,
 		}));
@@ -128,7 +128,7 @@ export default function FolderService($q, state, StateService, FolderRestService
 			lastModificationDate: moment(item.lastModificationDate).fromNow(),
 			icon: 'talend-folder',
 			displayMode: 'text',
-			className: 'list-item-preparation',
+			className: 'list-item-folder',
 			actions: this.getFolderActions(item),
 			model: item,
 		}));

--- a/dataprep-webapp/src/app/services/folder/folder-service.js
+++ b/dataprep-webapp/src/app/services/folder/folder-service.js
@@ -104,6 +104,7 @@ export default function FolderService($q, state, StateService, FolderRestService
 			nbSteps: item.steps.length - 1, // remove root step
 			icon: 'talend-dataprep',
 			displayMode: 'text',
+			className: 'list-item-folder',
 			actions: this.getPreparationActions(item),
 			model: item,
 		}));
@@ -127,6 +128,7 @@ export default function FolderService($q, state, StateService, FolderRestService
 			lastModificationDate: moment(item.lastModificationDate).fromNow(),
 			icon: 'talend-folder',
 			displayMode: 'text',
+			className: 'list-item-preparation',
 			actions: this.getFolderActions(item),
 			model: item,
 		}));

--- a/dataprep-webapp/src/app/services/folder/folder-service.spec.js
+++ b/dataprep-webapp/src/app/services/folder/folder-service.spec.js
@@ -40,6 +40,7 @@ const adaptedPreparation = {
 	nbSteps: 3,
 	icon: 'talend-dataprep',
 	displayMode: 'text',
+	className: 'list-item-preparation',
 	actions: ['preparation:edit', 'preparation:copy-move', 'preparation:remove'],
 	model: preparation,
 };
@@ -61,6 +62,7 @@ const adaptedFolder = {
 	lastModificationDate: 'a few seconds ago',
 	icon: 'talend-folder',
 	displayMode: 'text',
+	className: 'list-item-folder',
 	actions: ['preparation:edit:folder', 'preparation:remove:folder'],
 	model: folder,
 };

--- a/dataprep-webapp/src/app/services/folder/folder-service.spec.js
+++ b/dataprep-webapp/src/app/services/folder/folder-service.spec.js
@@ -402,7 +402,7 @@ describe('Folder services', () => {
 	describe('getPreparationActions', () => {
 		it('should return fixed preparation actions', inject((FolderService) => {
 			// when
-			const actions = FolderService.getPreparationActions()
+			const actions = FolderService.getPreparationActions();
 
 			// then
 			expect(actions).toEqual(['preparation:edit', 'preparation:copy-move', 'preparation:remove']);
@@ -412,7 +412,7 @@ describe('Folder services', () => {
 	describe('getFolderActions', () => {
 		it('should return fixed folder actions', inject((FolderService) => {
 			// when
-			const actions = FolderService.getFolderActions()
+			const actions = FolderService.getFolderActions();
 
 			// then
 			expect(actions).toEqual(['preparation:edit:folder', 'preparation:remove:folder']);

--- a/dataprep-webapp/src/assets/config/app-settings.json
+++ b/dataprep-webapp/src/assets/config/app-settings.json
@@ -42,6 +42,9 @@
           { "key": "nbSteps", "label": "Steps" }
         ],
         "items": [],
+        "itemProps": {
+          "classNameKey": "className"
+        },
         "titleProps": {
           "displayModeKey": "displayMode",
           "iconKey": "icon",

--- a/dataprep-webapp/src/assets/config/app-settings.json
+++ b/dataprep-webapp/src/assets/config/app-settings.json
@@ -55,7 +55,7 @@
         }
       },
       "toolbar": {
-        "sortBy": [
+        "sortOptions": [
           { "id": "name", "name": "Name" },
           { "id": "date", "name": "Creation Date" }
         ],

--- a/dataprep-webapp/src/mocks/Settings.mock.js
+++ b/dataprep-webapp/src/mocks/Settings.mock.js
@@ -67,7 +67,7 @@ const settingsMock = {
 				},
 			},
 			toolbar: {
-				sortBy: [
+				sortOptions: [
 					{ id: 'name', name: 'Name' },
 					{ id: 'date', name: 'Creation Date' },
 				],

--- a/dataprep-webapp/src/mocks/Settings.mock.js
+++ b/dataprep-webapp/src/mocks/Settings.mock.js
@@ -57,6 +57,9 @@ const settingsMock = {
 					{ key: 'nbSteps', label: 'Nb steps' },
 				],
 				items: [],
+				itemProps: {
+					classNameKey: 'className',
+				},
 				titleProps: {
 					displayModeKey: 'displayMode',
 					iconKey: 'icon',

--- a/dataprep-webapp/yarn.lock
+++ b/dataprep-webapp/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-Base64@~0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.2.1.tgz#ba3a4230708e186705065e66babdd4c35cf60028"
-
 "X-SlickGrid@github:ddomingues/X-SlickGrid#2e7784a39c2625c3800ebfeb62e4b239e2eafacf":
   version "0.0.1"
   resolved "https://codeload.github.com/ddomingues/X-SlickGrid/tar.gz/2e7784a39c2625c3800ebfeb62e4b239e2eafacf"
@@ -68,8 +64,8 @@ ajv-keywords@^1.0.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.2.0.tgz#676c4f087bfe1e8b12dca6fda2f3c74f417b099c"
 
 ajv@^4.7.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.9.0.tgz#5a358085747b134eb567d6d15e015f1d7802f45c"
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.9.2.tgz#3f7dcda95b0c34bceb2d69945117d146219f1a2c"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
@@ -129,18 +125,18 @@ angular-sanitize@^1.5.7:
   resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.5.9.tgz#e2d7dd8e8587f1342b6d2efdfa67311fcf1f65ed"
 
 angular-translate-loader-static-files@^2.10.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/angular-translate-loader-static-files/-/angular-translate-loader-static-files-2.13.0.tgz#e76b56be4647be3594b3a4aaaabdc3ef0ada11f7"
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/angular-translate-loader-static-files/-/angular-translate-loader-static-files-2.13.1.tgz#61f0365fa749bc10afd6952eb1fa36de5f03569d"
   dependencies:
-    angular-translate "~2.13.0"
+    angular-translate "~2.13.1"
 
 angular-translate-once@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/angular-translate-once/-/angular-translate-once-1.0.3.tgz#a3cb068ada267ed37feb38b3f1d1be4181dceb70"
 
-angular-translate@^2.10.0, angular-translate@~2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/angular-translate/-/angular-translate-2.13.0.tgz#f070410b018d72061d2f782516401eb8ccb4fc62"
+angular-translate@^2.10.0, angular-translate@~2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/angular-translate/-/angular-translate-2.13.1.tgz#05673eb371986fc11edc151f590299d7e0c46228"
   dependencies:
     angular ">=1.2.26 <=1.6"
 
@@ -495,8 +491,8 @@ babel-helpers@^6.16.0:
     babel-template "^6.16.0"
 
 babel-loader@^6.2.4:
-  version "6.2.8"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.2.8.tgz#30d7183aef60afc140b36443676b7acb4c12ac9c"
+  version "6.2.9"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.2.9.tgz#2bce6a1c29b47afa90b937ba1fb1f87084d61c61"
   dependencies:
     find-cache-dir "^0.1.1"
     loader-utils "^0.2.11"
@@ -1017,8 +1013,8 @@ bourbon@^4.2.6, bourbon@^4.2.7:
   resolved "https://registry.yarnpkg.com/bourbon/-/bourbon-4.2.7.tgz#48a805dff475fbf61e002a64e1e4db68d2f82fba"
 
 bowser@^1.0.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.5.0.tgz#b97414bacbc631f19f1e2e11466566ec19324983"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.0.tgz#37fc387b616cb6aef370dab4d6bd402b74c5c54d"
 
 brace-expansion@^1.0.0:
   version "1.1.6"
@@ -1041,7 +1037,13 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-browserify-zlib@~0.1.4:
+browserify-aes@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-0.4.0.tgz#067149b668df31c4b58533e02d01e806d8608e2c"
+  dependencies:
+    inherits "^2.0.1"
+
+browserify-zlib@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
   dependencies:
@@ -1068,6 +1070,10 @@ buffer@^4.9.0:
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+builtin-status-codes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz#6f22003baacf003ccd287afe6872151fddc58579"
 
 bytes@2.1.0:
   version "2.1.0"
@@ -1122,8 +1128,8 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
 caniuse-db@^1.0.30000539, caniuse-db@^1.0.30000578:
-  version "1.0.30000590"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000590.tgz#306e2b133ce467e8341b2accd223256b4040b2be"
+  version "1.0.30000592"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000592.tgz#7b916023941df4063d9d946a1f9ad0d5edaf2bcd"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -1460,9 +1466,9 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-constants-browserify@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-0.0.1.tgz#92577db527ba6c4cf0a4568d84bc031f441e21f2"
+constants-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
 contains-path@^0.1.0:
   version "0.1.0"
@@ -1547,10 +1553,11 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
-crypto-browserify@~3.2.6:
-  version "3.2.8"
-  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.2.8.tgz#b9b11dbe6d9651dd882a01e6cc467df718ecf189"
+crypto-browserify@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.3.0.tgz#b9fc75bb4a0ed61dcf1cd5dae96eb30c9c3e506c"
   dependencies:
+    browserify-aes "0.4.0"
     pbkdf2-compat "2.0.1"
     ripemd160 "0.2.0"
     sha.js "2.2.6"
@@ -1824,16 +1831,9 @@ doctrine@1.1.0:
     esutils "^1.1.6"
     isarray "0.0.1"
 
-doctrine@1.3.x:
+doctrine@1.3.x, doctrine@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.3.0.tgz#13e75682b55518424276f7c173783456ef913d26"
-  dependencies:
-    esutils "^2.0.2"
-    isarray "^1.0.0"
-
-doctrine@^1.2.2:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
@@ -2765,17 +2765,17 @@ gauge@~2.6.0:
     wide-align "^1.1.0"
 
 gauge@~2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.1.tgz#388473894fe8be5e13ffcdb8b93e4ed0616428c7"
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.2.tgz#15cecc31b02d05345a5d6b0e171cdb3ad2307774"
   dependencies:
     aproba "^1.0.3"
     console-control-strings "^1.0.0"
-    has-color "^0.1.7"
     has-unicode "^2.0.0"
     object-assign "^4.1.0"
     signal-exit "^3.0.0"
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+    supports-color "^0.2.0"
     wide-align "^1.1.0"
 
 gaze@^0.5.1:
@@ -3220,13 +3220,6 @@ htmlparser2@~3.3.0:
     domutils "1.1"
     readable-stream "1.0"
 
-http-browserify@^1.3.2:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/http-browserify/-/http-browserify-1.7.0.tgz#33795ade72df88acfbfd36773cefeda764735b20"
-  dependencies:
-    Base64 "~0.2.0"
-    inherits "~2.0.1"
-
 http-errors@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.3.1.tgz#197e22cdebd4198585e8694ef6786197b91ed942"
@@ -3261,8 +3254,8 @@ http-proxy@^0.10:
     utile "~0.2.1"
 
 http-proxy@^1.13.0, http-proxy@^1.15.1:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.0.tgz#f9b52305e9f864811835277e4a486051b5d4a523"
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.2.tgz#06dff292952bf64dbe8471fa9df73066d4f37742"
   dependencies:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
@@ -3275,9 +3268,9 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-browserify@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.0.tgz#b3ffdfe734b2a3d4a9efd58e8654c91fce86eafd"
+https-browserify@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
 hyphenate-style-name@^1.0.1:
   version "1.0.2"
@@ -3566,8 +3559,8 @@ is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
 is-unc-path@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-0.1.1.tgz#ab2533d77ad733561124c3dc0f5cd8b90054c86b"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-0.1.2.tgz#6ab053a72573c10250ff416a3814c35178af39b9"
   dependencies:
     unc-path-regex "^0.1.0"
 
@@ -3823,8 +3816,8 @@ karma-jasmine@~0.3.5:
   resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-0.3.8.tgz#5b6457791ad9b89aa173f079e3ebe1b8c805236c"
 
 karma-junit-reporter@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-1.1.0.tgz#12f8ff82050607a1d4f1192f0211efde4b59ca3e"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz#4f9c40cedfb1a395f8aef876abf96189917c6396"
   dependencies:
     path-is-absolute "^1.0.0"
     xmlbuilder "8.2.2"
@@ -3912,8 +3905,8 @@ keycode@^2.1.1, keycode@^2.1.2:
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.7.tgz#7b9255919f6cff562b09a064d222dca70b020f5c"
 
 kind-of@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.0.4.tgz#7b8ecf18a4e17f8269d73b501c9f232c96887a74"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
   dependencies:
     is-buffer "^1.0.2"
 
@@ -4239,7 +4232,11 @@ lower-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.3.tgz#c92393d976793eee5ba4edb583cf8eae35bd9bfb"
 
-lru-cache@2, lru-cache@2.2.x:
+lru-cache@2:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
+
+lru-cache@2.2.x:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.2.4.tgz#6c658619becf14031d0d0b594b16042ce4dc063d"
 
@@ -4461,8 +4458,8 @@ modernizr@^3.3.1:
     moment ">=1.5.0"
 
 moment@>=1.5.0, moment@^2.13.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.0.tgz#a4c292e02aac5ddefb29a6eed24f51938dd3b74f"
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.17.1.tgz#fed9506063f36b10f066c8b59a144d7faebe1d82"
 
 morgan@~1.6.1:
   version "1.6.1"
@@ -4621,32 +4618,32 @@ node-gyp@^3.3.1:
     tar "^2.0.0"
     which "1"
 
-node-libs-browser@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-0.6.0.tgz#244806d44d319e048bc8607b5cc4eaf9a29d2e3c"
+node-libs-browser@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-0.7.0.tgz#3e272c0819e308935e26674408d7af0e1491b83b"
   dependencies:
     assert "^1.1.1"
-    browserify-zlib "~0.1.4"
+    browserify-zlib "^0.1.4"
     buffer "^4.9.0"
     console-browserify "^1.1.0"
-    constants-browserify "0.0.1"
-    crypto-browserify "~3.2.6"
+    constants-browserify "^1.0.0"
+    crypto-browserify "3.3.0"
     domain-browser "^1.1.1"
     events "^1.0.0"
-    http-browserify "^1.3.2"
-    https-browserify "0.0.0"
-    os-browserify "~0.1.2"
+    https-browserify "0.0.1"
+    os-browserify "^0.2.0"
     path-browserify "0.0.0"
     process "^0.11.0"
     punycode "^1.2.4"
-    querystring-es3 "~0.2.0"
-    readable-stream "^1.1.13"
-    stream-browserify "^1.0.0"
-    string_decoder "~0.10.25"
-    timers-browserify "^1.0.1"
+    querystring-es3 "^0.2.0"
+    readable-stream "^2.0.5"
+    stream-browserify "^2.0.1"
+    stream-http "^2.3.1"
+    string_decoder "^0.10.25"
+    timers-browserify "^2.0.2"
     tty-browserify "0.0.0"
-    url "~0.10.1"
-    util "~0.10.3"
+    url "^0.11.0"
+    util "^0.10.3"
     vm-browserify "0.0.4"
 
 node-pre-gyp@^0.6.29:
@@ -4872,9 +4869,9 @@ original@>=0.0.5:
   dependencies:
     url-parse "1.0.x"
 
-os-browserify@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.1.2.tgz#49ca0293e0b19590a5f5de10c7f265a617d8fe54"
+os-browserify@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
 
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
@@ -5336,7 +5333,7 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-process@^0.11.0, process@~0.11.0:
+process@^0.11.0:
   version "0.11.9"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
 
@@ -5404,7 +5401,7 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-querystring-es3@~0.2.0:
+querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
 
@@ -5523,9 +5520,11 @@ react-prop-types@^0.4.0:
   dependencies:
     warning "^3.0.0"
 
-react-talend-components@0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/react-talend-components/-/react-talend-components-0.24.0.tgz#1f7afac63b356acb5612100543f36a9d5ea205f1"
+react-talend-components@0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/react-talend-components/-/react-talend-components-0.26.0.tgz#463117dfbee34e500b439019e9b69426409d1c98"
+  dependencies:
+    react-autowhatever "^7.0.0"
 
 react-talend-forms@0.7.1:
   version "0.7.1"
@@ -5580,27 +5579,7 @@ readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^1.0.27-1, readable-stream@^1.1.13, readable-stream@~1.1.8, readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@~2.0.0, readable-stream@~2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.1.5:
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.1.5:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -5611,6 +5590,26 @@ readable-stream@^2.1.5:
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
+
+readable-stream@^2.0.1, readable-stream@~2.0.0, readable-stream@~2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
+    util-deprecate "~1.0.1"
+
+readable-stream@~1.1.8, readable-stream@~1.1.9:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readable-stream@~2.1.4:
   version "2.1.5"
@@ -6099,7 +6098,7 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-setimmediate@^1.0.5:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
@@ -6128,8 +6127,8 @@ sigmund@~1.0.0:
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
 signal-exit@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.1.tgz#5a4c884992b63a7acd9badb7894c3ee9cfccad81"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
 simple-assign@^0.1.0:
   version "0.1.0"
@@ -6254,7 +6253,7 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-list-map@^0.1.4, source-list-map@~0.1.0:
+source-list-map@^0.1.4, source-list-map@~0.1.0, source-list-map@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.7.tgz#d4b5ce2a46535c72c7e8527c71a77d250618172e"
 
@@ -6364,12 +6363,12 @@ statuses@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.2.1.tgz#dded45cc18256d51ed40aec142489d5c61026d28"
 
-stream-browserify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-1.0.0.tgz#bf9b4abfb42b274d751479e44e0ff2656b6f1193"
+stream-browserify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"
   dependencies:
     inherits "~2.0.1"
-    readable-stream "^1.0.27-1"
+    readable-stream "^2.0.2"
 
 stream-cache@~0.0.1:
   version "0.0.2"
@@ -6384,6 +6383,16 @@ stream-counter@~0.2.0:
   resolved "https://registry.yarnpkg.com/stream-counter/-/stream-counter-0.2.0.tgz#ded266556319c8b0e222812b9cf3b26fa7d947de"
   dependencies:
     readable-stream "~1.1.8"
+
+stream-http@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.5.0.tgz#585eee513217ed98fe199817e7313b6f772a6802"
+  dependencies:
+    builtin-status-codes "^2.0.0"
+    inherits "^2.0.1"
+    readable-stream "^2.1.0"
+    to-arraybuffer "^1.0.0"
+    xtend "^4.0.0"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -6404,7 +6413,7 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
-string_decoder@~0.10.25, string_decoder@~0.10.x:
+string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
@@ -6529,9 +6538,9 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-talend-icons@0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.5.5.tgz#1fe28d922c774018be3c89ab7319d0f8b1e86e11"
+talend-icons@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.10.0.tgz#b8ced4b30fa8b9e85887cdff0a820ecd969dbd9f"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"
@@ -6594,11 +6603,11 @@ time-stamp@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.0.1.tgz#9f4bd23559c9365966f3302dbba2b07c6b99b151"
 
-timers-browserify@^1.0.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-1.4.2.tgz#c9c58b575be8407375cb5e2462dacee74359f41d"
+timers-browserify@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
-    process "~0.11.0"
+    setimmediate "^1.0.4"
 
 tinycolor@0.x:
   version "0.0.1"
@@ -6613,6 +6622,10 @@ tmp@0.0.28:
 to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
+
+to-arraybuffer@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
 to-fast-properties@^1.0.1:
   version "1.0.2"
@@ -6789,9 +6802,9 @@ url-parse@^1.1.1:
     querystringify "0.0.x"
     requires-port "1.0.x"
 
-url@~0.10.1:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
@@ -6820,7 +6833,7 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-util@0.10.3, util@^0.10.3, util@~0.10.3:
+util@0.10.3, util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
@@ -6950,11 +6963,11 @@ watchpack@^0.2.1:
     chokidar "^1.0.0"
     graceful-fs "^4.1.2"
 
-webpack-core@~0.6.0:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.8.tgz#edf9135de00a6a3c26dd0f14b208af0aa4af8d0a"
+webpack-core@~0.6.9:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/webpack-core/-/webpack-core-0.6.9.tgz#fc571588c8558da77be9efb6debdc5a3b172bdc2"
   dependencies:
-    source-list-map "~0.1.0"
+    source-list-map "~0.1.7"
     source-map "~0.4.1"
 
 webpack-dev-middleware@^1.0.11, webpack-dev-middleware@^1.4.0:
@@ -6992,8 +7005,8 @@ webpack-sources@^0.1.0:
     source-map "~0.5.3"
 
 webpack@^1.13.0:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-1.13.3.tgz#e79c46fe5a37c5ca70084ba0894c595cdcb42815"
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-1.14.0.tgz#54f1ffb92051a328a5b2057d6ae33c289462c823"
   dependencies:
     acorn "^3.0.0"
     async "^1.3.0"
@@ -7003,13 +7016,13 @@ webpack@^1.13.0:
     loader-utils "^0.2.11"
     memory-fs "~0.3.0"
     mkdirp "~0.5.0"
-    node-libs-browser "^0.6.0"
+    node-libs-browser "^0.7.0"
     optimist "~0.6.0"
     supports-color "^3.1.0"
     tapable "~0.1.8"
     uglify-js "~2.7.3"
     watchpack "^0.2.1"
-    webpack-core "~0.6.0"
+    webpack-core "~0.6.9"
 
 websocket-driver@>=0.5.1:
   version "0.6.5"


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2802

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)
Only black folder/preparation icons

**(Optional) What is the new behavior?**
(Additional information to the Jira)
Add colors and folders specificity : 
* orange folder on classical folders
* blue icon for preparation

**(Optional) Other information**:
