### PR TITLE
fix(TDP-2802):added folderId to sidepanel prep actions payload

### DIFF
--- a/dataprep-webapp/src/app/components/widgets-containers/side-panel/side-panel-controller.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/side-panel/side-panel-controller.js
@@ -24,6 +24,7 @@ export default class SidePanelCtrl {
 
 	$onChanges(changes) {
 		if (changes.active) {
+			this.actions[0].payload.folderId = this.state.inventory.folder.metadata.id;
 			this.actions = this.actions.map(action => ({
 				...action,
 				active: changes.active.currentValue === action.payload.args[0],

--- a/dataprep-webapp/src/app/settings/actions/menu-actions-service.js
+++ b/dataprep-webapp/src/app/settings/actions/menu-actions-service.js
@@ -20,8 +20,8 @@ export default class MenuActionsService {
 	dispatch(action) {
 		switch (action.type) {
 		case '@@router/GO': {
-			const { method, args } = action.payload;
-			this.$state[method](...args);
+			const { method, args, folderId } = action.payload;
+			this.$state[method](...args, { folderId });
 			break;
 		}
 		case '@@router/GO_DATASET': {


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-2802

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
Being on a folder, then redirecting to datasets list then back to preparations list, the initial folder is lost

**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:
