### PR TITLE
feat TDP-3160: give a dataprep-specific name to git properties file

### DIFF
--- a/dataprep-backend-service/pom.xml
+++ b/dataprep-backend-service/pom.xml
@@ -307,6 +307,8 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/dataprep-git.properties
+                    </generateGitPropertiesFilename>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                 </configuration>
             </plugin>

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/info/ManifestInfo.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/info/ManifestInfo.java
@@ -36,7 +36,7 @@ public class ManifestInfo {
      * The ID (from the SCM) of the source's version of the running application
      */
     private String buildId;
-    
+
     /**
      * The unique instance of this singleton class
      */
@@ -44,7 +44,7 @@ public class ManifestInfo {
 
     private ManifestInfo() {
         Properties properties = new Properties();
-        final InputStream gitProperties = ManifestInfo.class.getResourceAsStream("/git.properties");
+        final InputStream gitProperties = ManifestInfo.class.getResourceAsStream("/dataprep-git.properties");
         if (gitProperties != null) {
             try {
                 properties.load(gitProperties);


### PR DESCRIPTION
Named 'git.properties' to 'dataprep-git.properties'

https://jira.talendforge.org/browse/TDP-3160

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
