### PR TITLE
feat(TDP-2933): use 1 button to avoid glitch

### DIFF
--- a/dataprep-webapp/src/app/components/about/about-component.spec.js
+++ b/dataprep-webapp/src/app/components/about/about-component.spec.js
@@ -138,6 +138,14 @@ describe('Breadcrumb component', () => {
 			expect(element.find('#copyrights').text().trim()).toBe('current copyRights');
 		});
 
+		it('should render toggle button', () => {
+			// when
+			createElement();
+
+			// then
+			expect(element.find('#toggle-details').length).toBe(1);
+		});
+
 		describe('no builds list', () => {
 			it('should not render builds list', () => {
 				// when
@@ -152,8 +160,7 @@ describe('Breadcrumb component', () => {
 				createElement();
 
 				// then
-				expect(element.find('.modal-body button').length).toBe(1);
-				expect(element.find('.modal-body button').text().trim()).toBe('more');
+				expect(element.find('#toggle-details').text().trim()).toBe('more');
 			});
 		});
 
@@ -184,8 +191,7 @@ describe('Breadcrumb component', () => {
 				scope.$digest();
 
 				// then
-				expect(element.find('.modal-body button').length).toBe(1);
-				expect(element.find('.modal-body button').text().trim()).toBe('less');
+				expect(element.find('#toggle-details').text().trim()).toBe('less');
 			});
 		});
 
@@ -195,7 +201,7 @@ describe('Breadcrumb component', () => {
 				createElement();
 
 				// when
-				element.find('.modal-body button').click();
+				element.find('#toggle-details').click();
 				scope.$digest();
 
 				// then
@@ -210,7 +216,7 @@ describe('Breadcrumb component', () => {
 				expect(element.find('table').length).toBe(1);
 
 				// when
-				element.find('.modal-body button').click();
+				element.find('#toggle-details').click();
 				scope.$digest();
 
 				// then

--- a/dataprep-webapp/src/app/components/about/about.html
+++ b/dataprep-webapp/src/app/components/about/about.html
@@ -48,7 +48,6 @@
             </tbody>
         </table>
 
-        <button class="btn btn-primary" translate-once="MORE" ng-if="!$ctrl.showBuildDetails" ng-click="$ctrl.toggleDetailsDisplay()"></button>
-        <button class="btn btn-primary" translate-once="LESS" ng-if="$ctrl.showBuildDetails" ng-click="$ctrl.toggleDetailsDisplay()"></button>
+        <button class="btn btn-primary" id="toggle-details" translate="{{!$ctrl.showBuildDetails ? 'MORE' : 'LESS'}}" ng-click="$ctrl.toggleDetailsDisplay()"></button>
     </div>
 </talend-modal>


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-2833

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
There is a glitch when toggle button is clicked

**(Optional) What is the new behavior?**
Used 1 button instead of 2
