### PR TITLE
fix(TDP-3287): Disable compatibility mode in internet explorer

### DIFF
--- a/dataprep-webapp/src/index.html
+++ b/dataprep-webapp/src/index.html
@@ -18,6 +18,7 @@
 <html ng-strict-di>
     <head>
         <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
         <title><%= htmlWebpackPlugin.options.title %></title>
         <meta name="viewport" content="width=device-width">
         <link rel="shortcut icon" type="image/png" href="/assets/images/favicon.png">


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3287

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !

**(Optional) Other information**:
https://github.com/h5bp/html5-boilerplate/blob/5.3.0/dist/doc/html.md#x-ua-compatible