### PR TITLE
fix(TDP-3201): recipe pbm with safari

### DIFF
--- a/dataprep-webapp/src/app/components/recipe/_recipe.scss
+++ b/dataprep-webapp/src/app/components/recipe/_recipe.scss
@@ -34,7 +34,7 @@ $recipe-step-draggable-background-color: #808080 !default;
 
     .step-trigger {
       position: relative;
-      padding-right: 11px;
+      padding-right: 9px;
     }
 
     &.disabled-step {
@@ -55,22 +55,16 @@ $recipe-step-draggable-background-color: #808080 !default;
       }
     }
 
-    .reorder-handler + step-description {
-      @include transition(margin-left .1s linear);
-      margin-left: 0;
+    .reorder-handler {
+      margin-right: 5px;
     }
 
     .reorder-handler,
     .remove-icon {
-      @include transition(opacity .1s linear);
       opacity: 0;
     }
 
     &:hover {
-      .reorder-handler + step-description {
-        margin-left: 10px;
-      }
-
       .reorder-handler,
       .remove-icon {
         opacity: 1;
@@ -166,6 +160,7 @@ $recipe-step-draggable-background-color: #808080 !default;
     sc-accordion-item {
       .trigger-container {
         cursor: move;
+        margin-left: -5px;
       }
 
       .content-container {


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3201

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
1- There is a transition on step hover to display the handler, wich pushed the step-description to the right.
2- The steps dividers exceeds the knot lines 

**(Optional) What is the new behavior?**
1- No more transitions.
2- The steps dividers stop on knot lines 

**(Optional) Other information**:
