### PR TITLE
fix(TDP-2802): keep prep folder in navigation

### DIFF
--- a/dataprep-webapp/src/app/components/dataset/preview/dataset-xls-preview-controller.js
+++ b/dataprep-webapp/src/app/components/dataset/preview/dataset-xls-preview-controller.js
@@ -11,6 +11,12 @@
 
  ============================================================================*/
 
+import {
+	HOME_DATASETS_ROUTE,
+	PLAYGROUND_DATASET_ROUTE,
+	PLAYGROUND_PREPARATION_ROUTE,
+} from '../../../index-route';
+
 /**
  * @ngdoc controller
  * @name data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
@@ -29,14 +35,14 @@ export default function DatasetXlsPreviewCtrl($timeout, $state, state,
 	const vm = this;
 	vm.datasetSheetPreviewService = DatasetSheetPreviewService;
 
-    /**
-     * @ngdoc method
-     * @name initGrid
-     * @methodOf data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
-     * @description [PRIVATE] Initialize the grid and set it in the service.
-     * The service will provide the data in it.
-     * This is called at controller creation
-     */
+	/**
+	 * @ngdoc method
+	 * @name initGrid
+	 * @methodOf data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
+	 * @description [PRIVATE] Initialize the grid and set it in the service.
+	 * The service will provide the data in it.
+	 * This is called at controller creation
+	 */
 	vm.initGrid = function () {
 		const options = {
 			enableColumnReorder: false,
@@ -47,29 +53,29 @@ export default function DatasetXlsPreviewCtrl($timeout, $state, state,
 		};
 
 		DatasetSheetPreviewService.grid = new Slick.Grid(
-            '#datasetSheetPreviewGrid',
-            [],
-            [],
-            options
-        );
+			'#datasetSheetPreviewGrid',
+			[],
+			[],
+			options
+		);
 	};
 
-    /**
-     * @ngdoc method
-     * @name selectSheet
-     * @methodOf data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
-     * @description Load a sheet preview in the grid
-     */
+	/**
+	 * @ngdoc method
+	 * @name selectSheet
+	 * @methodOf data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
+	 * @description Load a sheet preview in the grid
+	 */
 	vm.selectSheet = function selectSheet() {
 		return DatasetSheetPreviewService.loadSheet(vm.selectedSheetName);
 	};
 
-    /**
-     * @ngdoc method
-     * @name disableDatasetSheetConfirm
-     * @methodOf data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
-     * @description Disable dataset Sheet confirm button
-     */
+	/**
+	 * @ngdoc method
+	 * @name disableDatasetSheetConfirm
+	 * @methodOf data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
+	 * @description Disable dataset Sheet confirm button
+	 */
 	vm.disableDatasetSheetConfirm = function disableDatasetSheetConfirm() {
 		if (DatasetSheetPreviewService.addPreparation && vm.metadata) {
 			return _.some(state.inventory.folder.content.preparations, { name: vm.metadata.name });
@@ -80,34 +86,34 @@ export default function DatasetXlsPreviewCtrl($timeout, $state, state,
 	};
 
 
-    /**
-     * @ngdoc method
-     * @name setDatasetSheet
-     * @methodOf data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
-     * @description Set the sheet in the dataset, update the dataset list, and hide the modal
-     */
+	/**
+	 * @ngdoc method
+	 * @name setDatasetSheet
+	 * @methodOf data-prep.dataset-xls-preview.controller:DatasetPreviewXlsCtrl
+	 * @description Set the sheet in the dataset, update the dataset list, and hide the modal
+	 */
 	vm.setDatasetSheet = function () {
 		DatasetSheetPreviewService.setDatasetSheet(vm.selectedSheetName)
-            .then(() => {
-	vm.visible = false;
-})
-            .then(() => {
-	if (DatasetSheetPreviewService.addPreparation) {
-		PreparationService
-                        .create(
-                            vm.metadata.id,
-                            DatasetSheetPreviewService.preparationName,
-                            state.inventory.folder.metadata.id
-                        )
-                        .then((prepid) => {
-	$state.go('playground.preparation', { prepid });
-});
-	}
-	else {
-		StateService.setPreviousRoute('nav.index.datasets');
-		$state.go('playground.dataset', { datasetid: vm.metadata.id });
-	}
-});
+			.then(() => {
+				vm.visible = false;
+			})
+			.then(() => {
+				if (DatasetSheetPreviewService.addPreparation) {
+					PreparationService
+						.create(
+							vm.metadata.id,
+							DatasetSheetPreviewService.preparationName,
+							state.inventory.folder.metadata.id
+						)
+						.then((prepid) => {
+							$state.go(PLAYGROUND_PREPARATION_ROUTE, { prepid });
+						});
+				}
+				else {
+					StateService.setPreviousRoute(HOME_DATASETS_ROUTE);
+					$state.go(PLAYGROUND_DATASET_ROUTE, { datasetid: vm.metadata.id });
+				}
+			});
 	};
 }
 
@@ -119,17 +125,17 @@ export default function DatasetXlsPreviewCtrl($timeout, $state, state,
  * This list is bound to {@link data-prep.services.dataset.service:DatasetSheetPreviewService DatasetSheetPreviewService}.showModal
  */
 Object.defineProperty(DatasetXlsPreviewCtrl.prototype,
-    'visible', {
-	enumerable: true,
-	configurable: false,
-	get() {
-		return this.datasetSheetPreviewService.showModal;
-	},
+	'visible', {
+		enumerable: true,
+		configurable: false,
+		get() {
+			return this.datasetSheetPreviewService.showModal;
+		},
 
-	set(value) {
-		this.datasetSheetPreviewService.showModal = value;
-	},
-});
+		set(value) {
+			this.datasetSheetPreviewService.showModal = value;
+		},
+	});
 
 /**
  * @ngdoc property
@@ -139,13 +145,13 @@ Object.defineProperty(DatasetXlsPreviewCtrl.prototype,
  * This list is bound to {@link data-prep.services.dataset.service:DatasetSheetPreviewService DatasetSheetPreviewService}.currentMetadata
  */
 Object.defineProperty(DatasetXlsPreviewCtrl.prototype,
-    'metadata', {
-	enumerable: true,
-	configurable: false,
-	get() {
-		return this.datasetSheetPreviewService.currentMetadata;
-	},
-});
+	'metadata', {
+		enumerable: true,
+		configurable: false,
+		get() {
+			return this.datasetSheetPreviewService.currentMetadata;
+		},
+	});
 
 /**
  * @ngdoc property
@@ -155,14 +161,14 @@ Object.defineProperty(DatasetXlsPreviewCtrl.prototype,
  * This list is bound to {@link data-prep.services.dataset.service:DatasetSheetPreviewService DatasetSheetPreviewService}.selectedSheetName
  */
 Object.defineProperty(DatasetXlsPreviewCtrl.prototype,
-    'selectedSheetName', {
-	enumerable: true,
-	configurable: false,
-	get() {
-		return this.datasetSheetPreviewService.selectedSheetName;
-	},
+	'selectedSheetName', {
+		enumerable: true,
+		configurable: false,
+		get() {
+			return this.datasetSheetPreviewService.selectedSheetName;
+		},
 
-	set(newValue) {
-		this.datasetSheetPreviewService.selectedSheetName = newValue;
-	},
-});
+		set(newValue) {
+			this.datasetSheetPreviewService.selectedSheetName = newValue;
+		},
+	});

