### PR TITLE
fix(TDP-2802 TDP-3134): open xls preview on draft dataset

### DIFF
--- a/dataprep-webapp/src/app/components/home/react-home-component.js
+++ b/dataprep-webapp/src/app/components/home/react-home-component.js
@@ -17,12 +17,12 @@ const HomeComponent = {
 			<ui-view name="home-content"></ui-view>
 		</layout>
 
+		<about></about>
 		<dataset-xls-preview></dataset-xls-preview>
 		<folder-creator></folder-creator>
 		<preparation-copy-move></preparation-copy-move>
 		<preparation-creator></preparation-creator>
 		<insertion-home></insertion-home>
-		<about></about>
 	`,
 };
 

--- a/dataprep-webapp/src/app/settings/actions/dataset-actions-service.js
+++ b/dataprep-webapp/src/app/settings/actions/dataset-actions-service.js
@@ -14,9 +14,10 @@
 import { HOME_DATASETS_ROUTE } from '../../index-route';
 
 export default class DatasetActionsService {
-	constructor($document, $stateParams, state, DatasetService, ImportService,
-				MessageService, StateService, StorageService,
-				TalendConfirmService) {
+	constructor($document, $stateParams, state,
+				StateService, StorageService, DatasetService,
+				ImportService, UploadWorkflowService,
+				MessageService, TalendConfirmService) {
 		'ngInject';
 		this.$document = $document;
 		this.$stateParams = $stateParams;
@@ -27,6 +28,7 @@ export default class DatasetActionsService {
 		this.StateService = StateService;
 		this.StorageService = StorageService;
 		this.TalendConfirmService = TalendConfirmService;
+		this.UploadWorkflowService = UploadWorkflowService;
 
 		this.renamingList = [];
 	}
@@ -136,6 +138,10 @@ export default class DatasetActionsService {
 				const defaultImport = importTypes.find(type => type.defaultImport) || importTypes[0];
 				this.ImportService.startImport(defaultImport);
 			}
+			break;
+		}
+		case '@@dataset/OPEN': {
+			this.UploadWorkflowService.openDataset(action.payload.model);
 			break;
 		}
 		}

--- a/dataprep-webapp/src/app/settings/actions/dataset-actions-service.spec.js
+++ b/dataprep-webapp/src/app/settings/actions/dataset-actions-service.spec.js
@@ -407,5 +407,22 @@ describe('Datasets actions service', () => {
 			// then
 			expect(ImportService.startImport).toHaveBeenCalledWith(defaultType);
 		}));
+
+		it('should open dataset via workflow service', inject((DatasetActionsService, UploadWorkflowService) => {
+			// given
+			const dataset = { id: 'myDatasetId', draft: true };
+			const action = {
+				type: '@@dataset/OPEN',
+				payload: { model: dataset }
+			};
+
+			spyOn(UploadWorkflowService, 'openDataset').and.returnValue();
+
+			// when
+			DatasetActionsService.dispatch(action);
+
+			// then
+			expect(UploadWorkflowService.openDataset).toHaveBeenCalledWith(dataset);
+		}));
 	});
 });

--- a/dataprep-webapp/src/assets/config/app-settings.json
+++ b/dataprep-webapp/src/assets/config/app-settings.json
@@ -103,7 +103,7 @@
           "displayModeKey": "displayMode",
           "iconKey": "icon",
           "key": "name",
-          "onClick": "menu:playground:dataset",
+          "onClick": "dataset:open",
           "onEditCancel": "inventory:cancel-edit",
           "onEditSubmit": "dataset:submit-edit"
         }
@@ -246,6 +246,12 @@
       "payload": {
         "method": "toggleAbout"
       }
+    },
+    "dataset:open": {
+      "id": "dataset:open",
+      "name": "Open dataset",
+      "icon": "",
+      "type": "@@dataset/OPEN"
     },
     "dataset:display-mode": {
       "id": "dataset:display-mode",

--- a/dataprep-webapp/src/mocks/Settings.mock.js
+++ b/dataprep-webapp/src/mocks/Settings.mock.js
@@ -113,7 +113,7 @@ const settingsMock = {
 					displayModeKey: 'displayMode',
 					iconKey: 'icon',
 					key: 'name',
-					onClick: 'menu:playground:dataset',
+					onClick: 'dataset:open',
 					onEditCancel: 'inventory:cancel-edit',
 					onEditSubmit: 'dataset:submit-edit',
 				},
@@ -248,6 +248,12 @@ const settingsMock = {
 			payload: {
 				method: 'logout',
 			},
+		},
+		'dataset:open': {
+			id: 'dataset:open',
+			name: 'Open dataset',
+			icon: '',
+			type: '@@dataset/OPEN',
 		},
 		'dataset:display-mode': {
 			id: 'dataset:display-mode',


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3134

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
(Additional information to the Jira)
On draft (xls multi-sheet) datasets, when user click to open, there is no modal to choose the sheet to use.

**(Optional) What is the new behavior?**
(Additional information to the Jira)
The dataset xls preview modal appears
