### PR TITLE
feat: add ids on new home page elements

### DIFF
--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -58,7 +58,7 @@
     "react-autowhatever": "^7.0.0",
     "react-bootstrap": "^0.30.3",
     "react-dom": "^15.4.1",
-    "react-talend-components": "0.26.0",
+    "react-talend-components": "0.27.0",
     "react-talend-forms": "0.7.1",
     "sunchoke": "git+https://github.com/Talend/sunchoke.git#1.0.0",
     "talend-icons": "0.10.0",

--- a/dataprep-webapp/src/app/components/home/dataset/react-home-dataset-container.js
+++ b/dataprep-webapp/src/app/components/home/dataset/react-home-dataset-container.js
@@ -14,6 +14,7 @@ const HomeDatasetContainer = {
 	template: `
 		<div class="home-content">
 			<inventory-list
+				id="'datasets-list'"
 				display-mode="$ctrl.state.inventory.datasetsDisplayMode"
 				items="$ctrl.state.inventory.datasets"
 				sort-by="$ctrl.state.inventory.datasetsSort.id"

--- a/dataprep-webapp/src/app/components/home/preparation/react-home-preparation-container.js
+++ b/dataprep-webapp/src/app/components/home/preparation/react-home-preparation-container.js
@@ -13,8 +13,9 @@
 const HomePreparationContainer = {
 	template: `
 		<div class="home-content">
-			<breadcrumbs items="$ctrl.state.inventory.breadcrumb"></breadcrumbs>
+			<breadcrumbs id="preparations-breadcrumb" items="$ctrl.state.inventory.breadcrumb"></breadcrumbs>
 			<inventory-list
+				id="'preparations-list'"
 				display-mode="$ctrl.state.inventory.preparationsDisplayMode"
 				folders="$ctrl.state.inventory.folder.content.folders"
 				items="$ctrl.state.inventory.folder.content.preparations"

--- a/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-container.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-container.js
@@ -21,12 +21,14 @@ import './inventory-list-container.scss';
 const InventoryListContainer = {
 	template: `
 		<pure-list
+			id="$ctrl.id"
 			display-mode="$ctrl.displayMode"
 			list="$ctrl.listProps"
 			toolbar="$ctrl.toolbarProps"
 		/>
 	`,
 	bindings: {
+		id: '<',
 		displayMode: '<',
 		folders: '<',
 		items: '<',

--- a/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-controller.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-controller.js
@@ -138,11 +138,12 @@ export default class InventoryListCtrl {
 	}
 
 	adaptActions(items) {
-		return items.map((item) => {
+		return items.map((item, index) => {
 			const actions = item.actions.map((actionName) => {
 				const settingAction = this.appSettings.actions[actionName];
 				const dispatch = this.getActionDispatcher(actionName);
 				return {
+					id: `${this.id}-${index}-${settingAction.id}`,
 					icon: settingAction.icon,
 					label: settingAction.name,
 					model: item,

--- a/dataprep-webapp/src/app/components/widgets-containers/layout/layout-container.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/layout/layout-container.js
@@ -19,7 +19,7 @@ const LayoutContainer = {
 			</div>
 			<div class="content">
 				<div class="sidemenu">
-					<side-panel active="$ctrl.$state.current.name"><side-panel/>
+					<side-panel id="'side-panel'" active="$ctrl.$state.current.name"><side-panel/>
 				</div>
 				<div class="main">
 					<div class="main-wrapper">

--- a/dataprep-webapp/src/app/components/widgets-containers/side-panel/side-panel-container.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/side-panel/side-panel-container.js
@@ -14,13 +14,15 @@
 import SidePanelCtrl from './side-panel-controller';
 
 const SidePanelContainer = {
-	template: `<pure-app-side-panel
+	template: `<pure-side-panel
+			id="$ctrl.id"
 		 	actions="$ctrl.actions"
 		 	toggle-icon="$ctrl.toggleIcon"
 			on-toggle-dock="$ctrl.toggle"
 			docked="$ctrl.state.home.sidePanelDocked"
 		/>`,
 	bindings: {
+		id: '<',
 		active: '<',
 	},
 	controller: SidePanelCtrl,

--- a/dataprep-webapp/src/app/components/widgets-containers/widgets-containers-module.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/widgets-containers-module.js
@@ -40,7 +40,7 @@ angular.module(MODULE_NAME,
 	.directive('pureAppHeaderBar', ['reactDirective', reactDirective => reactDirective(AppHeaderBar)])
 	.directive('pureBreadcrumb', ['reactDirective', reactDirective => reactDirective(Breadcrumbs)])
 	.directive('pureList', ['reactDirective', reactDirective => reactDirective(List)])
-	.directive('pureAppSidePanel', ['reactDirective', reactDirective => reactDirective(SidePanel)])
+	.directive('pureSidePanel', ['reactDirective', reactDirective => reactDirective(SidePanel)])
 	.directive('iconsProvider', ['reactDirective', reactDirective => reactDirective(IconsProvider)])
 	.directive('talendForm', ['reactDirective', reactDirective => reactDirective(Form)])
     .component('appHeaderBar', AppHeaderBarContainer)

--- a/dataprep-webapp/yarn.lock
+++ b/dataprep-webapp/yarn.lock
@@ -92,7 +92,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-angular-animate@^1.5.3, angular-animate@^1.5.7:
+angular-animate@1.5.9, angular-animate@^1.5.3:
   version "1.5.9"
   resolved "https://registry.yarnpkg.com/angular-animate/-/angular-animate-1.5.9.tgz#c958d524f9333a48abdaefb32947c7e611f54453"
 
@@ -112,7 +112,7 @@ angular-mass-autocomplete@^0.2.2:
     karma-firefox-launcher "~0.1.6"
     karma-jasmine "~0.3.5"
 
-angular-mocks@^1.5.7:
+angular-mocks@1.5.9:
   version "1.5.9"
   resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.5.9.tgz#5d6d6b37873d6c59e32e195f5de161f4a3f2f7e8"
 
@@ -120,7 +120,7 @@ angular-mocks@~1.3.15:
   version "1.3.20"
   resolved "https://registry.yarnpkg.com/angular-mocks/-/angular-mocks-1.3.20.tgz#7ecebd67aa093829dbcb2245fd68d39c77510df7"
 
-angular-sanitize@^1.5.7:
+angular-sanitize@1.5.9:
   version "1.5.9"
   resolved "https://registry.yarnpkg.com/angular-sanitize/-/angular-sanitize-1.5.9.tgz#e2d7dd8e8587f1342b6d2efdfa67311fcf1f65ed"
 
@@ -150,7 +150,7 @@ angular-ui-router@^0.2.15:
   dependencies:
     angular "^1.0.8"
 
-"angular@>=1.2.26 <=1.6", angular@^1.0.8, angular@^1.5.3, angular@^1.5.7:
+angular@1.5.9, "angular@>=1.2.26 <=1.6", angular@^1.0.8, angular@^1.5.3:
   version "1.5.9"
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.5.9.tgz#b7aeff42dad87881e06be16b6690fe766d868b51"
 
@@ -5516,9 +5516,9 @@ react-prop-types@^0.4.0:
   dependencies:
     warning "^3.0.0"
 
-react-talend-components@0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/react-talend-components/-/react-talend-components-0.26.0.tgz#463117dfbee34e500b439019e9b69426409d1c98"
+react-talend-components@0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/react-talend-components/-/react-talend-components-0.27.0.tgz#9ca1751b619f274e9893d3225083b8d6d16f4148"
   dependencies:
     react-autowhatever "^7.0.0"
 


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2459

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
(Additional information to the Jira)


**(Optional) What is the new behavior?**
(Additional information to the Jira)
Add ids on new home page elements. This will generate the ids described in https://jira.talendforge.org/browse/TDP-2459

**(Optional) Other information**:
Waiting for https://github.com/Talend/react-talend-components/pull/164 to upgrade RTC