--- a/dataprep-webapp/src/app/components/dataset/preview/dataset-xls-preview-controller.spec.js
+++ b/dataprep-webapp/src/app/components/dataset/preview/dataset-xls-preview-controller.spec.js
@@ -178,7 +178,7 @@ describe('Dataset xls preview controller', () => {
             scope.$digest();
 
             //then
-            expect(StateService.setPreviousRoute).toHaveBeenCalledWith('nav.index.datasets');
+            expect(StateService.setPreviousRoute).toHaveBeenCalledWith('home.datasets');
             expect($state.go).toHaveBeenCalledWith('playground.dataset', { datasetid: '13aa256cf813a25d158' });
         }));
 

--- a/dataprep-webapp/src/app/components/playground/playground-controller.spec.js
+++ b/dataprep-webapp/src/app/components/playground/playground-controller.spec.js
@@ -11,6 +11,10 @@
 
  ============================================================================*/
 
+import {
+    HOME_PREPARATIONS_ROUTE,
+} from '../../index-route';
+
 describe('Playground controller', () => {
     let createController;
     let scope;
@@ -56,7 +60,7 @@ describe('Playground controller', () => {
     beforeEach(angular.mock.module('data-prep.playground', ($provide) => {
         stateMock = {
             route: {
-                previous: 'nav.index.preparations',
+                previous: HOME_PREPARATIONS_ROUTE,
             },
             playground: {
                 dataset: {},
@@ -218,7 +222,7 @@ describe('Playground controller', () => {
                 scope.$digest();
                 // then
                 expect(MessageService.error).toHaveBeenCalledWith('PLAYGROUND_FILE_NOT_FOUND_TITLE', 'PLAYGROUND_FILE_NOT_FOUND', { type: 'preparation' });
-                expect($state.go).toHaveBeenCalledWith('nav.index.preparations', undefined);
+                expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, undefined);
             }));
 
             it('should fetch statistics when they are not computed yet', inject(($q, $stateParams, PlaygroundService, StateService) => {
@@ -484,7 +488,7 @@ describe('Playground controller', () => {
 
                 // then
                 expect(MessageService.error).toHaveBeenCalledWith('PLAYGROUND_FILE_NOT_FOUND_TITLE', 'PLAYGROUND_FILE_NOT_FOUND', { type: 'dataset' });
-                expect($state.go).toHaveBeenCalledWith('nav.index.preparations', undefined);
+                expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, undefined);
             }));
         });
     });
@@ -645,7 +649,7 @@ describe('Playground controller', () => {
         beforeEach(inject(($q, PreparationService, StateService) => {
             preparation = { id: '9af874865e42b546', draft: true };
             stateMock.playground.preparation = preparation;
-            stateMock.route.previous = 'nav.index.preparations';
+            stateMock.route.previous = HOME_PREPARATIONS_ROUTE;
 
             spyOn(PreparationService, 'delete').and.returnValue($q.when(true));
             spyOn(StateService, 'resetPlayground').and.returnValue();
@@ -677,7 +681,7 @@ describe('Playground controller', () => {
 
                 // then
                 expect(StateService.resetPlayground).toHaveBeenCalled();
-                expect($state.go).toHaveBeenCalledWith('nav.index.preparations', undefined);
+                expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, undefined);
             }));
 
             it('should show preparation save/discard modal with implicit preparation if there are steps', () => {
@@ -720,7 +724,7 @@ describe('Playground controller', () => {
 
                 // then
                 expect(StateService.resetPlayground).toHaveBeenCalled();
-                expect($state.go).toHaveBeenCalledWith('nav.index.preparations', undefined);
+                expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, undefined);
             }));
         });
 
@@ -766,7 +770,7 @@ describe('Playground controller', () => {
 
                 // then
                 expect(StateService.resetPlayground).toHaveBeenCalled();
-                expect($state.go).toHaveBeenCalledWith('nav.index.preparations', undefined);
+                expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, undefined);
             }));
 
             it('should manage isSaving flag', inject((StateService) => {

--- a/dataprep-webapp/src/app/components/widgets-containers/side-panel/side-panel-container.spec.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/side-panel/side-panel-container.spec.js
@@ -74,7 +74,7 @@ describe('Side Panel container', () => {
 			createElement();
 
 			// when
-			scope.active = 'reactHome.datasets';
+			scope.active = 'home.datasets';
 			scope.$digest();
 
 			// then
@@ -114,8 +114,8 @@ describe('Side Panel container', () => {
 
 			// then
 			expect(SettingsActionsService.dispatch).toHaveBeenCalled();
-			expect(SettingsActionsService.dispatch.calls.argsFor(0)[0].type).toBe('@@router/GO');
-			expect(SettingsActionsService.dispatch.calls.argsFor(0)[0].payload.args[0]).toBe('reactHome.preparations');
+			expect(SettingsActionsService.dispatch.calls.argsFor(0)[0].type).toBe('@@router/GO_CURRENT_FOLDER');
+			expect(SettingsActionsService.dispatch.calls.argsFor(0)[0].payload.args[0]).toBe('home.preparations');
 		}));
 
 		it('should dispatch datasets button click', inject((SettingsActionsService) => {
@@ -130,7 +130,7 @@ describe('Side Panel container', () => {
 			// then
 			expect(SettingsActionsService.dispatch).toHaveBeenCalled();
 			expect(SettingsActionsService.dispatch.calls.argsFor(0)[0].type).toBe('@@router/GO');
-			expect(SettingsActionsService.dispatch.calls.argsFor(0)[0].payload.args[0]).toBe('reactHome.datasets');
+			expect(SettingsActionsService.dispatch.calls.argsFor(0)[0].payload.args[0]).toBe('home.datasets');
 		}));
 	});
 });

--- a/dataprep-webapp/src/app/index-module.js
+++ b/dataprep-webapp/src/app/index-module.js
@@ -26,6 +26,8 @@ import SERVICES_REST_MODULE from './services/rest/rest-module';
 import SERVICES_UTILS_MODULE from './services/utils/utils-module';
 import SETTINGS_MODULE from './settings/settings-module';
 
+import routeConfig from './index-route';
+
 const MODULE_NAME = 'data-prep';
 
 let ws;
@@ -44,7 +46,7 @@ const app = angular.module(MODULE_NAME,
 		APP_MODULE, // app root
 	])
 
-// Performance config
+	// Performance config
 	.config(($httpProvider) => {
 		'ngInject';
 		$httpProvider.useApplyAsync(true);
@@ -63,66 +65,7 @@ const app = angular.module(MODULE_NAME,
 	})
 
 	// Router config
-	.config(($stateProvider, $urlRouterProvider, $urlMatcherFactoryProvider) => {
-		'ngInject';
-
-		// override the built-in string type (which is performing the slash encoding)
-		// by registering 'string' type
-		const originalStringMatcher = $urlMatcherFactoryProvider.type('string');
-		const overriddenStringMatcher = _.extend({}, originalStringMatcher, {
-			encode: val => (val !== null ? val.toString() : val),
-			decode: val => (val !== null ? val.toString() : val),
-		});
-		$urlMatcherFactoryProvider.type('string', overriddenStringMatcher);
-
-		// route definitions
-		$stateProvider
-			.state('nav', {
-				abstract: true,
-				template: '<navbar></navbar>',
-			})
-			.state('nav.index', {
-				abstract: true,
-				url: '/index',
-				template: '<home></home>',
-			})
-			.state('nav.index.datasets', {
-				url: '/datasets',
-				views: {
-					'home-content': { template: '<home-dataset></home-dataset>' },
-				},
-			})
-			.state('nav.index.preparations', {
-				url: '/preparations/{folderId}',
-				views: {
-					'home-content': { template: '<home-preparation></home-preparation>' },
-				},
-			})
-			.state('reactHome', {
-				url: '/react',
-				template: '<react-home></react-home>',
-			})
-			.state('reactHome.preparations', {
-				url: '/preparations/{folderId}',
-				views: {
-					'home-content': { template: '<react-home-preparation></react-home-preparation>' },
-				},
-			})
-			.state('reactHome.datasets', {
-				url: '/datasets',
-				views: {
-					'home-content': { template: '<react-home-dataset></react-home-dataset>' },
-				},
-			})
-			.state('playground', {
-				url: '/playground',
-				template: '<playground></playground>',
-				abstract: true,
-			})
-			.state('playground.preparation', { url: '/preparation?prepid' })
-			.state('playground.dataset', { url: '/dataset?datasetid' });
-		$urlRouterProvider.otherwise('/index/preparations/');
-	})
+	.config(routeConfig)
 
 	// Language to use at startup (for now only english)
 	.run(($window, $translate) => {

--- a/dataprep-webapp/src/app/index-route.js
+++ b/dataprep-webapp/src/app/index-route.js
@@ -1,0 +1,67 @@
+export const OLD_NAV_ROUTE = 'nav';
+export const OLD_INDEX_ROUTE = 'nav.index';
+export const OLD_INDEX_DATASETS_ROUTE = 'nav.index.datasets';
+export const OLD_INDEX_PREPARATIONS_ROUTE = 'nav.index.preparations';
+
+export const HOME_ROUTE = 'home';
+export const HOME_PREPARATIONS_ROUTE = 'home.preparations';
+export const HOME_DATASETS_ROUTE = 'home.datasets';
+
+export const PLAYGROUND_ROUTE = 'playground';
+export const PLAYGROUND_PREPARATION_ROUTE = 'playground.preparation';
+export const PLAYGROUND_DATASET_ROUTE = 'playground.dataset';
+
+export const DEFAULT_HOME_URL = '/home/preparations/';
+
+export default ($stateProvider, $urlRouterProvider) => {
+	'ngInject';
+
+	$stateProvider
+		.state(OLD_NAV_ROUTE, {
+			abstract: true,
+			template: '<navbar></navbar>',
+		})
+		.state(OLD_INDEX_ROUTE, {
+			abstract: true,
+			url: '/index',
+			template: '<home></home>',
+		})
+		.state(OLD_INDEX_DATASETS_ROUTE, {
+			url: '/datasets',
+			views: {
+				'home-content': { template: '<home-dataset></home-dataset>' },
+			},
+		})
+		.state(OLD_INDEX_PREPARATIONS_ROUTE, {
+			url: '/preparations/{folderId}',
+			views: {
+				'home-content': { template: '<home-preparation></home-preparation>' },
+			},
+		})
+		.state(HOME_ROUTE, {
+			abstract: true,
+			url: '/home',
+			template: '<react-home></react-home>',
+		})
+		.state(HOME_PREPARATIONS_ROUTE, {
+			url: '/preparations/{folderId}',
+			views: {
+				'home-content': { template: '<react-home-preparation></react-home-preparation>' },
+			},
+		})
+		.state(HOME_DATASETS_ROUTE, {
+			url: '/datasets',
+			views: {
+				'home-content': { template: '<react-home-dataset></react-home-dataset>' },
+			},
+		})
+		.state(PLAYGROUND_ROUTE, {
+			abstract: true,
+			url: '/playground',
+			template: '<playground></playground>',
+		})
+		.state(PLAYGROUND_PREPARATION_ROUTE, { url: '/preparation?prepid' })
+		.state(PLAYGROUND_DATASET_ROUTE, { url: '/dataset?datasetid' });
+
+	$urlRouterProvider.otherwise(DEFAULT_HOME_URL);
+};

--- a/dataprep-webapp/src/app/services/onboarding/onboarding-service.js
+++ b/dataprep-webapp/src/app/services/onboarding/onboarding-service.js
@@ -13,13 +13,17 @@
 
 import _ from 'lodash';
 import { introJs } from 'intro.js';
+import {
+	HOME_DATASETS_ROUTE,
+	HOME_PREPARATIONS_ROUTE,
+} from '../../index-route';
 
 /**
  * The step template with title and content
  */
 const template =
-    '<div class="introjs-tooltiptitle"><%= title %></div>' +
-    '<div class="introjs-tooltipcontent"><%= content %></div>';
+	'<div class="introjs-tooltiptitle"><%= title %></div>' +
+	'<div class="introjs-tooltipcontent"><%= content %></div>';
 
 const TOUR_OPTIONS_KEY = 'org.talend.dataprep.tour_options';
 
@@ -46,14 +50,14 @@ export default class OnboardingService {
 		this.preparationTour = preparationTour;
 	}
 
-    /**
-     * @ngdoc method
-     * @name createIntroSteps
-     * @methodOf data-prep.services.onboarding.service:OnboardingService
-     * @param {Array} configs The array of configs, one config for each step
-     * @description Create the Intro.js steps
-     * @returns {Array} The Intro.js steps
-     */
+	/**
+	 * @ngdoc method
+	 * @name createIntroSteps
+	 * @methodOf data-prep.services.onboarding.service:OnboardingService
+	 * @param {Array} configs The array of configs, one config for each step
+	 * @description Create the Intro.js steps
+	 * @returns {Array} The Intro.js steps
+	 */
 	createIntroSteps(configs) {
 		return _.map(configs, config => ({
 			element: config.element,
@@ -62,37 +66,37 @@ export default class OnboardingService {
 		}));
 	}
 
-    /**
-     * @ngdoc method
-     * @name getTourOptions
-     * @methodOf data-prep.services.onboarding.service:OnboardingService
-     * @description Get options from localStorage
-     * @returns {object} The saved tour config
-     */
+	/**
+	 * @ngdoc method
+	 * @name getTourOptions
+	 * @methodOf data-prep.services.onboarding.service:OnboardingService
+	 * @description Get options from localStorage
+	 * @returns {object} The saved tour config
+	 */
 	getTourOptions() {
 		const tourOptionsString = this.$window.localStorage.getItem(TOUR_OPTIONS_KEY);
 		return tourOptionsString ? JSON.parse(tourOptionsString) : {};
 	}
 
-    /**
-     * @ngdoc method
-     * @name setTourOptions
-     * @methodOf data-prep.services.onboarding.service:OnboardingService
-     * @param {object} options The options to save
-     * @description Set options in localStorage
-     */
+	/**
+	 * @ngdoc method
+	 * @name setTourOptions
+	 * @methodOf data-prep.services.onboarding.service:OnboardingService
+	 * @param {object} options The options to save
+	 * @description Set options in localStorage
+	 */
 	setTourOptions(options) {
 		this.$window.localStorage.setItem(TOUR_OPTIONS_KEY, JSON.stringify(options));
 	}
 
-    /**
-     * @ngdoc method
-     * @name getTour
-     * @methodOf data-prep.services.onboarding.service:OnboardingService
-     * @param {String} tour The tour Id
-     * @description Get tour details
-     * @returns {Array} Tour details
-     */
+	/**
+	 * @ngdoc method
+	 * @name getTour
+	 * @methodOf data-prep.services.onboarding.service:OnboardingService
+	 * @param {String} tour The tour Id
+	 * @description Get tour details
+	 * @returns {Array} Tour details
+	 */
 	getTour(tour) {
 		switch (tour) {
 		case 'playground':
@@ -104,65 +108,65 @@ export default class OnboardingService {
 		}
 	}
 
-    /**
-     * @ngdoc method
-     * @name setTourDone
-     * @methodOf data-prep.services.onboarding.service:OnboardingService
-     * @param {String} tour The tour Id
-     * @description Set tour options as done in localStorage
-     */
+	/**
+	 * @ngdoc method
+	 * @name setTourDone
+	 * @methodOf data-prep.services.onboarding.service:OnboardingService
+	 * @param {String} tour The tour Id
+	 * @description Set tour options as done in localStorage
+	 */
 	setTourDone(tour) {
 		const options = this.getTourOptions();
 		options[tour] = true;
 		this.setTourOptions(options);
 	}
 
-    /**
-     * @ngdoc method
-     * @name shouldStartTour
-     * @methodOf data-prep.services.onboarding.service:OnboardingService
-     * @description Check if the tour should be started depending on the saved options
-     * @param {String} tour The tour Id
-     * @return {boolean} True if the tour has not been completed yet
-     */
+	/**
+	 * @ngdoc method
+	 * @name shouldStartTour
+	 * @methodOf data-prep.services.onboarding.service:OnboardingService
+	 * @description Check if the tour should be started depending on the saved options
+	 * @param {String} tour The tour Id
+	 * @return {boolean} True if the tour has not been completed yet
+	 */
 	shouldStartTour(tour) {
 		const tourOptions = this.getTourOptions();
 		return !tourOptions[tour];
 	}
 
-    /**
-     * @ngdoc method
-     * @name startTour
-     * @methodOf data-prep.services.onboarding.service:OnboardingService
-     * @param {String} tour The tour Id
-     * @description Configure and start an onboarding tour
-     */
+	/**
+	 * @ngdoc method
+	 * @name startTour
+	 * @methodOf data-prep.services.onboarding.service:OnboardingService
+	 * @param {String} tour The tour Id
+	 * @description Configure and start an onboarding tour
+	 */
 	startTour(tour) {
-		const isOnDatasetsRoute = this.$state.current.name === 'nav.index.datasets';
+		const isOnDatasetsRoute = this.$state.current.name === HOME_DATASETS_ROUTE;
 		if (isOnDatasetsRoute) {
-			this.$state.go('nav.index.preparations', { folderId: this.state.inventory.homeFolderId });
+			this.$state.go(HOME_PREPARATIONS_ROUTE, { folderId: this.state.inventory.homeFolderId });
 		}
 
 		this.$timeout(() => {
 			this.currentTour = introJs()
-                .setOptions({
-	nextLabel: 'NEXT',
-	prevLabel: 'BACK',
-	skipLabel: 'SKIP',
-	doneLabel: 'LET ME TRY',
-	steps: this.createIntroSteps(this.getTour(tour)),
-})
-                .oncomplete(() => {
-	this.setTourDone(tour);
-})
-                .onexit(() => {
-	this.setTourDone(tour);
-	if (isOnDatasetsRoute) {
-		this.$state.go('nav.index.datasets');
-	}
+				.setOptions({
+					nextLabel: 'NEXT',
+					prevLabel: 'BACK',
+					skipLabel: 'SKIP',
+					doneLabel: 'LET ME TRY',
+					steps: this.createIntroSteps(this.getTour(tour)),
+				})
+				.oncomplete(() => {
+					this.setTourDone(tour);
+				})
+				.onexit(() => {
+					this.setTourDone(tour);
+					if (isOnDatasetsRoute) {
+						this.$state.go(HOME_DATASETS_ROUTE);
+					}
 
-	this.currentTour = null;
-});
+					this.currentTour = null;
+				});
 			this.currentTour.start();
 		}, 200, false);
 	}

--- a/dataprep-webapp/src/app/services/onboarding/onboarding-service.spec.js
+++ b/dataprep-webapp/src/app/services/onboarding/onboarding-service.spec.js
@@ -11,9 +11,12 @@
 
  ============================================================================*/
 
-describe('Onboarding service', () => {
-    'use strict';
+import {
+    HOME_DATASETS_ROUTE,
+    HOME_PREPARATIONS_ROUTE,
+} from '../../index-route';
 
+describe('Onboarding service', () => {
     const TOUR_OPTIONS_KEY = 'org.talend.dataprep.tour_options';
     let stateMock;
 
@@ -178,25 +181,25 @@ describe('Onboarding service', () => {
     it('should redirect to "preparations" before starting onboarding', inject(($state, OnboardingService) => {
         // given
         $state.current = {
-            name: 'nav.index.datasets',
+            name: HOME_DATASETS_ROUTE,
         };
 
         // when
         OnboardingService.startTour('preparation');
 
         // then
-        expect($state.go).toHaveBeenCalledWith('nav.index.preparations', { folderId: stateMock.inventory.homeFolderId });
+        expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, { folderId: stateMock.inventory.homeFolderId });
     }));
 
     it('should redirect BACK to "datasets" after redirecting to "preparations" ', inject(($timeout, $state, OnboardingService) => {
         // given
         $state.current = {
-            name: 'nav.index.datasets',
+            name: HOME_DATASETS_ROUTE,
         };
 
         expect(OnboardingService.currentTour).toBeFalsy();
         OnboardingService.startTour('preparation');
-        expect($state.go).toHaveBeenCalledWith('nav.index.preparations', { folderId: stateMock.inventory.homeFolderId });
+        expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, { folderId: stateMock.inventory.homeFolderId });
 
         // when
         $timeout.flush(200);
@@ -206,6 +209,6 @@ describe('Onboarding service', () => {
         onexit();
 
         // then
-        expect($state.go).toHaveBeenCalledWith('nav.index.datasets');
+        expect($state.go).toHaveBeenCalledWith(HOME_DATASETS_ROUTE);
     }));
 });

--- a/dataprep-webapp/src/app/services/preparation/preparation-service.js
+++ b/dataprep-webapp/src/app/services/preparation/preparation-service.js
@@ -11,6 +11,8 @@
 
  ============================================================================*/
 
+import { HOME_PREPARATIONS_ROUTE } from '../../index-route';
+
 /**
  * @ngdoc service
  * @name data-prep.services.preparation.service:PreparationService
@@ -63,7 +65,7 @@ export default function PreparationService($q, $state, $window, $stateParams, St
 	 * @returns {promise} The POST promise
 	 */
 	function create(datasetId, name, destinationFolder) {
-		StateService.setPreviousRoute('nav.index.preparations', { folderId: $stateParams.folderId });
+		StateService.setPreviousRoute(HOME_PREPARATIONS_ROUTE, { folderId: $stateParams.folderId });
 		return PreparationRestService.create(datasetId, name, destinationFolder)
 			.then((preparationId) => {
 				// get all dataset aggregations per columns from localStorage and save them for the new preparation

--- a/dataprep-webapp/src/app/services/preparation/preparation-service.spec.js
+++ b/dataprep-webapp/src/app/services/preparation/preparation-service.spec.js
@@ -1,3 +1,5 @@
+import { HOME_PREPARATIONS_ROUTE } from '../../index-route';
+
 describe('Preparation Service', () => {
     'use strict';
 
@@ -66,7 +68,7 @@ describe('Preparation Service', () => {
                 PreparationService.create(datasetId, name, 'destinationFolder');
 
                 //then
-                expect(StateService.setPreviousRoute).toHaveBeenCalledWith('nav.index.preparations', { folderId: $stateParams.folderId });
+                expect(StateService.setPreviousRoute).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, { folderId: $stateParams.folderId });
             }));
 
             it('should create a new preparation', inject(($rootScope, PreparationService, PreparationRestService) => {

--- a/dataprep-webapp/src/app/services/state/route/route-state-service.js
+++ b/dataprep-webapp/src/app/services/state/route/route-state-service.js
@@ -11,10 +11,12 @@
 
  ============================================================================*/
 
+import { HOME_PREPARATIONS_ROUTE } from '../../../index-route';
+
 export const routeState = {
-	previous: 'nav.index.preparations',
+	previous: HOME_PREPARATIONS_ROUTE,
 	previousOptions: { folderId: '' },
-	next: 'nav.index.preparations',
+	next: HOME_PREPARATIONS_ROUTE,
 	nextOptions: { folderId: '' },
 };
 
@@ -38,12 +40,12 @@ export class RouteStateService {
 	}
 
 	resetPrevious() {
-		routeState.previous = 'nav.index.preparations';
+		routeState.previous = HOME_PREPARATIONS_ROUTE;
 		routeState.previousOptions = { folderId: '' };
 	}
 
 	resetNext() {
-		routeState.next = 'nav.index.preparations';
+		routeState.next = HOME_PREPARATIONS_ROUTE;
 		routeState.nextOptions = { folderId: '' };
 	}
 

--- a/dataprep-webapp/src/app/services/state/route/route-state-service.spec.js
+++ b/dataprep-webapp/src/app/services/state/route/route-state-service.spec.js
@@ -11,6 +11,8 @@
 
  ============================================================================*/
 
+import { HOME_PREPARATIONS_ROUTE } from '../../../index-route';
+
 describe('Route state service', () => {
     'use strict';
 
@@ -19,7 +21,7 @@ describe('Route state service', () => {
     describe('previous', () => {
         it('should init previous route', inject((routeState) => {
             //then
-            expect(routeState.previous).toBe('nav.index.preparations');
+            expect(routeState.previous).toBe(HOME_PREPARATIONS_ROUTE);
             expect(routeState.previousOptions).toEqual({ folderId: '' });
         }));
 
@@ -70,7 +72,7 @@ describe('Route state service', () => {
             RouteStateService.resetPrevious();
 
             //then
-            expect(routeState.previous).toBe('nav.index.preparations');
+            expect(routeState.previous).toBe(HOME_PREPARATIONS_ROUTE);
             expect(routeState.previousOptions).toEqual({ folderId: '' });
         }));
     });
@@ -78,7 +80,7 @@ describe('Route state service', () => {
     describe('next', () => {
         it('should init next route', inject((routeState) => {
             //then
-            expect(routeState.next).toBe('nav.index.preparations');
+            expect(routeState.next).toBe(HOME_PREPARATIONS_ROUTE);
             expect(routeState.nextOptions).toEqual({ folderId: '' });
         }));
 
@@ -129,7 +131,7 @@ describe('Route state service', () => {
             RouteStateService.resetNext();
 
             //then
-            expect(routeState.next).toBe('nav.index.preparations');
+            expect(routeState.next).toBe(HOME_PREPARATIONS_ROUTE);
             expect(routeState.nextOptions).toEqual({ folderId: '' });
         }));
     });
@@ -153,9 +155,9 @@ describe('Route state service', () => {
             RouteStateService.reset();
 
             //then
-            expect(routeState.previous).toBe('nav.index.preparations');
+            expect(routeState.previous).toBe(HOME_PREPARATIONS_ROUTE);
             expect(routeState.previousOptions).toEqual({ folderId: '' });
-            expect(routeState.next).toBe('nav.index.preparations');
+            expect(routeState.next).toBe(HOME_PREPARATIONS_ROUTE);
             expect(routeState.nextOptions).toEqual({ folderId: '' });
         }));
     });

--- a/dataprep-webapp/src/app/settings/actions/dataset-actions-service.js
+++ b/dataprep-webapp/src/app/settings/actions/dataset-actions-service.js
@@ -11,6 +11,8 @@
 
  ============================================================================*/
 
+import { HOME_DATASETS_ROUTE } from '../../index-route';
+
 export default class DatasetActionsService {
 	constructor($document, $stateParams, state, DatasetService,
 				MessageService, StateService, StorageService,
@@ -48,7 +50,7 @@ export default class DatasetActionsService {
 			break;
 		}
 		case '@@dataset/DATASET_FETCH':
-			this.StateService.setPreviousRoute('nav.index.datasets');
+			this.StateService.setPreviousRoute(HOME_DATASETS_ROUTE);
 			this.StateService.setFetchingInventoryDatasets(true);
 			this.DatasetService.init().then(() => {
 				this.StateService.setFetchingInventoryDatasets(false);

--- a/dataprep-webapp/src/app/settings/actions/menu-actions-service.js
+++ b/dataprep-webapp/src/app/settings/actions/menu-actions-service.js
@@ -12,9 +12,10 @@
  ============================================================================*/
 
 export default class MenuActionsService {
-	constructor($state) {
+	constructor($state, state) {
 		'ngInject';
 		this.$state = $state;
+		this.state = state;
 	}
 
 	dispatch(action) {
@@ -32,6 +33,12 @@ export default class MenuActionsService {
 		case '@@router/GO_FOLDER': {
 			const { method, args, id } = action.payload;
 			this.$state[method](...args, { folderId: id });
+			break;
+		}
+		case '@@router/GO_CURRENT_FOLDER': {
+			const { method, args } = action.payload;
+			const folderId = this.state.inventory.folder.metadata.id;
+			this.$state[method](...args, { folderId });
 			break;
 		}
 		case '@@router/GO_PREPARATION': {

--- a/dataprep-webapp/src/app/settings/actions/menu-actions-service.spec.js
+++ b/dataprep-webapp/src/app/settings/actions/menu-actions-service.spec.js
@@ -12,9 +12,25 @@
  ============================================================================*/
 
 import angular from 'angular';
+import {
+	HOME_PREPARATIONS_ROUTE,
+	PLAYGROUND_DATASET_ROUTE,
+	PLAYGROUND_PREPARATION_ROUTE,
+} from '../../index-route';
 
 describe('Menu actions service', () => {
-	beforeEach(angular.mock.module('app.settings.actions'));
+	let stateMock;
+	
+	beforeEach(angular.mock.module('app.settings.actions', ($provide) => {
+		stateMock = {
+			inventory: {
+				folder: {
+					metadata: { id: 'currentFolderId' }
+				}
+			}
+		};
+		$provide.constant('state', stateMock);
+	}));
 
 	describe('dispatch', () => {
 		it('should change route', inject(($state, MenuActionsService) => {
@@ -23,7 +39,7 @@ describe('Menu actions service', () => {
 				type: '@@router/GO',
 				payload: {
 					method: 'go',
-					args: ['nav.index.preparations']
+					args: [HOME_PREPARATIONS_ROUTE]
 				}
 			};
 			spyOn($state, 'go').and.returnValue();
@@ -32,7 +48,7 @@ describe('Menu actions service', () => {
 			MenuActionsService.dispatch(action);
 
 			// then
-			expect($state.go).toHaveBeenCalledWith('nav.index.preparations');
+			expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE);
 		}));
 
 		it('should change route with dataset parameters', inject(($state, MenuActionsService) => {
@@ -41,7 +57,7 @@ describe('Menu actions service', () => {
 				type: '@@router/GO_DATASET',
 				payload: {
 					method: 'go',
-					args: ['nav.index.datasets'],
+					args: [PLAYGROUND_DATASET_ROUTE],
 					id: 'acbd'
 				},
 			};
@@ -51,7 +67,7 @@ describe('Menu actions service', () => {
 			MenuActionsService.dispatch(action);
 
 			// then
-			expect($state.go).toHaveBeenCalledWith('nav.index.datasets', { datasetid: 'acbd' });
+			expect($state.go).toHaveBeenCalledWith(PLAYGROUND_DATASET_ROUTE, { datasetid: 'acbd' });
 		}));
 
 		it('should change route with folder parameters', inject(($state, MenuActionsService) => {
@@ -60,7 +76,7 @@ describe('Menu actions service', () => {
 				type: '@@router/GO_FOLDER',
 				payload: {
 					method: 'go',
-					args: ['nav.index.preparations'],
+					args: [HOME_PREPARATIONS_ROUTE],
 					id: 'acbd'
 				},
 			};
@@ -70,7 +86,25 @@ describe('Menu actions service', () => {
 			MenuActionsService.dispatch(action);
 
 			// then
-			expect($state.go).toHaveBeenCalledWith('nav.index.preparations', { folderId: 'acbd' });
+			expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, { folderId: 'acbd' });
+		}));
+		
+		it('should change route with current folder parameters', inject(($state, MenuActionsService) => {
+			// given
+			const action = {
+				type: '@@router/GO_CURRENT_FOLDER',
+				payload: {
+					method: 'go',
+					args: [HOME_PREPARATIONS_ROUTE],
+				},
+			};
+			spyOn($state, 'go').and.returnValue();
+
+			// when
+			MenuActionsService.dispatch(action);
+
+			// then
+			expect($state.go).toHaveBeenCalledWith(HOME_PREPARATIONS_ROUTE, { folderId: 'currentFolderId' });
 		}));
 
 		it('should change route with preparation id', inject(($state, MenuActionsService) => {
@@ -79,7 +113,7 @@ describe('Menu actions service', () => {
 				type: '@@router/GO_PREPARATION',
 				payload: {
 					method: 'go',
-					args: ['playground.preparation'],
+					args: [PLAYGROUND_PREPARATION_ROUTE],
 					id: 'acbd'
 				},
 			};
@@ -89,7 +123,7 @@ describe('Menu actions service', () => {
 			MenuActionsService.dispatch(action);
 
 			// then
-			expect($state.go).toHaveBeenCalledWith('playground.preparation', { prepid: 'acbd' });
+			expect($state.go).toHaveBeenCalledWith(PLAYGROUND_PREPARATION_ROUTE, { prepid: 'acbd' });
 		}));
 	});
 });

--- a/dataprep-webapp/src/app/settings/actions/preparation-actions-service.js
+++ b/dataprep-webapp/src/app/settings/actions/preparation-actions-service.js
@@ -11,6 +11,8 @@
 
  ============================================================================*/
 
+import { HOME_PREPARATIONS_ROUTE } from '../../index-route';
+
 export default class PreparationActionsService {
 	constructor($stateParams, state, FolderService, MessageService, PreparationService,
 				StateService, StorageService, TalendConfirmService) {
@@ -61,7 +63,7 @@ export default class PreparationActionsService {
 		}
 		case '@@preparation/FOLDER_FETCH': {
 			const folderId = this.$stateParams.folderId;
-			this.StateService.setPreviousRoute('nav.index.preparations', { folderId });
+			this.StateService.setPreviousRoute(HOME_PREPARATIONS_ROUTE, { folderId });
 			this.StateService.setFetchingInventoryPreparations(true);
 			this.FolderService
 				.init(folderId)

--- a/dataprep-webapp/src/app/settings/actions/preparation-actions-service.spec.js
+++ b/dataprep-webapp/src/app/settings/actions/preparation-actions-service.spec.js
@@ -12,6 +12,7 @@
  ============================================================================*/
 
 import angular from 'angular';
+import { HOME_PREPARATIONS_ROUTE } from '../../index-route';
 
 describe('Preparation actions service', () => {
 	let stateMock;
@@ -175,7 +176,7 @@ describe('Preparation actions service', () => {
 			inject((StateService) => {
 				// then
 				expect(StateService.setPreviousRoute).toHaveBeenCalledWith(
-					'nav.index.preparations',
+					HOME_PREPARATIONS_ROUTE,
 					{ folderId }
 				);
 			})

--- a/dataprep-webapp/src/assets/config/app-settings.json
+++ b/dataprep-webapp/src/assets/config/app-settings.json
@@ -128,11 +128,11 @@
       "id": "menu:preparations",
       "name": "Preparations",
       "icon": "talend-dataprep",
-      "type": "@@router/GO",
+      "type": "@@router/GO_CURRENT_FOLDER",
       "payload": {
         "method": "go",
         "args": [
-          "reactHome.preparations"
+          "home.preparations"
         ]
       }
     },
@@ -144,7 +144,7 @@
       "payload": {
         "method": "go",
         "args": [
-          "reactHome.preparations"
+          "home.preparations"
         ]
       }
     },
@@ -156,7 +156,7 @@
       "payload": {
         "method": "go",
         "args": [
-          "reactHome.datasets"
+          "home.datasets"
         ]
       }
     },

--- a/dataprep-webapp/src/mocks/Settings.mock.js
+++ b/dataprep-webapp/src/mocks/Settings.mock.js
@@ -138,10 +138,10 @@ const settingsMock = {
 			id: 'menu:preparations',
 			name: 'Preparations',
 			icon: 'talend-dataprep',
-			type: '@@router/GO',
+			type: '@@router/GO_CURRENT_FOLDER',
 			payload: {
 				method: 'go',
-				args: ['reactHome.preparations'],
+				args: ['home.preparations'],
 			},
 		},
 		'menu:datasets': {
@@ -151,7 +151,7 @@ const settingsMock = {
 			type: '@@router/GO',
 			payload: {
 				method: 'go',
-				args: ['reactHome.datasets'],
+				args: ['home.datasets'],
 			},
 		},
 		'menu:folders': {
@@ -161,7 +161,7 @@ const settingsMock = {
 			type: '@@router/GO_FOLDER',
 			payload: {
 				method: 'go',
-				args: ['reactHome.preparations'],
+				args: ['home.preparations'],
 			},
 		},
 		'menu:playground:preparation': {

--- a/dataprep-webapp/yarn.lock
+++ b/dataprep-webapp/yarn.lock
@@ -1012,6 +1012,10 @@ bourbon@^4.2.6, bourbon@^4.2.7:
   version "4.2.7"
   resolved "https://registry.yarnpkg.com/bourbon/-/bourbon-4.2.7.tgz#48a805dff475fbf61e002a64e1e4db68d2f82fba"
 
+bowser@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.6.0.tgz#37fc387b616cb6aef370dab4d6bd402b74c5c54d"
+
 brace-expansion@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
@@ -1165,6 +1169,10 @@ chalk@~0.4.0:
     ansi-styles "~1.0.0"
     has-color "~0.1.0"
     strip-ansi "~0.1.0"
+
+change-emitter@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.2.tgz#6b88ca4d5d864e516f913421b11899a860aee8db"
 
 chokidar@^1.0.0, chokidar@^1.0.1, chokidar@^1.4.1:
   version "1.6.1"
@@ -1856,6 +1864,10 @@ dom-serializer@0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
@@ -2234,6 +2246,45 @@ eslint@^2.7.0:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
+eslint@^3.9.1:
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.12.2.tgz#6be5a9aa29658252abd7f91e9132bab1f26f3c34"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.4.6"
+    debug "^2.1.1"
+    doctrine "^1.2.2"
+    escope "^3.6.0"
+    espree "^3.3.1"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~1.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
 espree@^3.1.6, espree@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.3.2.tgz#dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
@@ -2445,7 +2496,7 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.6:
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.6.tgz#7eb67d6986b2d5007a9b6e92e0e7cb6f75cad290"
   dependencies:
@@ -2870,7 +2921,14 @@ global-prefix@^0.1.4:
     is-windows "^0.2.0"
     which "^1.2.12"
 
-globals@^9.0.0, globals@^9.2.0:
+global@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.1.tgz#5f757908c7cbabce54f386ae440e11e26b7916df"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
+
+globals@^9.0.0, globals@^9.14.0, globals@^9.2.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
 
@@ -3094,6 +3152,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoist-non-react-statics@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3210,6 +3272,10 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
+hyphenate-style-name@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 i@0.3.x:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/i/-/i-0.3.5.tgz#1d2b854158ec8169113c6cb7f6b6801e99e211d5"
@@ -3230,7 +3296,7 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
-ignore@^3.1.2, ignore@^3.1.5:
+ignore@^3.1.2, ignore@^3.1.5, ignore@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
 
@@ -3279,6 +3345,13 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
+inline-style-prefixer@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
+  dependencies:
+    bowser "^1.0.0"
+    hyphenate-style-name "^1.0.1"
+
 inquirer@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
@@ -3304,6 +3377,10 @@ interpret@^0.3.2:
 interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
+
+interpret@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
 intro.js@^1.1.1:
   version "1.1.1"
@@ -3823,7 +3900,7 @@ kew@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"
 
-keycode@^2.1.2:
+keycode@^2.1.1, keycode@^2.1.2:
   version "2.1.7"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.7.tgz#7b9255919f6cff562b09a064d222dca70b020f5c"
 
@@ -4060,6 +4137,10 @@ lodash.mapvalues@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
 
+lodash.merge@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
 lodash.pick@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
@@ -4092,6 +4173,10 @@ lodash.templatesettings@^3.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
 
 lodash.topath@^4.5.2:
   version "4.5.2"
@@ -4177,6 +4262,22 @@ map-obj@^1.0.0, map-obj@^1.0.1:
 marked@0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.5.tgz#4113a15ac5d7bca158a5aae07224587b9fa15b94"
+
+material-ui@^0.16.1:
+  version "0.16.6"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.16.6.tgz#683a038c25a6d77e3703a53a4401f3af44bc1db1"
+  dependencies:
+    babel-runtime "^6.11.6"
+    inline-style-prefixer "^2.0.1"
+    keycode "^2.1.1"
+    lodash.merge "^4.6.0"
+    lodash.throttle "^4.1.1"
+    react-addons-create-fragment "^15.0.0"
+    react-addons-transition-group "^15.0.0"
+    react-event-listener "^0.4.0"
+    recompose "^0.21.0"
+    simple-assign "^0.1.0"
+    warning "^3.0.0"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.14"
@@ -4280,6 +4381,12 @@ mime@1.2.x:
 mime@1.3.4, mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
 
 minimatch@0.3:
   version "0.3.0"
@@ -4719,7 +4826,7 @@ optimist@~0.3.5:
   dependencies:
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -5230,6 +5337,10 @@ process@^0.11.0:
   version "0.11.9"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 progress@^1.1.8, progress@~1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
@@ -5338,6 +5449,18 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
+react-addons-create-fragment@^15.0.0:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.4.1.tgz#596fde66cf7f375b5dad3c36ff6efe19c0ac47e7"
+
+"react-addons-shallow-compare@^0.14.0 || ^15.0.0":
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.4.1.tgz#b68103dd4d13144cb221065f6021de1822bd435a"
+
+react-addons-transition-group@^15.0.0:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/react-addons-transition-group/-/react-addons-transition-group-15.4.1.tgz#27d92717089c5e2db202e654a85b76a41b703acc"
+
 react-autowhatever@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-7.0.0.tgz#7ea19f8024183acf1568fc8e4b76c0d0cc250d00"
@@ -5373,6 +5496,13 @@ react-dom@^15.4.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
+react-event-listener@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.4.0.tgz#26c40ab18f9f0e0d8d1fed9c3465e79c0a99c9a5"
+  dependencies:
+    react-addons-shallow-compare "^0.14.0 || ^15.0.0"
+    warning "^3.0.0"
+
 react-jsonschema-form@^0.41.1:
   version "0.41.2"
   resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-0.41.2.tgz#a77921ceff102fc5d04344e50b8e622a7e0373c2"
@@ -5403,11 +5533,20 @@ react-talend-components@0.38.x:
     react-autowhatever "^7.0.0"
     react-debounce-input "^2.4.2"
 
-react-talend-forms@0.8.x:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/react-talend-forms/-/react-talend-forms-0.8.1.tgz#07f727ded2c0f222e8cf2c7fd82534ea8b7327e1"
+react-talend-forms@0.7.x:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/react-talend-forms/-/react-talend-forms-0.7.1.tgz#5af799e545053e37224bde0b291921e7b46f952f"
   dependencies:
+    material-ui "^0.16.1"
     react-jsonschema-form "^0.41.1"
+    react-tap-event-plugin "^2.0.0"
+    rjsf-material-design "^1.0.1"
+
+react-tap-event-plugin@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-2.0.1.tgz#316beb3bc6556e29ec869a7293e89c826a9074d2"
+  dependencies:
+    fbjs "^0.8.6"
 
 react-themeable@^1.1.0:
   version "1.1.0"
@@ -5522,6 +5661,15 @@ rechoir@^0.6.2:
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
   dependencies:
     resolve "^1.1.6"
+
+recompose@^0.21.0:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.21.2.tgz#ff3fbdb2397b1c77c47d451be2a63b9295d44681"
+  dependencies:
+    change-emitter "^0.1.2"
+    fbjs "^0.8.1"
+    hoist-non-react-statics "^1.0.0"
+    symbol-observable "^1.0.4"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -5778,6 +5926,14 @@ ripemd160@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-0.2.0.tgz#2bf198bde167cacfa51c0a928e84b68bbe171fce"
 
+rjsf-material-design@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rjsf-material-design/-/rjsf-material-design-1.0.1.tgz#b89b7769b188473e29de86db04203db76e223b09"
+  dependencies:
+    eslint "^3.9.1"
+    global "^4.3.1"
+    material-ui "^0.16.1"
+
 rndm@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rndm/-/rndm-1.2.0.tgz#f33fe9cfb52bbfd520aa18323bc65db110a1b76c"
@@ -5965,6 +6121,14 @@ shelljs@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.6.1.tgz#ec6211bed1920442088fe0f70b2837232ed2c8a8"
 
+shelljs@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.5.tgz#2eef7a50a21e1ccf37da00df767ec69e30ad0675"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
@@ -5972,6 +6136,10 @@ sigmund@~1.0.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-assign@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/simple-assign/-/simple-assign-0.1.0.tgz#17fd3066a5f3d7738f50321bb0f14ca281cc4baa"
 
 simple-fmt@~0.1.0:
   version "0.1.0"
@@ -6361,6 +6529,10 @@ svgo@^0.7.0:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
+
+symbol-observable@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 table@^3.7.8:
   version "3.8.3"


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2802

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
(Additional information to the Jira)
1. go to a folder (not home)
2. go to datasets
3. go back to preparations -- We end up to home folder

**(Optional) What is the new behavior?**
(Additional information to the Jira)
We are now back to the previous folder

**(Optional) Other information**:
