### PR TITLE
TDP-2681: Add max-width for Safari 10

### DIFF
--- a/dataprep-webapp/src/app/components/widgets/slidable/_slidable.scss
+++ b/dataprep-webapp/src/app/components/widgets/slidable/_slidable.scss
@@ -38,6 +38,7 @@
 
 	&.slide-hide {
 		flex: 0 0 $actionSize !important;
+		max-width: $actionSize; /* Safari 10 */
 		> .content {
 			width: 0;
 		}


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2681

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)


**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:
https://github.com/DrummerHead/safari-flex-basis-animation-bug