### PR TITLE
feat(TDP-2802): adapt onboarding to new home page

### DIFF
--- a/dataprep-webapp/src/app/services/onboarding/onboarding-preparations-constants.js
+++ b/dataprep-webapp/src/app/services/onboarding/onboarding-preparations-constants.js
@@ -13,34 +13,34 @@
 
 const preparationTour = [
 	{
-		element: '#nav_home_preparations',
+		element: '#side-panel-nav-preparations',
 		title: '<center>Preparations</center>',
 		content: 'Here you can browse through and manage the preparations you created.</br>A preparation is the outcome of the different steps applied to cleanse your data.',
 		position: 'right',
 		tooltipPosition: 'right',
 	},
 	{
-		element: '#nav_home_datasets',
+		element: '#side-panel-nav-datasets',
 		title: '<center>Datasets</center>',
 		content: 'Here you can browse through and manage the datasets you added.</br>A dataset holds the raw data that can be used as raw material without affecting your original data.',
 		position: 'right',
 		tooltipPosition: 'right',
 	},
 	{
-		element: '.preparations-list-header > #add-preparation',
+		element: '#preparations-list-actions-preparation\\:create',
 		title: '<center>Add preparation</center>',
 		content: 'Click here to add a preparation and start cleansing your data.',
 		position: 'right',
 		tooltipPosition: 'right',
 	},
 	{
-		element: '#onboarding-icon',
+		element: '#onboarding\\:preparation',
 		title: '<center>Guided tour</center>',
 		content: 'Click here to play this tour again.',
 		position: 'left',
 	},
 	{
-		element: '#online-help-icon',
+		element: '#external\\:help',
 		title: '<center>Online Documentation</center>',
 		content: 'Click here to access the <a href="https://help.talend.com/pages/viewpage.action?pageId=266307043&utm_medium=dpdesktop&utm_source=on_boarding" target="_blank">online help</a>.',
 		position: 'left',

--- a/dataprep-webapp/src/app/services/onboarding/onboarding-service.js
+++ b/dataprep-webapp/src/app/services/onboarding/onboarding-service.js
@@ -146,6 +146,14 @@ export default class OnboardingService {
 		if (isOnDatasetsRoute) {
 			this.$state.go(HOME_PREPARATIONS_ROUTE, { folderId: this.state.inventory.homeFolderId });
 		}
+		const onTourDone = () => {
+			this.setTourDone(tour);
+			if (isOnDatasetsRoute) {
+				this.$state.go(HOME_DATASETS_ROUTE);
+			}
+
+			this.currentTour = null;
+		};
 
 		this.$timeout(() => {
 			this.currentTour = introJs()
@@ -156,17 +164,8 @@ export default class OnboardingService {
 					doneLabel: 'LET ME TRY',
 					steps: this.createIntroSteps(this.getTour(tour)),
 				})
-				.oncomplete(() => {
-					this.setTourDone(tour);
-				})
-				.onexit(() => {
-					this.setTourDone(tour);
-					if (isOnDatasetsRoute) {
-						this.$state.go(HOME_DATASETS_ROUTE);
-					}
-
-					this.currentTour = null;
-				});
+				.oncomplete(onTourDone)
+				.onexit(onTourDone);
 			this.currentTour.start();
 		}, 200, false);
 	}

--- a/dataprep-webapp/src/app/services/onboarding/onboarding-service.spec.js
+++ b/dataprep-webapp/src/app/services/onboarding/onboarding-service.spec.js
@@ -86,7 +86,7 @@ describe('Onboarding service', () => {
         // then
         const options = OnboardingService.currentTour._options;
         expect(options.steps[0]).toEqual({
-            element: '#nav_home_preparations',
+            element: '#side-panel-nav-preparations',
             position: 'right',
             intro: '<div class="introjs-tooltiptitle"><center>Preparations</center></div><div class="introjs-tooltipcontent">Here you can browse through and manage the preparations you created.</br>A preparation is the outcome of the different steps applied to cleanse your data.</div>',
         });


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2802

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
(Additional information to the Jira)
The onboarding is still plugged on the old home page

**(Optional) What is the new behavior?**
(Additional information to the Jira)
Onboarding now targets new home page
