### PR TITLE
bugfix(TDP-3139): added state dependency, non regression TUs and remov…

### DIFF
--- a/dataprep-webapp/src/app/components/datagrid/header/datagrid-header-controller.js
+++ b/dataprep-webapp/src/app/components/datagrid/header/datagrid-header-controller.js
@@ -15,13 +15,14 @@
  * @ngdoc controller
  * @name data-prep.datagrid-header.controller:DatagridHeaderCtrl
  * @description Dataset Column Header controller.
+ * @requires data-prep.services.state.constant:state
  * @requires data-prep.services.column-types.service:ColumnTypesService
  * @requires data-prep.services.transformation.service:TransformationService
  * @requires data-prep.services.utils.service:ConverterService
  * @requires data-prep.services.playground.service:PlaygroundService
  * @requires data-prep.services.filter.service:FilterService
  */
-export default function DatagridHeaderCtrl($scope,
+export default function DatagridHeaderCtrl($scope, state,
                                            TransformationService, ConverterService,
                                            PlaygroundService, FilterService,
                                            ColumnTypesService, FilterManagerService) {
@@ -35,6 +36,7 @@ export default function DatagridHeaderCtrl($scope,
 	vm.converterService = ConverterService;
 	vm.filterManagerService = FilterManagerService;
 	vm.PlaygroundService = PlaygroundService;
+	vm.state = state;
 
 	/**
 	 * @ngdoc property

--- a/dataprep-webapp/src/app/components/datagrid/header/datagrid-header-directive.spec.js
+++ b/dataprep-webapp/src/app/components/datagrid/header/datagrid-header-directive.spec.js
@@ -12,313 +12,456 @@
  ============================================================================*/
 
 describe('Datagrid header directive', () => {
-    let scope;
-    let createElement;
-    let element;
-    let ctrl;
-    let stateMock;
-    const types = [
-        { id: 'ANY', name: 'any', labelKey: 'ANY' },
-        { id: 'STRING', name: 'string', labelKey: 'STRING' },
-        { id: 'NUMERIC', name: 'numeric', labelKey: 'NUMERIC' },
-        { id: 'INTEGER', name: 'integer', labelKey: 'INTEGER' },
-        { id: 'DOUBLE', name: 'double', labelKey: 'DOUBLE' },
-        { id: 'FLOAT', name: 'float', labelKey: 'FLOAT' },
-        { id: 'BOOLEAN', name: 'boolean', labelKey: 'BOOLEAN' },
-        { id: 'DATE', name: 'date', labelKey: 'DATE' },
-    ];
-
-    const semanticDomains = [
-        {
-            "id": "AIRPORT",
-            "label": "Airport",
-            "frequency": 3.03,
-        },
-        {
-            "id": "CITY",
-            "label": "City",
-            "frequency": 99.24,
-        },
-    ];
-
-    const body = angular.element('body');
-    const column = {
-        id: '0001',
-        name: 'MostPopulousCity',
-        quality: {
-            empty: 5,
-            invalid: 10,
-            valid: 72,
-        },
-        type: 'string',
-    };
-
-    beforeEach(angular.mock.module('data-prep.datagrid-header', ($provide) => {
-        stateMock = {
-            playground: {
-                preparation: {
-                    id: 'prepId',
-                },
-            },
-        };
-        $provide.constant('state', stateMock);
-    }));
-
-    beforeEach(inject(($q, StateService, ColumnTypesService) => {
-        spyOn(ColumnTypesService, 'refreshSemanticDomains').and.returnValue($q.when(semanticDomains));
-        spyOn(ColumnTypesService, 'refreshTypes').and.returnValue($q.when(types));
-    }));
-
-    beforeEach(inject(($rootScope, $compile, $timeout) => {
-        scope = $rootScope.$new(true);
-        scope.column = column;
-
-        createElement = () => {
-            element = angular.element('<datagrid-header column="column"></datagrid-header>');
-            body.append(element);
-            $compile(element)(scope);
-            scope.$digest();
-            $timeout.flush();
-
-            ctrl = element.controller('datagridHeader');
-            spyOn(ctrl, 'updateColumnName').and.returnValue();
-            ctrl.columnNameEdition = { $commitViewValue: jasmine.createSpy('$commitViewValue') };
-        };
-    }));
-
-    afterEach(() => {
-        scope.$destroy();
-        element.remove();
-    });
-
-    it('should display column title and domain', () => {
-        //given
-        scope.column = {
-            id: '0001',
-            name: 'MostPopulousCity',
-            quality: {
-                empty: 5,
-                invalid: 10,
-                valid: 72,
-            },
-            type: 'string',
-            domain: 'city',
-        };
-
-        //when
-        createElement();
-
-        //then
-        expect(element.find('.grid-header-title').text()).toBe('MostPopulousCity');
-        expect(element.find('.grid-header-type').text()).toBe('city');
-    });
-
-    it('should display column title and type when there is no domain', () => {
-        //when
-        createElement();
+	let scope;
+	let createElement;
+	let element;
+	let ctrl;
+	let stateMock;
+	const types = [
+		{ id: 'ANY', name: 'any', labelKey: 'ANY' },
+		{ id: 'STRING', name: 'string', labelKey: 'STRING' },
+		{ id: 'NUMERIC', name: 'numeric', labelKey: 'NUMERIC' },
+		{ id: 'INTEGER', name: 'integer', labelKey: 'INTEGER' },
+		{ id: 'DOUBLE', name: 'double', labelKey: 'DOUBLE' },
+		{ id: 'FLOAT', name: 'float', labelKey: 'FLOAT' },
+		{ id: 'BOOLEAN', name: 'boolean', labelKey: 'BOOLEAN' },
+		{ id: 'DATE', name: 'date', labelKey: 'DATE' },
+	];
+
+	const semanticDomains = [
+		{
+			"id": "AIRPORT",
+			"label": "Airport",
+			"frequency": 3.03,
+		},
+		{
+			"id": "CITY",
+			"label": "City",
+			"frequency": 99.24,
+		},
+	];
+
+	const body = angular.element('body');
+	const column = {
+		id: '0001',
+		name: 'MostPopulousCity',
+		quality: {
+			empty: 5,
+			invalid: 10,
+			valid: 72,
+		},
+		type: 'string',
+		statistics: {
+			frequencyTable: [
+				{},
+			],
+		},
+	};
+
+	const emptyCellsTransfo = {
+		'actionScope': ['empty'],
+		'name': 'delete_empty',
+		'description': 'Delete rows that have empty cells',
+		'label': 'Delete the Rows with Empty Cell',
+	};
+
+	const invalidCellsTransfo = {
+		'actionScope': ['invalid'],
+		'category': 'data cleansing',
+		'name': 'clear_invalid',
+		'description': 'Clear cells that contain a value recognized as invalid',
+		'label': 'Clear the Cells with Invalid Values',
+	};
+
+	beforeEach(angular.mock.module('data-prep.datagrid-header', ($provide) => {
+		stateMock = {
+			playground: {
+				preparation: {
+					id: 'prepId',
+				},
+				suggestions: {
+					transformationsForEmptyCells: [emptyCellsTransfo],
+					transformationsForInvalidCells: [invalidCellsTransfo],
+				},
+			},
+		};
+		$provide.constant('state', stateMock);
+	}));
+
+	beforeEach(angular.mock.module('pascalprecht.translate', ($translateProvider) => {
+		$translateProvider.translations('en', {
+			"SELECT_VALID_RECORDS": "Select rows with valid values for ",
+			"SELECT_INVALID_RECORDS": "Select rows with invalid values for ",
+			"SELECT_EMPTY_RECORDS": "Select rows with empty values for ",
+		});
+		$translateProvider.preferredLanguage('en');
+	}));
+
+	beforeEach(inject(($q, StateService, ColumnTypesService, FilterManagerService, PlaygroundService) => {
+		spyOn(ColumnTypesService, 'refreshSemanticDomains').and.returnValue($q.when(semanticDomains));
+		spyOn(ColumnTypesService, 'refreshTypes').and.returnValue($q.when(types));
+		spyOn(FilterManagerService, 'addFilter').and.returnValue();
+		spyOn(PlaygroundService, 'completeParamsAndAppend').and.returnValue();
+	}));
+
+	beforeEach(inject(($rootScope, $compile, $timeout) => {
+		scope = $rootScope.$new(true);
+		scope.column = column;
+
+		createElement = () => {
+			element = angular.element('<datagrid-header column="column"></datagrid-header>');
+			body.append(element);
+			$compile(element)(scope);
+			scope.$digest();
+			$timeout.flush();
+
+			ctrl = element.controller('datagridHeader');
+			spyOn(ctrl, 'updateColumnName').and.returnValue();
+			ctrl.columnNameEdition = { $commitViewValue: jasmine.createSpy('$commitViewValue') };
+		};
+	}));
+
+	afterEach(() => {
+		scope.$destroy();
+		element.remove();
+	});
+
+	it('should display column title and domain', () => {
+		//given
+		scope.column = {
+			id: '0001',
+			name: 'MostPopulousCity',
+			quality: {
+				empty: 5,
+				invalid: 10,
+				valid: 72,
+			},
+			type: 'string',
+			domain: 'city',
+		};
+
+		//when
+		createElement();
+
+		//then
+		expect(element.find('.grid-header-title').text()).toBe('MostPopulousCity');
+		expect(element.find('.grid-header-type').text()).toBe('city');
+	});
+
+	it('should display column title and type when there is no domain', () => {
+		//when
+		createElement();
+
+		//then
+		expect(element.find('.grid-header-title').text()).toBe('MostPopulousCity');
+		expect(element.find('.grid-header-type').text()).toBe('text');
+	});
+
+	it('should close dropdown on get transform list error', inject(($timeout, $q, TransformationService) => {
+		//given
+		createElement();
+		spyOn(TransformationService, 'getTransformations').and.returnValue($q.when({ allTransformations: [] }));
+		element.find('.grid-header-caret').click();
+		const dropdown = element.find('sc-dropdown').eq(0);
+		expect(dropdown.hasClass('show')).toBe(true);
+
+		//when
+		ctrl.transformationsRetrieveError = true;
+		scope.$digest();
+		$timeout.flush();
+
+		//then
+		expect(dropdown.hasClass('show')).toBe(false);
+	}));
+
+	it('should show input to rename column name when double click', () => {
+		//given
+		createElement();
+
+		const headerTitle = element.find('.grid-header-title').eq(0);
+		expect(ctrl.isEditMode).toBeFalsy();
 
-        //then
-        expect(element.find('.grid-header-title').text()).toBe('MostPopulousCity');
-        expect(element.find('.grid-header-type').text()).toBe('text');
-    });
+		//when
+		headerTitle.dblclick();
 
-    it('should close dropdown on get transform list error', inject(($timeout, $q, TransformationService) => {
-        //given
-        createElement();
-        spyOn(TransformationService, 'getTransformations').and.returnValue($q.when({ allTransformations : [] }));
-        element.find('.grid-header-caret').click();
-        const dropdown = element.find('sc-dropdown').eq(0);
-        expect(dropdown.hasClass('show')).toBe(true);
+		//then
+		expect(ctrl.isEditMode).toBeTruthy();
+	});
 
-        //when
-        ctrl.transformationsRetrieveError = true;
-        scope.$digest();
-        $timeout.flush();
+	it('should select input text when edition mode is tuned on', inject(($window, $timeout) => {
+		//given
+		createElement();
 
-        //then
-        expect(dropdown.hasClass('show')).toBe(false);
-    }));
+		const headerTitle = element.find('.grid-header-title').eq(0);
 
-    it('should show input to rename column name when double click', () => {
-        //given
-        createElement();
+		//when
+		headerTitle.dblclick();
+		$timeout.flush(100);
 
-        const headerTitle = element.find('.grid-header-title').eq(0);
-        expect(ctrl.isEditMode).toBeFalsy();
+		//then
+		expect(document.activeElement).toBe(element.find('.grid-header-title-input').eq(0)[0]); //eslint-disable-line angular/document-service
+		expect($window.getSelection().toString()).toBe('MostPopulousCity');
+	}));
 
-        //when
-        headerTitle.dblclick();
+	it('should switch from input to text on ESC keydown', () => {
+		//given
+		createElement();
 
-        //then
-        expect(ctrl.isEditMode).toBeTruthy();
-    });
+		ctrl.setEditMode(true);
 
-    it('should select input text when edition mode is tuned on', inject(($window, $timeout) => {
-        //given
-        createElement();
+		const event = angular.element.Event('keydown');
+		event.keyCode = 27;
 
-        const headerTitle = element.find('.grid-header-title').eq(0);
+		//when
+		element.find('.grid-header-title-input').eq(0).trigger(event);
 
-        //when
-        headerTitle.dblclick();
-        $timeout.flush(100);
+		//then
+		expect(ctrl.isEditMode).toBe(false);
+	});
 
-        //then
-        expect(document.activeElement).toBe(element.find('.grid-header-title-input').eq(0)[0]); //eslint-disable-line angular/document-service
-        expect($window.getSelection().toString()).toBe('MostPopulousCity');
-    }));
+	it('should reset column name on ESC keydown', () => {
+		//given
+		createElement();
 
-    it('should switch from input to text on ESC keydown', () => {
-        //given
-        createElement();
+		ctrl.setEditMode(true);
+		ctrl.newName = 'toto';
 
-        ctrl.setEditMode(true);
+		const event = angular.element.Event('keydown');
+		event.keyCode = 27;
 
-        const event = angular.element.Event('keydown');
-        event.keyCode = 27;
+		//when
+		element.find('.grid-header-title-input').eq(0).trigger(event);
 
-        //when
-        element.find('.grid-header-title-input').eq(0).trigger(event);
+		//then
+		expect(ctrl.newName).toBe('MostPopulousCity');
+	});
 
-        //then
-        expect(ctrl.isEditMode).toBe(false);
-    });
+	it('should switch from input to text on ENTER event without changes', () => {
+		//given
+		createElement();
 
-    it('should reset column name on ESC keydown', () => {
-        //given
-        createElement();
+		ctrl.setEditMode(true);
+
+		const event = angular.element.Event('keydown');
+		event.keyCode = 13;
 
-        ctrl.setEditMode(true);
-        ctrl.newName = 'toto';
-
-        const event = angular.element.Event('keydown');
-        event.keyCode = 27;
-
-        //when
-        element.find('.grid-header-title-input').eq(0).trigger(event);
-
-        //then
-        expect(ctrl.newName).toBe('MostPopulousCity');
-    });
-
-    it('should switch from input to text on ENTER event without changes', () => {
-        //given
-        createElement();
-
-        ctrl.setEditMode(true);
-
-        const event = angular.element.Event('keydown');
-        event.keyCode = 13;
-
-        //when
-        element.find('.grid-header-title-input').eq(0).trigger(event);
-
-        //then
-        expect(ctrl.isEditMode).toBe(false);
-    });
-
-    it('should submit update on ENTER with changes', () => {
-        //given
-        createElement();
-
-        ctrl.setEditMode(true);
-        ctrl.newName = 'MostPopulousCityInTheWorld';
-
-        const event = angular.element.Event('keydown');
-        event.keyCode = 13;
-
-        //when
-        element.find('.grid-header-title-input').eq(0).trigger(event);
-
-        //then
-        expect(ctrl.updateColumnName).toHaveBeenCalled();
-        expect(ctrl.columnNameEdition.$commitViewValue).toHaveBeenCalled();
-    });
-
-    it('should switch from input to text on BLUR event without changes', () => {
-        //given
-        createElement();
-
-        ctrl.setEditMode(true);
-
-        const event = angular.element.Event('blur');
-
-        //when
-        element.find('.grid-header-title-input').eq(0).trigger(event);
-
-        //then
-        expect(ctrl.isEditMode).toBe(false);
-    });
-
-    it('should submit update on BLUR event with changes', () => {
-        //given
-        createElement();
-
-        ctrl.setEditMode(true);
-        ctrl.newName = 'MostPopulousCityInTheWorld';
-
-        const event = angular.element.Event('blur');
-
-        //when
-        element.find('.grid-header-title-input').eq(0).trigger(event);
-
-        //then
-        expect(ctrl.updateColumnName).toHaveBeenCalled();
-    });
-
-    it('should stop click propagation in input', () => {
-        //given
-        createElement();
-        const event = angular.element.Event('click');
-
-        //when
-        element.find('input').eq(0).trigger(event);
-
-        //then
-        expect(event.isPropagationStopped()).toBe(true);
-        expect(event.isDefaultPrevented()).toBe(true);
-    });
-
-    it('should hide menu on left click on grid-header', () => {
-        //given
-        createElement();
-        element.find('.dropdown-menu').addClass('show-menu');
-
-        //when
-        const event = angular.element.Event('mousedown');
-        event.which = 1;
-        element.find('.grid-header').eq(0).trigger(event);
-
-        //then
-        expect(element.find('.dropdown-menu').hasClass('show-menu')).toBeFalsy();
-    });
-
-    it('should show menu on right click on grid-header if menu is hidden', inject(($q, TransformationService) => {
-        //given
-        createElement();
-        spyOn(TransformationService, 'getTransformations').and.returnValue($q.when({ allTransformations : []}));
-        expect(element.find('sc-dropdown').hasClass('show')).toBeFalsy();
-
-        //when
-        const event = angular.element.Event('mouseup');
-        event.which = 3;
-        element.find('.grid-header').eq(0).trigger(event);
-
-        //then
-        expect(element.find('sc-dropdown').hasClass('show')).toBeTruthy();
-    }));
-
-    it('should hide menu on right click if menu is visible', () => {
-        //given
-        createElement();
-        element.find('.dropdown-menu').addClass('show-menu');
-
-        //when
-        const event = angular.element.Event('mousedown');
-        event.which = 3;
-        element.find('.grid-header').eq(0).trigger(event);
-
-        //then
-        expect(element.find('.dropdown-menu').hasClass('show-menu')).toBeFalsy();
-    });
+		//when
+		element.find('.grid-header-title-input').eq(0).trigger(event);
+
+		//then
+		expect(ctrl.isEditMode).toBe(false);
+	});
+
+	it('should submit update on ENTER with changes', () => {
+		//given
+		createElement();
+
+		ctrl.setEditMode(true);
+		ctrl.newName = 'MostPopulousCityInTheWorld';
+
+		const event = angular.element.Event('keydown');
+		event.keyCode = 13;
+
+		//when
+		element.find('.grid-header-title-input').eq(0).trigger(event);
+
+		//then
+		expect(ctrl.updateColumnName).toHaveBeenCalled();
+		expect(ctrl.columnNameEdition.$commitViewValue).toHaveBeenCalled();
+	});
+
+	it('should switch from input to text on BLUR event without changes', () => {
+		//given
+		createElement();
+
+		ctrl.setEditMode(true);
+
+		const event = angular.element.Event('blur');
+
+		//when
+		element.find('.grid-header-title-input').eq(0).trigger(event);
+
+		//then
+		expect(ctrl.isEditMode).toBe(false);
+	});
+
+	it('should submit update on BLUR event with changes', () => {
+		//given
+		createElement();
+
+		ctrl.setEditMode(true);
+		ctrl.newName = 'MostPopulousCityInTheWorld';
+
+		const event = angular.element.Event('blur');
+
+		//when
+		element.find('.grid-header-title-input').eq(0).trigger(event);
+
+		//then
+		expect(ctrl.updateColumnName).toHaveBeenCalled();
+	});
+
+	it('should stop click propagation in input', () => {
+		//given
+		createElement();
+		const event = angular.element.Event('click');
+
+		//when
+		element.find('input').eq(0).trigger(event);
+
+		//then
+		expect(event.isPropagationStopped()).toBe(true);
+		expect(event.isDefaultPrevented()).toBe(true);
+	});
+
+	it('should hide menu on left click on grid-header', () => {
+		//given
+		createElement();
+		element.find('.dropdown-menu').addClass('show-menu');
+
+		//when
+		const event = angular.element.Event('mousedown');
+		event.which = 1;
+		element.find('.grid-header').eq(0).trigger(event);
+
+		//then
+		expect(element.find('.dropdown-menu').hasClass('show-menu')).toBeFalsy();
+	});
+
+	it('should show menu on right click on grid-header if menu is hidden', inject(($q, TransformationService) => {
+		//given
+		createElement();
+		spyOn(TransformationService, 'getTransformations').and.returnValue($q.when({ allTransformations: [] }));
+		expect(element.find('sc-dropdown').hasClass('show')).toBeFalsy();
+
+		//when
+		const event = angular.element.Event('mouseup');
+		event.which = 3;
+		element.find('.grid-header').eq(0).trigger(event);
+
+		//then
+		expect(element.find('sc-dropdown').hasClass('show')).toBeTruthy();
+	}));
+
+	it('should hide menu on right click if menu is visible', () => {
+		//given
+		createElement();
+		element.find('.dropdown-menu').addClass('show-menu');
+
+		//when
+		const event = angular.element.Event('mousedown');
+		event.which = 3;
+		element.find('.grid-header').eq(0).trigger(event);
+
+		//then
+		expect(element.find('.dropdown-menu').hasClass('show-menu')).toBeFalsy();
+	});
+
+	describe('quality bar', () => {
+		it('should render quality bar', () => {
+			// when
+			createElement();
+
+			// then
+			expect(element.find('quality-bar').length).toBe(1);
+			expect(element.find('quality-bar valid-menu-items').length).toBe(1);
+			expect(element.find('quality-bar empty-menu-items').length).toBe(1);
+			expect(element.find('quality-bar invalid-menu-items').length).toBe(1);
+		});
+
+		describe('valid menu', () => {
+			it('should render valid menu content', () => {
+				// when
+				createElement();
+
+				// then
+				expect(element.find('quality-bar valid-menu-items li').length).toBe(1);
+				expect(element.find('quality-bar valid-menu-items li').text().trim())
+					.toBe('Select rows with valid values for  MOSTPOPULOUSCITY');
+			});
+
+			it('should trigger addFilter callback on 1st item menu click', inject((FilterManagerService) => {
+				// given
+				createElement();
+
+				// when
+				element.find('quality-bar valid-menu-items li').click();
+
+				// then
+				expect(FilterManagerService.addFilter).toHaveBeenCalledWith('valid_records', column.id, column.name);
+			}));
+		});
+
+		describe('empty menu', () => {
+			it('should render empty menu content', () => {
+				// when
+				createElement();
+
+				// then
+				expect(element.find('quality-bar empty-menu-items > li').length).toBe(3);
+				expect(element.find('quality-bar empty-menu-items > li').eq(0).text().trim())
+					.toBe('Select rows with empty values for  MOSTPOPULOUSCITY');
+				expect(element.find('quality-bar empty-menu-items > li').eq(2).text().trim())
+					.toBe(emptyCellsTransfo.label);
+			});
+
+			it('should trigger addFilter callback on 1st item menu click', inject((FilterManagerService) => {
+				// given
+				createElement();
+
+				// when
+				element.find('quality-bar empty-menu-items > li').eq(0).click();
+
+				// then
+				expect(FilterManagerService.addFilter).toHaveBeenCalledWith('empty_records', column.id, column.name);
+			}));
+
+			it('should delete rows on 2nd item menu click', inject((PlaygroundService) => {
+				// given
+				createElement();
+
+				// when
+				element.find('quality-bar empty-menu-items > li').eq(2).click();
+
+				// then
+				expect(PlaygroundService.completeParamsAndAppend).toHaveBeenCalledWith(emptyCellsTransfo, 'column');
+			}));
+		});
+
+		describe('invalid menu', () => {
+			it('should render invalid menu content', () => {
+				// when
+				createElement();
+
+				// then
+				expect(element.find('quality-bar invalid-menu-items > li').length).toBe(3);
+				expect(element.find('quality-bar invalid-menu-items > li').eq(0).text().trim())
+					.toBe('Select rows with invalid values for  MOSTPOPULOUSCITY');
+				expect(element.find('quality-bar invalid-menu-items > li').eq(2).text().trim())
+					.toBe(invalidCellsTransfo.label);
+			});
+
+			it('should trigger addFilter callback on 1st item menu click', inject((FilterManagerService) => {
+				// given
+				createElement();
+
+				// when
+				element.find('quality-bar invalid-menu-items > li').eq(0).click();
+
+				// then
+				expect(FilterManagerService.addFilter).toHaveBeenCalledWith('invalid_records', column.id, column.name);
+			}));
+
+			it('should clear invalid cells on 2nd item menu click', inject((PlaygroundService) => {
+				// given
+				createElement();
+
+				// when
+				element.find('quality-bar invalid-menu-items > li').eq(2).click();
+
+				// then
+				expect(PlaygroundService.completeParamsAndAppend).toHaveBeenCalledWith(invalidCellsTransfo, 'column');
+			}));
+		});
+	});
 });

--- a/dataprep-webapp/src/app/components/datagrid/header/datagrid-header.html
+++ b/dataprep-webapp/src/app/components/datagrid/header/datagrid-header.html
@@ -61,7 +61,8 @@
             <a><span translate-once="SELECT_EMPTY_RECORDS"></span> {{ datagridHeaderCtrl.column.name | uppercase}}</a>
         </li>
         <li class="divider"></li>
-        <li ng-repeat="transfo in datagridHeaderCtrl.state.playground.suggestions.transformationsForEmptyCells track by $index" ng-click="datagridHeaderCtrl.PlaygroundService.completeParamsAndAppend(transfo, 'column')">
+        <li ng-repeat="transfo in datagridHeaderCtrl.state.playground.suggestions.transformationsForEmptyCells track by $index"
+            ng-click="datagridHeaderCtrl.PlaygroundService.completeParamsAndAppend(transfo, 'column')">
             <a>{{transfo.label}}</a>
         </li>
     </empty-menu-items>
@@ -71,7 +72,8 @@
             <a><span translate-once="SELECT_INVALID_RECORDS"></span> {{ datagridHeaderCtrl.column.name | uppercase}}</a>
         </li>
         <li class="divider"></li>
-        <li ng-repeat="transfo in datagridHeaderCtrl.state.playground.suggestions.transformationsForInvalidCells track by $index" ng-click="datagridHeaderCtrl.PlaygroundService.completeParamsAndAppend(transfo, 'column')">
+        <li ng-repeat="transfo in datagridHeaderCtrl.state.playground.suggestions.transformationsForInvalidCells track by $index"
+            ng-click="datagridHeaderCtrl.PlaygroundService.completeParamsAndAppend(transfo, 'column')">
             <a>{{transfo.label}}</a>
         </li>
     </invalid-menu-items>

--- a/dataprep-webapp/src/app/services/state/playground/playground-state-service.js
+++ b/dataprep-webapp/src/app/services/state/playground/playground-state-service.js
@@ -97,8 +97,6 @@ export function PlaygroundStateService(RecipeStateService, recipeState,
 		selectTransformationsTab: SuggestionsStateService.selectTab,
 		setTransformations: SuggestionsStateService.setTransformations,
 		setTransformationsLoading: SuggestionsStateService.setLoading,
-		setTransformationsForEmptyCells: SuggestionsStateService.setTransformationsForEmptyCells,
-		setTransformationsForInvalidCells: SuggestionsStateService.setTransformationsForInvalidCells,
 		updateFilteredTransformations: SuggestionsStateService.updateFilteredTransformations,
 
         // statistics

--- a/dataprep-webapp/src/app/services/state/state-service.js
+++ b/dataprep-webapp/src/app/services/state/state-service.js
@@ -117,8 +117,6 @@ export function StateService(RouteStateService, routeState,
 		selectTransformationsTab: PlaygroundStateService.selectTransformationsTab,
 		setTransformations: PlaygroundStateService.setTransformations,
 		setTransformationsLoading: PlaygroundStateService.setTransformationsLoading,
-		setTransformationsForEmptyCells: PlaygroundStateService.setTransformationsForEmptyCells,
-		setTransformationsForInvalidCells: PlaygroundStateService.setTransformationsForInvalidCells,
 		updateFilteredTransformations: PlaygroundStateService.updateFilteredTransformations,
 
 		// playground - Statistics


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-3139

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
In datagrid-header-controller the dependency to the state has been removed causing this regression 

**(Optional) What is the new behavior?**
Brought back the state dependency and added non regression TUs

**(Optional) Other information**:
