### PR TITLE
fix(TDP-2802): configure ngReact watch depth

### DIFF
--- a/dataprep-webapp/src/app/components/widgets-containers/breadcrumb/breadcrumb-container.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/breadcrumb/breadcrumb-container.js
@@ -14,7 +14,13 @@
 import BreadcrumbCtrl from './breadcrumb-controller';
 
 const BreadcrumbContainer = {
-	template: '<pure-breadcrumb items="$ctrl.breadcrumbItems" max-items="$ctrl.maxItems"></pure-breadcrumb>',
+	template: `
+		<pure-breadcrumb
+			items="$ctrl.breadcrumbItems"
+			max-items="$ctrl.maxItems"
+			watch-depth="reference"
+		/>
+	`,
 	controller: BreadcrumbCtrl,
 	bindings: {
 		items: '<',

--- a/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-container.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-container.js
@@ -25,6 +25,7 @@ const InventoryListContainer = {
 			display-mode="$ctrl.displayMode"
 			list="$ctrl.listProps"
 			toolbar="$ctrl.toolbarProps"
+			watch-depth="reference"
 		/>
 	`,
 	bindings: {

--- a/dataprep-webapp/src/app/components/widgets-containers/side-panel/side-panel-container.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/side-panel/side-panel-container.js
@@ -20,6 +20,7 @@ const SidePanelContainer = {
 		 	toggle-icon="$ctrl.toggleIcon"
 			on-toggle-dock="$ctrl.toggle"
 			docked="$ctrl.state.home.sidePanelDocked"
+			watch-depth="reference"
 		/>`,
 	bindings: {
 		id: '<',


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2802

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
(Additional information to the Jira)
NgReact watch depth is `value` by default.

**(Optional) What is the new behavior?**
(Additional information to the Jira)
It compares the references

**(Optional) Other information**:

