### PR TITLE
feat(Grid): add "selected" class name on selected column header

### DIFF
--- a/dataprep-webapp/src/app/components/datagrid/datagrid-directive.js
+++ b/dataprep-webapp/src/app/components/datagrid/datagrid-directive.js
@@ -220,7 +220,6 @@ export default function Datagrid($timeout, state, DatagridGridService, DatagridC
 						else {
 							DatagridStyleService.updateColumnsClass(getSelectedColumns());
 						}
-						grid.invalidate();
 					}, 0, false);
 
                     // manage column selection (external)

--- a/dataprep-webapp/src/app/components/datagrid/services/datagrid-column-service.js
+++ b/dataprep-webapp/src/app/components/datagrid/services/datagrid-column-service.js
@@ -37,18 +37,18 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 	let renewAllFlag;
 	let availableHeaders = [];
 
-    /**
-     * contains a backup of the columnsMetadata to find which has been moved after a reorder
-     * @type {Array}
-     */
+	/**
+	 * contains a backup of the columnsMetadata to find which has been moved after a reorder
+	 * @type {Array}
+	 */
 	let originalColumns = [];
 
 	const gridHeaderPreviewTemplate =
-        '<div class="grid-header <%= diffClass %>">' +
-        '   <div class="grid-header-title dropdown-button ng-binding"><%= name || "&nbsp;" %></div>' +
-        '   <div class="grid-header-type ng-binding"><%= simpleType %></div>' +
-        '</div>' +
-        '<div class="quality-bar"><div class="record-unknown"></div></div>';
+		'<div class="grid-header <%= diffClass %>">' +
+		'   <div class="grid-header-title dropdown-button ng-binding"><%= name || "&nbsp;" %></div>' +
+		'   <div class="grid-header-type ng-binding"><%= simpleType %></div>' +
+		'</div>' +
+		'<div class="quality-bar"><div class="record-unknown"></div></div>';
 
 	return {
 		init,
@@ -57,34 +57,34 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		columnsOrderChanged,
 	};
 
-    // --------------------------------------------------------------------------------------------
-    // -----------------------------------------------GRID COLUMNS---------------------------------
-    // --------------------------------------------------------------------------------------------
+	// --------------------------------------------------------------------------------------------
+	// -----------------------------------------------GRID COLUMNS---------------------------------
+	// --------------------------------------------------------------------------------------------
 
-    /**
-     * @ngdoc method
-     * @name createColumnDefinition
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param {object} col The column metadata to adapt
-     * @param {boolean} preview Flag that indicates if we are in the preview mode
-     * @description Adapt column metadata to slick column.
-     * <ul>
-     *     <li>
-     *         Non preview mode : The div id depending on index is important.
-     *         It is used as insertion point for the header directive.
-     *     </li>
-     *     <li>Preview mode : we inject directly a fake header</li>
-     * </ul>
-     * @returns {object} The adapted column item
-     */
+	/**
+	 * @ngdoc method
+	 * @name createColumnDefinition
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param {object} col The column metadata to adapt
+	 * @param {boolean} preview Flag that indicates if we are in the preview mode
+	 * @description Adapt column metadata to slick column.
+	 * <ul>
+	 *     <li>
+	 *         Non preview mode : The div id depending on index is important.
+	 *         It is used as insertion point for the header directive.
+	 *     </li>
+	 *     <li>Preview mode : we inject directly a fake header</li>
+	 * </ul>
+	 * @returns {object} The adapted column item
+	 */
 	function createColumnDefinition(col, preview) {
 		const template = preview ?
-            _.template(gridHeaderPreviewTemplate)({
-	name: col.name,
-	diffClass: DatagridStyleService.getColumnPreviewStyle(col),
-	simpleType: col.domain ? col.domain : ConverterService.simplifyType(col.type),
-}) :
-            '';
+			_.template(gridHeaderPreviewTemplate)({
+				name: col.name,
+				diffClass: DatagridStyleService.getColumnPreviewStyle(col),
+				simpleType: col.domain ? col.domain : ConverterService.simplifyType(col.type),
+			}) :
+			'';
 		const translatedMsg = $translate.instant('APPLY_TO_ALL_CELLS');
 
 		return {
@@ -94,39 +94,39 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 			formatter: DatagridStyleService.columnFormatter(col),
 			tdpColMetadata: col,
 			editor: preview ?
-                null :
-                Slick.Editors.TalendEditor( // eslint-disable-line new-cap
-                    PlaygroundService.editCell,
-                    translatedMsg
-                ),
+				null :
+				Slick.Editors.TalendEditor( // eslint-disable-line new-cap
+					PlaygroundService.editCell,
+					translatedMsg
+				),
 			preview,
 		};
 	}
 
-    /**
-     * @ngdoc method
-     * @name createColumns
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param {object[]} columnsMetadata Columns details
-     * @param {boolean} preview Flag that indicates if we are in preview mode
-     * @description Two modes :
-     * <ul>
-     *     <li>
-     *         Preview : we save actual headers
-     *         and simulate fake headers with the new preview columns
-     *     </li>
-     *     <li>
-     *         Classic : we map each column to a header.
-     *         This header can be a reused header if the column was the same as before,
-     *         or a new created one otherwise.
-     * </li>
-     * </ul>
-     */
+	/**
+	 * @ngdoc method
+	 * @name createColumns
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param {object[]} columnsMetadata Columns details
+	 * @param {boolean} preview Flag that indicates if we are in preview mode
+	 * @description Two modes :
+	 * <ul>
+	 *     <li>
+	 *         Preview : we save actual headers
+	 *         and simulate fake headers with the new preview columns
+	 *     </li>
+	 *     <li>
+	 *         Classic : we map each column to a header.
+	 *         This header can be a reused header if the column was the same as before,
+	 *         or a new created one otherwise.
+	 * </li>
+	 * </ul>
+	 */
 	function createColumns(columnsMetadata, preview) {
-        // create new SlickGrid columns
+		// create new SlickGrid columns
 		const colIndexArray = [];
 
-        // Add index column
+		// Add index column
 		colIndexArray.push({
 			id: COLUMN_INDEX_ID,
 			name: '',
@@ -148,18 +148,18 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		return columns;
 	}
 
-    /**
-     * @ngdoc method
-     * @name columnsOrderChanged
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param {object[]} columnsMetadata Columns details
-     * @param {object[]} originals the optional original columns
-     * if null the field will be used originalColumns
-     * @description method trigger on columns reorder
-     */
+	/**
+	 * @ngdoc method
+	 * @name columnsOrderChanged
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param {object[]} columnsMetadata Columns details
+	 * @param {object[]} originals the optional original columns
+	 * if null the field will be used originalColumns
+	 * @description method trigger on columns reorder
+	 */
 	function columnsOrderChanged(columnsMetadata, originals) {
 		const original = originals || originalColumns;
-        // the user started reordering but has abandoned his action at the end
+		// the user started reordering but has abandoned his action at the end
 		if (_.map(original, 'tdpColMetadata.id').join() === _.map(columnsMetadata, 'tdpColMetadata.id').join()) {
 			return;
 		}
@@ -177,22 +177,22 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		PlaygroundService.appendStep([{ action: 'reorder', parameters: params }]);
 	}
 
-    /**
-     * @ngdoc method
-     * @name findMovedCols
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param originalCols
-     * @param newCols
-     * @returns Object with fields :
-     *  <ul>
-     *    <li>selected: containing the column id to move</li>
-     *    <li>target: containing the column id where to move</li>
-     *    <li>name: the name of the moved field</li>
-     * @private
-     * @description find which columnMetadata has been moved between the two arrays
-     * during a reorder columns.
-     * We iterate on array and so some comparaisons.
-     */
+	/**
+	 * @ngdoc method
+	 * @name findMovedCols
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param originalCols
+	 * @param newCols
+	 * @returns Object with fields :
+	 *  <ul>
+	 *    <li>selected: containing the column id to move</li>
+	 *    <li>target: containing the column id where to move</li>
+	 *    <li>name: the name of the moved field</li>
+	 * @private
+	 * @description find which columnMetadata has been moved between the two arrays
+	 * during a reorder columns.
+	 * We iterate on array and so some comparaisons.
+	 */
 	function findMovedCols(originalCols, newCols) {
 		const result = {};
 		let index = 0;
@@ -200,12 +200,12 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		let movedCol = null;
 		_.forEach(originalCols, (col) => {
 			if (!movedCol && col.id) {
-                // move forward case
+				// move forward case
 				if (col.id !== newCols[index].id &&
-                    originalCols[index + 1].id === newCols[index].id) {
+					originalCols[index + 1].id === newCols[index].id) {
 					movedCol = col;
 					movedIndex = index;
-                    // find new index of movedCol
+					// find new index of movedCol
 					result.selected = movedCol.id;
 					result.name = _.get(movedCol, 'tdpColMetadata.name');
 					index = 0;
@@ -218,7 +218,7 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 					});
 					return result;
 				}
-                // move backward case
+				// move backward case
 				else if (col.id !== newCols[index].id && col.id === newCols[index + 1].id) {
 					movedCol = col;
 					movedIndex = index;
@@ -234,30 +234,30 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		return result;
 	}
 
-    // --------------------------------------------------------------------------------------------
-    // -----------------------------------------------GRID HEADERS---------------------------------
-    // --------------------------------------------------------------------------------------------
-    /**
-     * @ngdoc method
-     * @name destroyHeader
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param {object} headerDefinition The header definition
-     * that contains scope (the angular scope) and header (the element)
-     * @description Destroy the angular scope and header element
-     */
+	// --------------------------------------------------------------------------------------------
+	// -----------------------------------------------GRID HEADERS---------------------------------
+	// --------------------------------------------------------------------------------------------
+	/**
+	 * @ngdoc method
+	 * @name destroyHeader
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param {object} headerDefinition The header definition
+	 * that contains scope (the angular scope) and header (the element)
+	 * @description Destroy the angular scope and header element
+	 */
 	function destroyHeader(headerDefinition) {
 		headerDefinition.scope.$destroy();
 		headerDefinition.header.remove();
 	}
 
-    /**
-     * @ngdoc method
-     * @name renewAllColumns
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param {boolean} value The new flag value
-     * @description Set the 'renewAllFlag' with provided value to control
-     * whether the headers should be reused or recreated
-     */
+	/**
+	 * @ngdoc method
+	 * @name renewAllColumns
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param {boolean} value The new flag value
+	 * @description Set the 'renewAllFlag' with provided value to control
+	 * whether the headers should be reused or recreated
+	 */
 	function renewAllColumns(value) {
 		renewAllFlag = value;
 
@@ -267,17 +267,17 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		}
 	}
 
-    /**
-     * @ngdoc method
-     * @name createHeader
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @description [PRIVATE] Create a column header object containing
-     * <ul>
-     *     <li>the element directive</li>
-     *     <li>The directive scope</li>
-     *     <li>The column metadata</li>
-     * </ul>
-     */
+	/**
+	 * @ngdoc method
+	 * @name createHeader
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @description [PRIVATE] Create a column header object containing
+	 * <ul>
+	 *     <li>the element directive</li>
+	 *     <li>The directive scope</li>
+	 *     <li>The column metadata</li>
+	 * </ul>
+	 */
 	function createHeader(col) {
 		const headerScope = $rootScope.$new(true);
 		headerScope.column = col;
@@ -291,17 +291,17 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		};
 	}
 
-    /**
-     * @ngdoc method
-     * @name createIndexHeader
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @description [PRIVATE] Create the index column header object containing
-     * <ul>
-     *     <li>the element directive</li>
-     *     <li>The directive scope</li>
-     *     <li>The column metadata</li>
-     * </ul>
-     */
+	/**
+	 * @ngdoc method
+	 * @name createIndexHeader
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @description [PRIVATE] Create the index column header object containing
+	 * <ul>
+	 *     <li>the element directive</li>
+	 *     <li>The directive scope</li>
+	 *     <li>The column metadata</li>
+	 * </ul>
+	 */
 	function createIndexHeader() {
 		const headerScope = $rootScope.$new(true);
 		const headerElement = angular.element('<datagrid-index-header></datagrid-index-header>');
@@ -314,30 +314,30 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		};
 	}
 
-    /**
-     * @ngdoc method
-     * @name detachAndSaveHeader
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param {object} event The Slickgrid header destroy event
-     * @param {object} columnsArgs The column header arguments passed by SlickGrid
-     * @description This is part of the process to avoid recreation of the datagrid header
-     * when it is not necessary.
-     * It detach the element and save it with its scope, so it can be reused.
-     * If the 'renewAllFlag' is set to true, the headers are destroyed.
-     * So they are forced to be recreated.
-     */
+	/**
+	 * @ngdoc method
+	 * @name detachAndSaveHeader
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param {object} event The Slickgrid header destroy event
+	 * @param {object} columnsArgs The column header arguments passed by SlickGrid
+	 * @description This is part of the process to avoid recreation of the datagrid header
+	 * when it is not necessary.
+	 * It detach the element and save it with its scope, so it can be reused.
+	 * If the 'renewAllFlag' is set to true, the headers are destroyed.
+	 * So they are forced to be recreated.
+	 */
 	function detachAndSaveHeader(event, columnsArgs) {
-        // No header to detach on preview
+		// No header to detach on preview
 		const columnDef = columnsArgs.column;
 		if (columnDef.preview) {
 			return;
 		}
 
-        // Destroy the header if explicitly requested
+		// Destroy the header if explicitly requested
 		if (renewAllFlag) {
 			destroyHeader(columnDef);
 		}
-        // Detach and save it otherwise
+		// Detach and save it otherwise
 		else {
 			const scope = columnDef.scope;
 			const header = columnDef.header;
@@ -353,77 +353,77 @@ export default function DatagridColumnService($rootScope, $compile, $log, $trans
 		}
 	}
 
-    /**
-     * @ngdoc method
-     * @name createAndAttachHeader
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param {object} event The Slickgrid header creation event
-     * @param {object} columnsArgs The column header arguments passed by SlickGrid
-     * @description This is part of the process to avoid recreation od the datagrid header
-     * when it is not necessary.
-     * It fetch an existing saved header to reuse it, or create it otherwise.
-     * The existing header is then updated with the new column metadata.
-     */
+	/**
+	 * @ngdoc method
+	 * @name createAndAttachHeader
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param {object} event The Slickgrid header creation event
+	 * @param {object} columnsArgs The column header arguments passed by SlickGrid
+	 * @description This is part of the process to avoid recreation od the datagrid header
+	 * when it is not necessary.
+	 * It fetch an existing saved header to reuse it, or create it otherwise.
+	 * The existing header is then updated with the new column metadata.
+	 */
 	function createAndAttachHeader(event, columnsArgs) {
-        // No header to append on preview
+		// No header to append on preview
 		const columnDef = columnsArgs.column;
 		if (columnDef.preview) {
 			return;
 		}
+		const isIndexColumn = columnDef.id === COLUMN_INDEX_ID;
 
-        // Get existing header and remove it from available headers list
-		let headerDefinition = _.find(availableHeaders, { id: columnDef.id });
+		// Get existing header and remove it from available headers list
+		let headerDefinition = availableHeaders.find(header => header.id === columnDef.id);
 		if (headerDefinition) {
 			const headerIndex = availableHeaders.indexOf(headerDefinition);
 			availableHeaders.splice(headerIndex, 1);
 		}
 
-        // Update column metadata in header if there is an available one
+		// Update column metadata in header if there is an available one
 		if (headerDefinition) {
-			if (columnDef.id !== COLUMN_INDEX_ID) {
+			if (!isIndexColumn) {
 				headerDefinition.scope.column = columnDef.tdpColMetadata;
-				headerDefinition.scope.$digest();
 			}
 		}
-        // Create the header if no available created header
+		// Create the header if no available created header
 		else {
-			headerDefinition = columnDef.id === COLUMN_INDEX_ID ?
-                createIndexHeader() :
-                createHeader(columnDef.tdpColMetadata);
+			headerDefinition = isIndexColumn ?
+				createIndexHeader() :
+				createHeader(columnDef.tdpColMetadata);
 		}
 
-        // Update column definition
+		// Update column definition
 		columnDef.scope = headerDefinition.scope;
 		columnDef.header = headerDefinition.header;
 
-        // Append the header
+		// Append the header
 		const node = angular.element(columnsArgs.node);
 		node.append(headerDefinition.header);
 	}
 
-    // --------------------------------------------------------------------------------------------
-    // --------------------------------------------------INIT--------------------------------------
-    // --------------------------------------------------------------------------------------------
-    /**
-     * @ngdoc method
-     * @name attachColumnHeaderEvents
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @description Attach listeners for header creation/destroy.
-     * The handler detach and save headers on destroy,
-     * attach (create them if necessary) and update them on render
-     */
+	// --------------------------------------------------------------------------------------------
+	// --------------------------------------------------INIT--------------------------------------
+	// --------------------------------------------------------------------------------------------
+	/**
+	 * @ngdoc method
+	 * @name attachColumnHeaderEvents
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @description Attach listeners for header creation/destroy.
+	 * The handler detach and save headers on destroy,
+	 * attach (create them if necessary) and update them on render
+	 */
 	function attachColumnHeaderEvents() {
 		grid.onBeforeHeaderCellDestroy.subscribe(detachAndSaveHeader);
 		grid.onHeaderCellRendered.subscribe(createAndAttachHeader);
 	}
 
-    /**
-     * @ngdoc method
-     * @name init
-     * @methodOf data-prep.datagrid.service:DatagridColumnService
-     * @param {object} newGrid The new grid
-     * @description Initialize the grid and attach the column listeners
-     */
+	/**
+	 * @ngdoc method
+	 * @name init
+	 * @methodOf data-prep.datagrid.service:DatagridColumnService
+	 * @param {object} newGrid The new grid
+	 * @description Initialize the grid and attach the column listeners
+	 */
 	function init(newGrid) {
 		grid = newGrid;
 		attachColumnHeaderEvents();

--- a/dataprep-webapp/src/app/components/datagrid/services/datagrid-column-service.spec.js
+++ b/dataprep-webapp/src/app/components/datagrid/services/datagrid-column-service.spec.js
@@ -14,609 +14,613 @@
 import SlickGridMock from '../../../../mocks/SlickGrid.mock';
 
 describe('Datagrid column service', () => {
-    'use strict';
-
-    var gridMock;
-    var columnsMetadata;
-
-    beforeEach(angular.mock.module('data-prep.datagrid'));
-
-    beforeEach(inject(() => {
-        columnsMetadata = [
-            { id: '0000', name: 'col0', type: 'string' },
-            { id: '0001', name: 'col1', type: 'integer' },
-            { id: '0002', name: 'col2', type: 'string', domain: 'salary' },
-        ];
-
-        /*global SlickGridMock:false */
-        gridMock = new SlickGridMock();
-    }));
-
-    describe('on creation', function () {
-        it('should add SlickGrid header destroy handler', inject(function (DatagridColumnService) {
-            //given
-            spyOn(gridMock.onBeforeHeaderCellDestroy, 'subscribe').and.returnValue();
-
-            //when
-            DatagridColumnService.init(gridMock);
-
-            //then
-            expect(gridMock.onBeforeHeaderCellDestroy.subscribe).toHaveBeenCalled();
-        }));
-
-        it('should add SlickGrid header creation handler', inject(function (DatagridColumnService) {
-            //given
-            spyOn(gridMock.onHeaderCellRendered, 'subscribe').and.returnValue();
-
-            //when
-            DatagridColumnService.init(gridMock);
-
-            //then
-            expect(gridMock.onHeaderCellRendered.subscribe).toHaveBeenCalled();
-        }));
-    });
-
-    describe('create columns', function () {
-        var headers = [
-            {
-                element: {
-                    detach: function () {},
-                },
-            },
-            {
-                element: {
-                    detach: function () {},
-                },
-            },
-            {
-                element: {
-                    detach: function () {},
-                },
-            },];
-        var formatter = function () {};
-
-        beforeEach(inject(function (DatagridColumnService, DatagridStyleService) {
-            DatagridColumnService.init(gridMock);
-            headers.forEach(function (header) {
-                spyOn(header.element, 'detach').and.returnValue();
-            });
-
-            spyOn(DatagridStyleService, 'getColumnPreviewStyle').and.returnValue('');
-            spyOn(DatagridStyleService, 'columnFormatter').and.returnValue(formatter);
-        }));
-
-        it('should create new preview grid columns', inject(function (DatagridColumnService) {
-            //when
-            var createdColumns = DatagridColumnService.createColumns(columnsMetadata, true, false);
-
-            //then
-            expect(createdColumns[0].id).toEqual('tdpId');
-            expect(createdColumns[0].field).toEqual('tdpId');
-            expect(createdColumns[0].name).toEqual('');
-            expect(createdColumns[0].resizable).toBeFalsy();
-            expect(createdColumns[0].selectable).toBeFalsy();
-            expect(createdColumns[0].formatter(1, 2, 3)).toEqual('<div class="index-cell">3</div>');
-            expect(createdColumns[0].maxWidth).toEqual(60);
-
-            expect(createdColumns[1].id).toEqual('0000');
-            expect(createdColumns[1].field).toEqual('0000');
-            expect(createdColumns[1].name).toEqual('<div class="grid-header ">   <div class="grid-header-title dropdown-button ng-binding">col0</div>   <div class="grid-header-type ng-binding">text</div></div><div class="quality-bar"><div class="record-unknown"></div></div>');
-            expect(createdColumns[1].formatter).toEqual(formatter);
-            expect(createdColumns[1].tdpColMetadata).toEqual({ id: '0000', name: 'col0', type: 'string' });
-
-            expect(createdColumns[2].id).toEqual('0001');
-            expect(createdColumns[2].field).toEqual('0001');
-            expect(createdColumns[2].name).toEqual('<div class="grid-header ">   <div class="grid-header-title dropdown-button ng-binding">col1</div>   <div class="grid-header-type ng-binding">integer</div></div><div class="quality-bar"><div class="record-unknown"></div></div>');
-            expect(createdColumns[2].formatter).toEqual(formatter);
-            expect(createdColumns[2].tdpColMetadata).toEqual({ id: '0001', name: 'col1', type: 'integer' });
-
-            expect(createdColumns[3].id).toEqual('0002');
-            expect(createdColumns[3].field).toEqual('0002');
-            expect(createdColumns[3].name).toEqual('<div class="grid-header ">   <div class="grid-header-title dropdown-button ng-binding">col2</div>   <div class="grid-header-type ng-binding">salary</div></div><div class="quality-bar"><div class="record-unknown"></div></div>');
-            expect(createdColumns[3].formatter).toEqual(formatter);
-            expect(createdColumns[3].tdpColMetadata).toEqual({
-                id: '0002',
-                name: 'col2',
-                type: 'string',
-                domain: 'salary',
-            });
-        }));
-
-        it('should create new grid columns', inject(function (DatagridColumnService) {
-            //when
-            var createdColumns = DatagridColumnService.createColumns(columnsMetadata, false, false);
-
-            //then
-            expect(createdColumns[0].id).toEqual('tdpId');
-            expect(createdColumns[0].field).toEqual('tdpId');
-            expect(createdColumns[0].name).toEqual('');
-            expect(createdColumns[0].resizable).toBeFalsy();
-            expect(createdColumns[0].selectable).toBeFalsy();
-            expect(createdColumns[0].formatter(1, 2, 3)).toEqual('<div class="index-cell">3</div>');
-            expect(createdColumns[0].maxWidth).toEqual(60);
-
-            expect(createdColumns[1].id).toEqual('0000');
-            expect(createdColumns[1].field).toEqual('0000');
-            expect(createdColumns[1].name).toEqual('');
-            expect(createdColumns[1].formatter).toEqual(formatter);
-            expect(createdColumns[1].tdpColMetadata).toEqual({ id: '0000', name: 'col0', type: 'string' });
-
-            expect(createdColumns[2].id).toEqual('0001');
-            expect(createdColumns[2].field).toEqual('0001');
-            expect(createdColumns[2].name).toEqual('');
-            expect(createdColumns[2].formatter).toEqual(formatter);
-            expect(createdColumns[2].tdpColMetadata).toEqual({ id: '0001', name: 'col1', type: 'integer' });
-
-            expect(createdColumns[3].id).toEqual('0002');
-            expect(createdColumns[3].field).toEqual('0002');
-            expect(createdColumns[3].name).toEqual('');
-            expect(createdColumns[3].formatter).toEqual(formatter);
-            expect(createdColumns[3].tdpColMetadata).toEqual({
-                id: '0002',
-                name: 'col2',
-                type: 'string',
-                domain: 'salary',
-            });
-        }));
-    });
-
-    describe('on column header destroy event', function () {
-        var columnDef;
-
-        beforeEach(inject(function (DatagridColumnService) {
-            spyOn(gridMock.onBeforeHeaderCellDestroy, 'subscribe').and.returnValue();
-
-            columnDef = {
-                header: {
-                    remove: function () {}, detach: function () {},
-                },
-                scope: {
-                    $destroy: function () {},
-                },
-            };
-
-            spyOn(columnDef.header, 'detach').and.returnValue();
-            spyOn(columnDef.header, 'remove').and.returnValue();
-            spyOn(columnDef.scope, '$destroy').and.returnValue();
-
-            DatagridColumnService.init(gridMock);
-        }));
-
-        it('should do nothing when column is part of a preview', inject(function (DatagridColumnService) {
-            //given
-            columnDef.preview = true;
-            var columnsArgs = {
-                id: '0001',
-                column: columnDef,
-            };
-            DatagridColumnService.renewAllColumns(true);
-
-            //when
-            var onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
-            onBeforeHeaderCellDestroy(null, columnsArgs);
-
-            //then
-            expect(columnDef.header.detach).not.toHaveBeenCalled();
-            expect(columnDef.header.remove).not.toHaveBeenCalled();
-            expect(columnDef.scope.$destroy).not.toHaveBeenCalled();
-        }));
-
-        it('should destroy header when renewAllFlag is set to true', inject(function (DatagridColumnService) {
-            //given
-            columnDef.preview = false;
-            var columnsArgs = {
-                id: '0001',
-                column: columnDef,
-            };
-            DatagridColumnService.renewAllColumns(true);
-
-            //when
-            var onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
-            onBeforeHeaderCellDestroy(null, columnsArgs);
-
-            //then
-            expect(columnDef.header.detach).not.toHaveBeenCalled();
-            expect(columnDef.header.remove).toHaveBeenCalled();
-            expect(columnDef.scope.$destroy).toHaveBeenCalled();
-        }));
-
-        it('should detach header when renewAllFlag is set to false', inject(function (DatagridColumnService) {
-            //given
-            columnDef.preview = false;
-            var columnsArgs = {
-                id: '0001',
-                column: columnDef,
-            };
-            DatagridColumnService.renewAllColumns(false);
-
-            //when
-            var onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
-            onBeforeHeaderCellDestroy(null, columnsArgs);
-
-            //then
-            expect(columnDef.header.detach).toHaveBeenCalled();
-            expect(columnDef.header.remove).not.toHaveBeenCalled();
-            expect(columnDef.scope.$destroy).not.toHaveBeenCalled();
-        }));
-
-        it('should NOT detach header for index column', inject(function (DatagridColumnService) {
-            //given
-            columnDef.preview = false;
-            var columnsArgs = {
-                id: 'tdpId',
-                column: {
-                    id: 'tdpId',
-                    header: {
-                        remove: function () {}, detach: function () {},
-                    },
-                    scope: {
-                        $destroy: function () {},
-                    },
-                },
-            };
-            DatagridColumnService.renewAllColumns(false);
-
-            //when
-            var onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
-            onBeforeHeaderCellDestroy(null, columnsArgs);
-
-            //then
-            expect(columnDef.header.detach).not.toHaveBeenCalled();
-        }));
-    });
-
-    describe('on column header rendered event', function () {
-        var availableScope;
-        var availableHeader;
-
-        function saveHeader(id, scope, header) {
-            var columnsToDestroy = {
-                id: id,
-                scope: scope,
-                header: header,
-                preview: false,
-            };
-            var headerToDetach = {
-                column: columnsToDestroy,
-            };
-
-            //destroy to save header in the available headers
-            var onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
-            onBeforeHeaderCellDestroy(null, headerToDetach);
-        }
-
-        beforeEach(inject(function (DatagridColumnService) {
-            spyOn(gridMock.onBeforeHeaderCellDestroy, 'subscribe').and.returnValue();
-            spyOn(gridMock.onHeaderCellRendered, 'subscribe').and.returnValue();
-
-            DatagridColumnService.init(gridMock);
-
-            //save header in available headers list
-            availableScope = {
-                $destroy: function () {}, $digest: function () {},
-            };
-            availableHeader = angular.element('<div id="availableHeader"></div>');
-            saveHeader('0001', availableScope, availableHeader);
-
-            spyOn(availableScope, '$digest').and.returnValue();
-        }));
-
-        it('should attach and update available header that has the same id', inject(function () {
-            //given
-            var columnsArgs = {
-                column: {
-                    id: '0001',
-                    tdpColMetadata: {},
-                },
-                node: angular.element('<div></div>')[0],
-            };
-
-            //when
-            var onHeaderCellRendered = gridMock.onHeaderCellRendered.subscribe.calls.argsFor(0)[0];
-            onHeaderCellRendered(null, columnsArgs);
-
-            //then
-            expect(availableScope.column).toBe(columnsArgs.column.tdpColMetadata);
-            expect(availableScope.$digest).toHaveBeenCalled();
-
-            expect(columnsArgs.column.header).toBe(availableHeader);
-            expect(columnsArgs.column.scope).toBe(availableScope);
-
-            expect(angular.element(columnsArgs.node).find('#availableHeader').length).toBe(1);
-        }));
-
-        it('should create and attach a new header', inject(function () {
-            //given
-            var columnsArgs = {
-                column: {
-                    id: '0002',
-                    tdpColMetadata: {},
-                },
-                node: angular.element('<div></div>')[0],
-            };
-
-            //when
-            var onHeaderCellRendered = gridMock.onHeaderCellRendered.subscribe.calls.argsFor(0)[0];
-            onHeaderCellRendered(null, columnsArgs);
-
-            //then
-            expect(columnsArgs.column.scope).toBeDefined();
-            expect(columnsArgs.column.header).toBeDefined();
-
-            expect(columnsArgs.column.header).not.toBe(availableHeader);
-            expect(columnsArgs.column.scope).not.toBe(availableScope);
-
-            expect(angular.element(columnsArgs.node).find('datagrid-header').length).toBe(1);
-        }));
-
-        it('should do nothing if column is from preview', inject(function () {
-            //given
-            var columnsArgs = {
-                column: {
-                    id: '0002',
-                    tdpColMetadata: {},
-                    preview: true,
-                },
-                node: angular.element('<div></div>')[0],
-            };
-
-            //when
-            var onHeaderCellRendered = gridMock.onHeaderCellRendered.subscribe.calls.argsFor(0)[0];
-            onHeaderCellRendered(null, columnsArgs);
-
-            //then
-            expect(columnsArgs.column.scope).not.toBeDefined();
-            expect(columnsArgs.column.header).not.toBeDefined();
-
-            expect(angular.element(columnsArgs.node).find('datagrid-header').length).toBe(0);
-        }));
-
-        it('should create and attach index column header', inject(function () {
-            //given
-            var columnsArgs = {
-                column: {
-                    id: 'tdpId',
-                },
-                node: angular.element('<div></div>')[0],
-            };
-
-            //when
-            var onHeaderCellRendered = gridMock.onHeaderCellRendered.subscribe.calls.argsFor(0)[0];
-            onHeaderCellRendered(null, columnsArgs);
-
-            //then
-            expect(columnsArgs.column.scope).toBeDefined();
-            expect(columnsArgs.column.header).toBeDefined();
-
-            expect(angular.element(columnsArgs.node).find('datagrid-index-header').length).toBe(1);
-        }));
-    });
-
-    describe('on column reorder event', function () {
-        beforeEach(inject(function (PlaygroundService) {
-            spyOn(PlaygroundService, 'appendStep');
-        }));
-
-        it('should call PlaygroundService move columns 2 steps', inject(function (DatagridColumnService, PlaygroundService) {
-            //given
-            var original = [
-                { id: '0000', tdpColMetadata: { id: '0000', name: 'beer' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-            var newCols = [
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-
-            //when
-            DatagridColumnService.columnsOrderChanged(newCols, original);
-
-            //then
-            const expectedParams = [{
-                action: 'reorder',
-                parameters: {
-                    selected_column: '0002',
-                    scope: 'dataset',
-                    column_id: '0000',
-                    column_name: 'beer',
-                    dataset_action_display_type: 'column',
-                }
-            }];
-
-            expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
-        }));
-
-        it('should find move columns 2 steps', inject(function (DatagridColumnService, PlaygroundService) {
-            //given
-            var original = [
-                { id: '0000', tdpColMetadata: { id: '0000', name: 'beer' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-            var newCols = [
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-
-            //when
-            DatagridColumnService.columnsOrderChanged(newCols, original);
-
-            //then
-            const expectedParams = [{
-                action: 'reorder',
-                parameters: {
-                    selected_column: '0002',
-                    scope: 'dataset',
-                    column_id: '0000',
-                    column_name: 'beer',
-                    dataset_action_display_type: 'column',
-                }
-            }];
-
-            expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
-        }));
-
-        it('should find move columns simple swap', inject(function (DatagridColumnService, PlaygroundService) {
-            //given
-            var original = [
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0001', tdpColMetadata: { id: '0001', name: 'beer' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-            var newCols = [
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-
-            //when
-            DatagridColumnService.columnsOrderChanged(newCols, original);
-
-            //then
-            const expectedParams = [{
-                action: 'reorder',
-                parameters: {
-                    selected_column: '0002',
-                    scope: 'dataset',
-                    column_id: '0001',
-                    column_name: 'beer',
-                    dataset_action_display_type: 'column',
-                }
-            }];
-
-            expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
-        }));
-
-        it('should find move columns 3 steps', inject(function (DatagridColumnService, PlaygroundService) {
-            //given
-            var original = [
-                { id: '0000', tdpColMetadata: { id: '0000', name: 'beer' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-            var newCols = [
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-            ];
-
-            //when
-            DatagridColumnService.columnsOrderChanged(newCols, original);
-
-            //then
-            const expectedParams = [{
-                action: 'reorder',
-                parameters: {
-                    selected_column: '0003',
-                    scope: 'dataset',
-                    column_id: '0000',
-                    column_name: 'beer',
-                    dataset_action_display_type: 'column',
-                }
-            }];
-
-            expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
-        }));
-
-        it('should find not moved', inject(function (DatagridColumnService, PlaygroundService) {
-            //given
-            var original = [
-                { id: '0000', tdpColMetadata: { id: '0000', name: 'beer' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-            var newCols = [
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-
-            //when
-            DatagridColumnService.columnsOrderChanged(newCols, original);
-
-            //then
-            expect(PlaygroundService.appendStep).not.toHaveBeenCalledWith();
-        }));
-
-        it('should find move columns 2 steps backward', inject(function (DatagridColumnService, PlaygroundService) {
-            //given
-            var original = [
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002', name: 'beer' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-            var newCols = [
-                { id: '0002', tdpColMetadata: { id: '0002', name: 'beer' } },
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0003', tdpColMetadata: { id: '0003' } },
-            ];
-
-            //when
-            DatagridColumnService.columnsOrderChanged(newCols, original);
-
-            //then
-            const expectedParams = [{
-                action: 'reorder',
-                parameters: {
-                    selected_column: '0000',
-                    scope: 'dataset',
-                    column_id: '0002',
-                    column_name: 'beer',
-                    dataset_action_display_type: 'column',
-                }
-            }];
-
-            expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
-        }));
-
-        it('should find move columns 2 steps backward in the middle', inject(function (DatagridColumnService, PlaygroundService) {
-            //given
-            var original = [
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0003', tdpColMetadata: { id: '0003', name: 'beer' } },
-                { id: '0004', tdpColMetadata: { id: '0004' } },
-            ];
-            var newCols = [
-                { id: '0000', tdpColMetadata: { id: '0000' } },
-                { id: '0003', tdpColMetadata: { id: '0003', name: 'beer' } },
-                { id: '0001', tdpColMetadata: { id: '0001' } },
-                { id: '0002', tdpColMetadata: { id: '0002' } },
-                { id: '0004', tdpColMetadata: { id: '0004' } },
-            ];
-
-            //when
-            DatagridColumnService.columnsOrderChanged(newCols, original);
-
-            //then
-            const expectedParams = [{
-                action: 'reorder',
-                parameters: {
-                    selected_column: '0001',
-                    scope: 'dataset',
-                    column_id: '0003',
-                    column_name: 'beer',
-                    dataset_action_display_type: 'column',
-                }
-            }];
-
-            expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
-        }));
-    });
+	let gridMock;
+	let columnsMetadata;
+
+	beforeEach(angular.mock.module('data-prep.datagrid'));
+
+	beforeEach(inject(() => {
+		columnsMetadata = [
+			{ id: '0000', name: 'col0', type: 'string' },
+			{ id: '0001', name: 'col1', type: 'integer' },
+			{ id: '0002', name: 'col2', type: 'string', domain: 'salary' },
+		];
+
+		gridMock = new SlickGridMock();
+	}));
+
+	describe('on creation', () => {
+		it('should add SlickGrid header destroy handler', inject((DatagridColumnService) => {
+			//given
+			spyOn(gridMock.onBeforeHeaderCellDestroy, 'subscribe').and.returnValue();
+
+			//when
+			DatagridColumnService.init(gridMock);
+
+			//then
+			expect(gridMock.onBeforeHeaderCellDestroy.subscribe).toHaveBeenCalled();
+		}));
+
+		it('should add SlickGrid header creation handler', inject((DatagridColumnService) => {
+			//given
+			spyOn(gridMock.onHeaderCellRendered, 'subscribe').and.returnValue();
+
+			//when
+			DatagridColumnService.init(gridMock);
+
+			//then
+			expect(gridMock.onHeaderCellRendered.subscribe).toHaveBeenCalled();
+		}));
+	});
+
+	describe('create columns', () => {
+		const headers = [
+			{
+				element: {
+					detach: () => {
+					},
+				},
+			},
+			{
+				element: {
+					detach: () => {
+					},
+				},
+			},
+			{
+				element: {
+					detach: () => {
+					},
+				},
+			},];
+		const formatter = () => {
+		};
+
+		beforeEach(inject((DatagridColumnService, DatagridStyleService) => {
+			DatagridColumnService.init(gridMock);
+			headers.forEach((header) => {
+				spyOn(header.element, 'detach').and.returnValue();
+			});
+
+			spyOn(DatagridStyleService, 'getColumnPreviewStyle').and.returnValue('');
+			spyOn(DatagridStyleService, 'columnFormatter').and.returnValue(formatter);
+		}));
+
+		it('should create new preview grid columns', inject((DatagridColumnService) => {
+			//when
+			const createdColumns = DatagridColumnService.createColumns(columnsMetadata, true, false);
+
+			//then
+			expect(createdColumns[0].id).toEqual('tdpId');
+			expect(createdColumns[0].field).toEqual('tdpId');
+			expect(createdColumns[0].name).toEqual('');
+			expect(createdColumns[0].resizable).toBeFalsy();
+			expect(createdColumns[0].selectable).toBeFalsy();
+			expect(createdColumns[0].formatter(1, 2, 3)).toEqual('<div class="index-cell">3</div>');
+			expect(createdColumns[0].maxWidth).toEqual(60);
+
+			expect(createdColumns[1].id).toEqual('0000');
+			expect(createdColumns[1].field).toEqual('0000');
+			expect(createdColumns[1].name).toEqual('<div class="grid-header ">   <div class="grid-header-title dropdown-button ng-binding">col0</div>   <div class="grid-header-type ng-binding">text</div></div><div class="quality-bar"><div class="record-unknown"></div></div>');
+			expect(createdColumns[1].formatter).toEqual(formatter);
+			expect(createdColumns[1].tdpColMetadata).toEqual({ id: '0000', name: 'col0', type: 'string' });
+
+			expect(createdColumns[2].id).toEqual('0001');
+			expect(createdColumns[2].field).toEqual('0001');
+			expect(createdColumns[2].name).toEqual('<div class="grid-header ">   <div class="grid-header-title dropdown-button ng-binding">col1</div>   <div class="grid-header-type ng-binding">integer</div></div><div class="quality-bar"><div class="record-unknown"></div></div>');
+			expect(createdColumns[2].formatter).toEqual(formatter);
+			expect(createdColumns[2].tdpColMetadata).toEqual({ id: '0001', name: 'col1', type: 'integer' });
+
+			expect(createdColumns[3].id).toEqual('0002');
+			expect(createdColumns[3].field).toEqual('0002');
+			expect(createdColumns[3].name).toEqual('<div class="grid-header ">   <div class="grid-header-title dropdown-button ng-binding">col2</div>   <div class="grid-header-type ng-binding">salary</div></div><div class="quality-bar"><div class="record-unknown"></div></div>');
+			expect(createdColumns[3].formatter).toEqual(formatter);
+			expect(createdColumns[3].tdpColMetadata).toEqual({
+				id: '0002',
+				name: 'col2',
+				type: 'string',
+				domain: 'salary',
+			});
+		}));
+
+		it('should create new grid columns', inject((DatagridColumnService) => {
+			//when
+			const createdColumns = DatagridColumnService.createColumns(columnsMetadata, false, false);
+
+			//then
+			expect(createdColumns[0].id).toEqual('tdpId');
+			expect(createdColumns[0].field).toEqual('tdpId');
+			expect(createdColumns[0].name).toEqual('');
+			expect(createdColumns[0].resizable).toBeFalsy();
+			expect(createdColumns[0].selectable).toBeFalsy();
+			expect(createdColumns[0].formatter(1, 2, 3)).toEqual('<div class="index-cell">3</div>');
+			expect(createdColumns[0].maxWidth).toEqual(60);
+
+			expect(createdColumns[1].id).toEqual('0000');
+			expect(createdColumns[1].field).toEqual('0000');
+			expect(createdColumns[1].name).toEqual('');
+			expect(createdColumns[1].formatter).toEqual(formatter);
+			expect(createdColumns[1].tdpColMetadata).toEqual({ id: '0000', name: 'col0', type: 'string' });
+
+			expect(createdColumns[2].id).toEqual('0001');
+			expect(createdColumns[2].field).toEqual('0001');
+			expect(createdColumns[2].name).toEqual('');
+			expect(createdColumns[2].formatter).toEqual(formatter);
+			expect(createdColumns[2].tdpColMetadata).toEqual({ id: '0001', name: 'col1', type: 'integer' });
+
+			expect(createdColumns[3].id).toEqual('0002');
+			expect(createdColumns[3].field).toEqual('0002');
+			expect(createdColumns[3].name).toEqual('');
+			expect(createdColumns[3].formatter).toEqual(formatter);
+			expect(createdColumns[3].tdpColMetadata).toEqual({
+				id: '0002',
+				name: 'col2',
+				type: 'string',
+				domain: 'salary',
+			});
+		}));
+	});
+
+	describe('on column header destroy event', () => {
+		let columnDef;
+
+		beforeEach(inject((DatagridColumnService) => {
+			spyOn(gridMock.onBeforeHeaderCellDestroy, 'subscribe').and.returnValue();
+
+			columnDef = {
+				header: {
+					remove: () => {
+					}, detach: () => {
+					},
+				},
+				scope: {
+					$destroy: () => {
+					},
+				},
+			};
+
+			spyOn(columnDef.header, 'detach').and.returnValue();
+			spyOn(columnDef.header, 'remove').and.returnValue();
+			spyOn(columnDef.scope, '$destroy').and.returnValue();
+
+			DatagridColumnService.init(gridMock);
+		}));
+
+		it('should do nothing when column is part of a preview', inject((DatagridColumnService) => {
+			//given
+			columnDef.preview = true;
+			const columnsArgs = {
+				id: '0001',
+				column: columnDef,
+			};
+			DatagridColumnService.renewAllColumns(true);
+
+			//when
+			const onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
+			onBeforeHeaderCellDestroy(null, columnsArgs);
+
+			//then
+			expect(columnDef.header.detach).not.toHaveBeenCalled();
+			expect(columnDef.header.remove).not.toHaveBeenCalled();
+			expect(columnDef.scope.$destroy).not.toHaveBeenCalled();
+		}));
+
+		it('should destroy header when renewAllFlag is set to true', inject((DatagridColumnService) => {
+			//given
+			columnDef.preview = false;
+			const columnsArgs = {
+				id: '0001',
+				column: columnDef,
+			};
+			DatagridColumnService.renewAllColumns(true);
+
+			//when
+			const onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
+			onBeforeHeaderCellDestroy(null, columnsArgs);
+
+			//then
+			expect(columnDef.header.detach).not.toHaveBeenCalled();
+			expect(columnDef.header.remove).toHaveBeenCalled();
+			expect(columnDef.scope.$destroy).toHaveBeenCalled();
+		}));
+
+		it('should detach header when renewAllFlag is set to false', inject((DatagridColumnService) => {
+			//given
+			columnDef.preview = false;
+			const columnsArgs = {
+				id: '0001',
+				column: columnDef,
+			};
+			DatagridColumnService.renewAllColumns(false);
+
+			//when
+			const onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
+			onBeforeHeaderCellDestroy(null, columnsArgs);
+
+			//then
+			expect(columnDef.header.detach).toHaveBeenCalled();
+			expect(columnDef.header.remove).not.toHaveBeenCalled();
+			expect(columnDef.scope.$destroy).not.toHaveBeenCalled();
+		}));
+
+		it('should NOT detach header for index column', inject((DatagridColumnService) => {
+			//given
+			columnDef.preview = false;
+			const columnsArgs = {
+				id: 'tdpId',
+				column: {
+					id: 'tdpId',
+					header: {
+						remove: () => {
+						}, detach: () => {
+						},
+					},
+					scope: {
+						$destroy: () => {
+						},
+					},
+				},
+			};
+			DatagridColumnService.renewAllColumns(false);
+
+			//when
+			const onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
+			onBeforeHeaderCellDestroy(null, columnsArgs);
+
+			//then
+			expect(columnDef.header.detach).not.toHaveBeenCalled();
+		}));
+	});
+
+	describe('on column header rendered event', () => {
+		let availableScope;
+		let availableHeader;
+
+		function saveHeader(id, scope, header) {
+			const columnsToDestroy = {
+				id: id,
+				scope: scope,
+				header: header,
+				preview: false,
+			};
+			const headerToDetach = {
+				column: columnsToDestroy,
+			};
+
+			//destroy to save header in the available headers
+			const onBeforeHeaderCellDestroy = gridMock.onBeforeHeaderCellDestroy.subscribe.calls.argsFor(0)[0];
+			onBeforeHeaderCellDestroy(null, headerToDetach);
+		}
+
+		beforeEach(inject((DatagridColumnService) => {
+			spyOn(gridMock.onBeforeHeaderCellDestroy, 'subscribe').and.returnValue();
+			spyOn(gridMock.onHeaderCellRendered, 'subscribe').and.returnValue();
+
+			DatagridColumnService.init(gridMock);
+
+			//save header in available headers list
+			availableScope = {
+				$destroy: () => {
+				}
+			};
+			availableHeader = angular.element('<div id="availableHeader"></div>');
+			saveHeader('0001', availableScope, availableHeader);
+		}));
+
+		it('should attach and update available header that has the same id', inject(() => {
+			//given
+			const columnsArgs = {
+				column: {
+					id: '0001',
+					tdpColMetadata: {},
+				},
+				node: angular.element('<div></div>')[0],
+			};
+
+			//when
+			const onHeaderCellRendered = gridMock.onHeaderCellRendered.subscribe.calls.argsFor(0)[0];
+			onHeaderCellRendered(null, columnsArgs);
+
+			//then
+			expect(availableScope.column).toBe(columnsArgs.column.tdpColMetadata);
+			expect(columnsArgs.column.header).toBe(availableHeader);
+			expect(columnsArgs.column.scope).toBe(availableScope);
+
+			expect(angular.element(columnsArgs.node).find('#availableHeader').length).toBe(1);
+		}));
+
+		it('should create and attach a new header', inject(() => {
+			//given
+			const columnsArgs = {
+				column: {
+					id: '0002',
+					tdpColMetadata: {},
+				},
+				node: angular.element('<div></div>')[0],
+			};
+
+			//when
+			const onHeaderCellRendered = gridMock.onHeaderCellRendered.subscribe.calls.argsFor(0)[0];
+			onHeaderCellRendered(null, columnsArgs);
+
+			//then
+			expect(columnsArgs.column.scope).toBeDefined();
+			expect(columnsArgs.column.header).toBeDefined();
+
+			expect(columnsArgs.column.header).not.toBe(availableHeader);
+			expect(columnsArgs.column.scope).not.toBe(availableScope);
+
+			expect(angular.element(columnsArgs.node).find('datagrid-header').length).toBe(1);
+		}));
+
+		it('should do nothing if column is from preview', inject(() => {
+			//given
+			const columnsArgs = {
+				column: {
+					id: '0002',
+					tdpColMetadata: {},
+					preview: true,
+				},
+				node: angular.element('<div></div>')[0],
+			};
+
+			//when
+			const onHeaderCellRendered = gridMock.onHeaderCellRendered.subscribe.calls.argsFor(0)[0];
+			onHeaderCellRendered(null, columnsArgs);
+
+			//then
+			expect(columnsArgs.column.scope).not.toBeDefined();
+			expect(columnsArgs.column.header).not.toBeDefined();
+
+			expect(angular.element(columnsArgs.node).find('datagrid-header').length).toBe(0);
+		}));
+
+		it('should create and attach index column header', inject(() => {
+			//given
+			const columnsArgs = {
+				column: {
+					id: 'tdpId',
+				},
+				node: angular.element('<div></div>')[0],
+			};
+
+			//when
+			const onHeaderCellRendered = gridMock.onHeaderCellRendered.subscribe.calls.argsFor(0)[0];
+			onHeaderCellRendered(null, columnsArgs);
+
+			//then
+			expect(columnsArgs.column.scope).toBeDefined();
+			expect(columnsArgs.column.header).toBeDefined();
+
+			expect(angular.element(columnsArgs.node).find('datagrid-index-header').length).toBe(1);
+		}));
+	});
+
+	describe('on column reorder event', () => {
+		beforeEach(inject((PlaygroundService) => {
+			spyOn(PlaygroundService, 'appendStep');
+		}));
+
+		it('should call PlaygroundService move columns 2 steps', inject((DatagridColumnService, PlaygroundService) => {
+			//given
+			const original = [
+				{ id: '0000', tdpColMetadata: { id: '0000', name: 'beer' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+			const newCols = [
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+
+			//when
+			DatagridColumnService.columnsOrderChanged(newCols, original);
+
+			//then
+			const expectedParams = [{
+				action: 'reorder',
+				parameters: {
+					selected_column: '0002',
+					scope: 'dataset',
+					column_id: '0000',
+					column_name: 'beer',
+					dataset_action_display_type: 'column',
+				}
+			}];
+
+			expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
+		}));
+
+		it('should find move columns 2 steps', inject((DatagridColumnService, PlaygroundService) => {
+			//given
+			const original = [
+				{ id: '0000', tdpColMetadata: { id: '0000', name: 'beer' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+			const newCols = [
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+
+			//when
+			DatagridColumnService.columnsOrderChanged(newCols, original);
+
+			//then
+			const expectedParams = [{
+				action: 'reorder',
+				parameters: {
+					selected_column: '0002',
+					scope: 'dataset',
+					column_id: '0000',
+					column_name: 'beer',
+					dataset_action_display_type: 'column',
+				}
+			}];
+
+			expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
+		}));
+
+		it('should find move columns simple swap', inject((DatagridColumnService, PlaygroundService) => {
+			//given
+			const original = [
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0001', tdpColMetadata: { id: '0001', name: 'beer' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+			const newCols = [
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+
+			//when
+			DatagridColumnService.columnsOrderChanged(newCols, original);
+
+			//then
+			const expectedParams = [{
+				action: 'reorder',
+				parameters: {
+					selected_column: '0002',
+					scope: 'dataset',
+					column_id: '0001',
+					column_name: 'beer',
+					dataset_action_display_type: 'column',
+				}
+			}];
+
+			expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
+		}));
+
+		it('should find move columns 3 steps', inject((DatagridColumnService, PlaygroundService) => {
+			//given
+			const original = [
+				{ id: '0000', tdpColMetadata: { id: '0000', name: 'beer' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+			const newCols = [
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+			];
+
+			//when
+			DatagridColumnService.columnsOrderChanged(newCols, original);
+
+			//then
+			const expectedParams = [{
+				action: 'reorder',
+				parameters: {
+					selected_column: '0003',
+					scope: 'dataset',
+					column_id: '0000',
+					column_name: 'beer',
+					dataset_action_display_type: 'column',
+				}
+			}];
+
+			expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
+		}));
+
+		it('should find not moved', inject((DatagridColumnService, PlaygroundService) => {
+			//given
+			const original = [
+				{ id: '0000', tdpColMetadata: { id: '0000', name: 'beer' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+			const newCols = [
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+
+			//when
+			DatagridColumnService.columnsOrderChanged(newCols, original);
+
+			//then
+			expect(PlaygroundService.appendStep).not.toHaveBeenCalledWith();
+		}));
+
+		it('should find move columns 2 steps backward', inject((DatagridColumnService, PlaygroundService) => {
+			//given
+			const original = [
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002', name: 'beer' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+			const newCols = [
+				{ id: '0002', tdpColMetadata: { id: '0002', name: 'beer' } },
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0003', tdpColMetadata: { id: '0003' } },
+			];
+
+			//when
+			DatagridColumnService.columnsOrderChanged(newCols, original);
+
+			//then
+			const expectedParams = [{
+				action: 'reorder',
+				parameters: {
+					selected_column: '0000',
+					scope: 'dataset',
+					column_id: '0002',
+					column_name: 'beer',
+					dataset_action_display_type: 'column',
+				}
+			}];
+
+			expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
+		}));
+
+		it('should find move columns 2 steps backward in the middle', inject((DatagridColumnService, PlaygroundService) => {
+			//given
+			const original = [
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0003', tdpColMetadata: { id: '0003', name: 'beer' } },
+				{ id: '0004', tdpColMetadata: { id: '0004' } },
+			];
+			const newCols = [
+				{ id: '0000', tdpColMetadata: { id: '0000' } },
+				{ id: '0003', tdpColMetadata: { id: '0003', name: 'beer' } },
+				{ id: '0001', tdpColMetadata: { id: '0001' } },
+				{ id: '0002', tdpColMetadata: { id: '0002' } },
+				{ id: '0004', tdpColMetadata: { id: '0004' } },
+			];
+
+			//when
+			DatagridColumnService.columnsOrderChanged(newCols, original);
+
+			//then
+			const expectedParams = [{
+				action: 'reorder',
+				parameters: {
+					selected_column: '0001',
+					scope: 'dataset',
+					column_id: '0003',
+					column_name: 'beer',
+					dataset_action_display_type: 'column',
+				}
+			}];
+
+			expect(PlaygroundService.appendStep).toHaveBeenCalledWith(expectedParams);
+		}));
+	});
 });

--- a/dataprep-webapp/src/app/components/datagrid/services/datagrid-style-service.js
+++ b/dataprep-webapp/src/app/components/datagrid/services/datagrid-style-service.js
@@ -30,62 +30,66 @@ export default class DatagridStyleService {
 		this.TextFormatService = TextFormatService;
 	}
 
-    /**
-     * @ngdoc method
-     * @name resetCellStyles
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Reset the cells css
-     */
+	/**
+	 * @ngdoc method
+	 * @name resetCellStyles
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Reset the cells css
+	 */
 	resetHighlightStyles() {
 		this.hightlightedColumnId = null;
 		this.hightlightedContent = null;
 	}
 
-    /**
-     * @ngdoc method
-     * @name resetCellStyles
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Reset the cells css
-     */
+	/**
+	 * @ngdoc method
+	 * @name resetCellStyles
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Reset the cells css
+	 */
 	resetCellStyles() {
 		this.grid.resetActiveCell();
 		this.resetHighlightStyles();
 	}
 
-    /**
-     * @ngdoc method
-     * @name addClass
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Add a css class to a column
-     * @param {object} column The target column
-     * @param {string} newClass The class to add
-     */
+	/**
+	 * @ngdoc method
+	 * @name addClass
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Add a css class to a column
+	 * @param {object} column The target column
+	 * @param {string} newClass The class to add
+	 */
 	_addClass(column, newClass) {
 		column.cssClass = (column.cssClass || '') + ' ' + newClass;
 	}
 
-    /**
-     * @ngdoc method
-     * @name updateSelectionsClass
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Add 'selected' class if the column is the selected one
-     * @param {object} column The target column
-     * @param {array} selectedCols The selected columns
-     */
+	/**
+	 * @ngdoc method
+	 * @name updateSelectionsClass
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Add 'selected' class if the column is the selected one
+	 * @param {object} column The target column
+	 * @param {array} selectedCols The selected columns
+	 */
 	updateSelectionsClass(column, selectedCols) {
 		if ((selectedCols.length === 1 && column.id === selectedCols[0].id) ||
 			(selectedCols.length > 1 && _.find(selectedCols, { id: column.id }))) {
 			this._addClass(column, 'selected');
+			column.headerCssClass = 'selected';
+		}
+		else {
+			column.headerCssClass = null;
 		}
 	}
 
-    /**
-     * @ngdoc method
-     * @name updateNumbersClass
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Add the 'number' class to the column if its type is a number type
-     * @param {object} column the target column
-     */
+	/**
+	 * @ngdoc method
+	 * @name updateNumbersClass
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Add the 'number' class to the column if its type is a number type
+	 * @param {object} column the target column
+	 */
 	updateNumbersClass(column) {
 		const simplifiedType = this.ConverterService.simplifyType(column.tdpColMetadata.type);
 		if (simplifiedType === 'integer' || simplifiedType === 'decimal') {
@@ -93,15 +97,16 @@ export default class DatagridStyleService {
 		}
 	}
 
-    /**
-     * @ngdoc method
-     * @name updateColumnsClass
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Set style classes on columns depending on its state (type, selection, ...)
-     * @param {array} selectedCols The grid selected columns
-     */
+	/**
+	 * @ngdoc method
+	 * @name updateColumnsClass
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Set style classes on columns depending on its state (type, selection, ...)
+	 * @param {array} selectedCols The grid selected columns
+	 */
 	updateColumnsClass(selectedCols) {
-		_.forEach(this.grid.getColumns(), (column) => {
+		const columns = this.grid.getColumns();
+		columns.forEach((column) => {
 			if (column.id === 'tdpId') {
 				column.cssClass = 'index-column';
 			}
@@ -111,25 +116,26 @@ export default class DatagridStyleService {
 				this.updateNumbersClass(column);
 			}
 		});
+		this.grid.setColumns(columns);
 	}
 
-    /**
-     * @ngdoc method
-     * @name columnFormatter
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Value formatter used in SlickGrid column definition. This is called to get a cell formatted value
-     * @param {object} col The column to format
-     */
+	/**
+	 * @ngdoc method
+	 * @name columnFormatter
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Value formatter used in SlickGrid column definition. This is called to get a cell formatted value
+	 * @param {object} col The column to format
+	 */
 	columnFormatter(col) {
 		function formatter(row, cell, value, columnDef, dataContext) {
 			let classNames = (col.id === this.hightlightedColumnId) && (value === this.hightlightedContent) ?
-                'highlight' :
-                '';
+				'highlight' :
+				'';
 
-            // hidden characters need to be shown
+			// hidden characters need to be shown
 			const returnStr = this.TextFormatService.adaptToGridConstraints(value);
 
-            // entire row modification preview
+			// entire row modification preview
 			switch (dataContext.__tdpRowDiff) { // eslint-disable-line no-underscore-dangle
 			case 'delete':
 				classNames += ' cellDeletedValue';
@@ -139,7 +145,7 @@ export default class DatagridStyleService {
 				break;
 			}
 
-            // cell modification preview
+			// cell modification preview
 			if (dataContext.__tdpDiff && dataContext.__tdpDiff[columnDef.id]) { // eslint-disable-line no-underscore-dangle
 				switch (dataContext.__tdpDiff[columnDef.id]) { // eslint-disable-line no-underscore-dangle
 				case 'update':
@@ -157,8 +163,8 @@ export default class DatagridStyleService {
 			const formattedValue = `<div class="${classNames}">${returnStr}</div>`;
 			const isInvalid = dataContext.__tdpInvalid && dataContext.__tdpInvalid.indexOf(columnDef.id) > -1;
 			const indicator = isInvalid ?
-                '<div title="Invalid Value" class="red-rect"></div>' :
-                '<div class="invisible-rect"></div>';
+				'<div title="Invalid Value" class="red-rect"></div>' :
+				'<div class="invisible-rect"></div>';
 
 			return formattedValue + indicator;
 		}
@@ -166,13 +172,13 @@ export default class DatagridStyleService {
 		return formatter.bind(this);
 	}
 
-    /**
-     * @ngdoc method
-     * @name getColumnPreviewStyle
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Get the column header preview style
-     * @param {object} col The column metadata
-     */
+	/**
+	 * @ngdoc method
+	 * @name getColumnPreviewStyle
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Get the column header preview style
+	 * @param {object} col The column metadata
+	 */
 	getColumnPreviewStyle(col) {
 		switch (col.__tdpColumnDiff) { // eslint-disable-line no-underscore-dangle
 		case 'new':
@@ -186,26 +192,26 @@ export default class DatagridStyleService {
 		}
 	}
 
-    /**
-     * @ngdoc method
-     * @name resetStyles
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @description Reset the cell styles and update the columns style
-     * @param {array} selectedCols The selected columns
-     */
+	/**
+	 * @ngdoc method
+	 * @name resetStyles
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @description Reset the cell styles and update the columns style
+	 * @param {array} selectedCols The selected columns
+	 */
 	resetStyles(selectedCols) {
 		this.resetCellStyles();
 		this.updateColumnsClass(selectedCols);
 	}
 
-    /**
-     * @ngdoc method
-     * @name highlightCellsContaining
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @param {String} colId The column id
-     * @param {String} content The value to highlight
-     * @description Highlight the cells in column that contains the same value as content
-     */
+	/**
+	 * @ngdoc method
+	 * @name highlightCellsContaining
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @param {String} colId The column id
+	 * @param {String} content The value to highlight
+	 * @description Highlight the cells in column that contains the same value as content
+	 */
 	highlightCellsContaining(colId, content) {
 		this.hightlightedColumnId = colId;
 		this.hightlightedContent = content;
@@ -224,13 +230,13 @@ export default class DatagridStyleService {
 		}
 	}
 
-    /**
-     * @ngdoc method
-     * @name init
-     * @methodOf data-prep.datagrid.service:DatagridStyleService
-     * @param {object} newGrid The new grid
-     * @description Initialize the grid and attach the style listeners
-     */
+	/**
+	 * @ngdoc method
+	 * @name init
+	 * @methodOf data-prep.datagrid.service:DatagridStyleService
+	 * @param {object} newGrid The new grid
+	 * @description Initialize the grid and attach the style listeners
+	 */
 	init(newGrid) {
 		this.grid = newGrid;
 	}

--- a/dataprep-webapp/src/app/components/datagrid/services/datagrid-style-service.spec.js
+++ b/dataprep-webapp/src/app/components/datagrid/services/datagrid-style-service.spec.js
@@ -14,461 +14,476 @@
 import SlickGridMock from '../../../../mocks/SlickGrid.mock';
 
 describe('Datagrid style service', () => {
-    'use strict';
-
-    var gridMock;
-    var gridColumns;
-    var stateMock;
-
-    function assertColumnsHasNoStyles() {
-        gridColumns.forEach(function (column) {
-            expect(column.cssClass).toBeFalsy();
-        });
-    }
-
-    beforeEach(angular.mock.module('data-prep.datagrid', ($provide) => {
-        stateMock = { playground: { grid: {} } };
-        $provide.constant('state', stateMock);
-    }));
-
-    beforeEach(() => {
-        gridColumns = [
-            { id: '0000', field: 'col0', tdpColMetadata: { id: '0000', name: 'col0', type: 'string' } },
-            { id: '0001', field: 'col1', tdpColMetadata: { id: '0001', name: 'col1', type: 'integer' } },
-            { id: '0002', field: 'col2', tdpColMetadata: { id: '0002', name: 'col2', type: 'string' } },
-            { id: '0003', field: 'col3', tdpColMetadata: { id: '0003', name: 'col3', type: 'string' } },
-            { id: '0004', field: 'col4', tdpColMetadata: { id: '0004', name: 'col4', type: 'string' } },
-            { id: 'tdpId', field: 'tdpId', tdpColMetadata: { id: 'tdpId', name: '#' } },
-        ];
-
-        gridMock = new SlickGridMock();
-        gridMock.initColumnsMock(gridColumns);
-
-        spyOn(gridMock.onClick, 'subscribe').and.returnValue();
-        spyOn(gridMock.onHeaderClick, 'subscribe').and.returnValue();
-        spyOn(gridMock.onHeaderContextMenu, 'subscribe').and.returnValue();
-        spyOn(gridMock.onActiveCellChanged, 'subscribe').and.returnValue();
-        spyOn(gridMock, 'resetActiveCell').and.returnValue();
-        spyOn(gridMock, 'invalidate').and.returnValue();
-    });
-
-    describe('reset cell styles', () => {
-        it('should reset cell styles configuration', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            DatagridStyleService.hightlightedColumnId = '0000';
-            DatagridStyleService.hightlightedContent = 'toto';
-
-            //when
-            DatagridStyleService.resetCellStyles();
-
-            //then
-            expect(DatagridStyleService.hightlightedColumnId).toBeFalsy();
-            expect(DatagridStyleService.hightlightedContent).toBeFalsy();
-        }));
-
-        it('should reset grid active cell', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-
-            //when
-            DatagridStyleService.resetCellStyles();
-
-            //then
-            expect(gridMock.resetActiveCell).toHaveBeenCalled();
-        }));
-    });
-
-    describe('highlight cells', () => {
-        it('should set highlight configuration', inject((DatagridStyleService) => {
-            //given
-            var colId = '0000';
-            var content = 'toto';
-
-            DatagridStyleService.init(gridMock);
-            expect(DatagridStyleService.hightlightedColumnId).toBeFalsy();
-            expect(DatagridStyleService.hightlightedContent).toBeFalsy();
-
-            //when
-            DatagridStyleService.highlightCellsContaining(colId, content);
-
-            //then
-            expect(DatagridStyleService.hightlightedColumnId).toBe(colId);
-            expect(DatagridStyleService.hightlightedContent).toBe(content);
-        }));
-
-        it('should invalidate all rows when there is no cell editor', inject((DatagridStyleService) => {
-            //given
-            var colId = '0000';
-            var content = 'toto';
-
-            gridMock.initCellEditorMock(null);
-            DatagridStyleService.init(gridMock);
-
-            expect(gridMock.invalidate).not.toHaveBeenCalled();
-
-            //when
-            DatagridStyleService.highlightCellsContaining(colId, content);
-
-            //then
-            expect(gridMock.invalidate).toHaveBeenCalled();
-        }));
-
-        it('should invalidate all rows except the currently edited one', inject((DatagridStyleService) => {
-            //given
-            var colId = '0000';
-            var content = 'toto';
-
-            spyOn(gridMock, 'invalidateRows');
-            spyOn(gridMock, 'render');
-
-            gridMock.initCellEditorMock({}); //truthy editor
-            gridMock.initRenderedRangeMock({ top: 20, bottom: 30 });
-            gridMock.initActiveCellMock({ row: 25 });
-
-            DatagridStyleService.init(gridMock);
-
-            expect(gridMock.invalidateRows).not.toHaveBeenCalled();
-            expect(gridMock.render).not.toHaveBeenCalled();
-
-            //when
-            DatagridStyleService.highlightCellsContaining(colId, content);
-
-            //then
-            expect(gridMock.invalidateRows).toHaveBeenCalledWith([20, 21, 22, 23, 24, /*missing 25*/ 26, 27, 28, 29, 30]);
-            expect(gridMock.render).toHaveBeenCalled();
-        }));
-    });
-
-    describe('update column styles', () => {
-        it('should set "selected" class on active cell column when this is NOT a preview', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            assertColumnsHasNoStyles();
-
-            //when
-            DatagridStyleService.updateColumnsClass([gridColumns[1]]);
-
-            //then
-            expect(gridColumns[0].cssClass).toBeFalsy();
-            expect(gridColumns[1].cssClass.indexOf('selected') > -1).toBe(true);
-            expect(gridColumns[2].cssClass).toBeFalsy();
-            expect(gridColumns[3].cssClass).toBeFalsy();
-            expect(gridColumns[4].cssClass).toBeFalsy();
-            expect(gridColumns[5].cssClass).toBe('index-column');
-        }));
-
-        it('should set "number" class on number column', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            assertColumnsHasNoStyles();
-
-            //when
-            DatagridStyleService.updateColumnsClass([]);
-
-            //then
-            expect(gridColumns[0].cssClass).toBeFalsy();
-            expect(gridColumns[1].cssClass.indexOf('number') > -1).toBe(true);
-            expect(gridColumns[2].cssClass).toBeFalsy();
-            expect(gridColumns[3].cssClass).toBeFalsy();
-            expect(gridColumns[4].cssClass).toBeFalsy();
-            expect(gridColumns[5].cssClass).toBe('index-column');
-        }));
-    });
-
-    describe('reset style', () => {
-        it('should reset cell styles', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            DatagridStyleService.hightlightedColumnId = '0000';
-            DatagridStyleService.hightlightedContent = 'toto';
-
-            //when
-            DatagridStyleService.resetStyles([gridColumns[1]]);
-
-            //then
-            expect(DatagridStyleService.hightlightedColumnId).toBeFalsy();
-            expect(DatagridStyleService.hightlightedContent).toBeFalsy();
-        }));
-
-        it('should update column styles', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            assertColumnsHasNoStyles();
-
-            //when
-            DatagridStyleService.resetStyles([gridColumns[1]]);
-
-            //then
-            expect(gridColumns[0].cssClass).toBeFalsy();
-            expect(gridColumns[1].cssClass.indexOf('selected') > -1).toBe(true);
-            expect(gridColumns[1].cssClass.indexOf('number') > -1).toBe(true);
-            expect(gridColumns[2].cssClass).toBeFalsy();
-            expect(gridColumns[3].cssClass).toBeFalsy();
-            expect(gridColumns[4].cssClass).toBeFalsy();
-            expect(gridColumns[5].cssClass).toBe('index-column');
-        }));
-    });
-
-    describe('column formatter', () => {
-        it('should adapt value into html with leading/trailing spaces management', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            var col = { quality: { invalidValues: [] } };
-            var value = '  my value     ';
-            var columnDef = gridColumns[1];
-            var dataContext = {};
-
-            //when
-            var formatter = DatagridStyleService.columnFormatter(col);
-            var result = formatter(null, null, value, columnDef, dataContext);
-
-            //then
-            expect(result.indexOf('<span class="hiddenChars">  </span>my value<span class="hiddenChars">     </span>') > 0).toBe(true);
-        }));
-
-        it('should adapt value into html on empty cell', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            var col = { quality: { invalidValues: [] } };
-            var value = '';
-            var columnDef = gridColumns[1];
-
-            //when
-            var formatter = DatagridStyleService.columnFormatter(col);
-            var result = formatter(null, null, value, columnDef, {});
-
-            //then
-            expect(result.indexOf('<div class=""></div>')).toBe(0);
-        }));
-
-        describe('indicator', () => {
-            it('should add invisible rectangle on valid value', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                var col = { quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = {};
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result.indexOf('<div class="invisible-rect"></div>') > 0).toBe(true);
-            }));
-
-            it('should add red rectangle on invalid value', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                var col = {};
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = {__tdpInvalid: gridColumns[1].id};
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result.indexOf('<div title="Invalid Value" class="red-rect"></div>') > 0).toBe(true);
-            }));
-        });
-
-        describe('new', () => {
-            it('should add "new" class on a new row', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                var col = { quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = { __tdpRowDiff: 'new' };
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result).toBe('<div class=" cellNewValue">my value</div><div class="invisible-rect"></div>');
-            }));
-
-            it('should add "new" class on a new cell', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                var col = { quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = { __tdpDiff: { '0001': 'new' } };
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result).toBe('<div class=" cellNewValue">my value</div><div class="invisible-rect"></div>');
-            }));
-        });
-
-        describe('update', () => {
-            it('should add "update" class on an updated cell', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                var col = { quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = { __tdpDiff: { '0001': 'update' } };
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result).toBe('<div class=" cellUpdateValue">my value</div><div class="invisible-rect"></div>');
-            }));
-        });
-
-        describe('deleted', () => {
-            it('should add "deleted" class on deleted row', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                var col = { quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = { __tdpRowDiff: 'delete' };
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result).toBe('<div class=" cellDeletedValue">my value</div><div class="invisible-rect"></div>');
-            }));
-
-            it('should add "delete" class on a deleted cell', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                var col = { quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = { __tdpDiff: { '0001': 'delete' } };
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result).toBe('<div class=" cellDeletedValue">my value</div><div class="invisible-rect"></div>');
-            }));
-        });
-
-        describe('highlight', () => {
-            it('should add "highlight" class', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                DatagridStyleService.hightlightedColumnId = '0001';
-                DatagridStyleService.hightlightedContent = 'my value';
-
-                var col = { id: '0001', quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = {};
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result).toBe('<div class="highlight">my value</div><div class="invisible-rect"></div>');
-            }));
-
-            it('should NOT add "highlight" class if the column is not the target', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                DatagridStyleService.hightlightedColumnId = '0000';
-                DatagridStyleService.hightlightedContent = 'my value';
-
-                var col = { id: '0001', quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = {};
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result).toBe('<div class="">my value</div><div class="invisible-rect"></div>');
-            }));
-
-            it('should NOT add "highlight" class if content does not match', inject((DatagridStyleService) => {
-                //given
-                DatagridStyleService.init(gridMock);
-                DatagridStyleService.hightlightedColumnId = '0001';
-                DatagridStyleService.hightlightedContent = 'my specific value';
-
-                var col = { id: '0001', quality: { invalidValues: [] } };
-                var value = 'my value';
-                var columnDef = gridColumns[1];
-                var dataContext = {};
-
-                //when
-                var formatter = DatagridStyleService.columnFormatter(col);
-                var result = formatter(null, null, value, columnDef, dataContext);
-
-                //then
-                expect(result).toBe('<div class="">my value</div><div class="invisible-rect"></div>');
-            }));
-        });
-    });
-
-    describe('column preview style', () => {
-        it('should return "new" column style', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            var col = { __tdpColumnDiff: 'new' };
-
-            //when
-            var diffClass = DatagridStyleService.getColumnPreviewStyle(col);
-
-            //then
-            expect(diffClass).toBe('newColumn');
-        }));
-
-        it('should return "deleted" column style', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            var col = { __tdpColumnDiff: 'delete' };
-
-            //when
-            var diffClass = DatagridStyleService.getColumnPreviewStyle(col);
-
-            //then
-            expect(diffClass).toBe('deletedColumn');
-        }));
-
-        it('should return "updated" column style', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            var col = { __tdpColumnDiff: 'update' };
-
-            //when
-            var diffClass = DatagridStyleService.getColumnPreviewStyle(col);
-
-            //then
-            expect(diffClass).toBe('updatedColumn');
-        }));
-
-        it('should return empty string on no change diff', inject((DatagridStyleService) => {
-            //given
-            DatagridStyleService.init(gridMock);
-            var col = {};
-
-            //when
-            var diffClass = DatagridStyleService.getColumnPreviewStyle(col);
-
-            //then
-            expect(diffClass).toBe('');
-        }));
-    });
+	let gridMock;
+	let gridColumns;
+	let stateMock;
+
+	function assertColumnsHasNoStyles() {
+		gridColumns.forEach((column) => {
+			expect(column.cssClass).toBeFalsy();
+		});
+	}
+
+	beforeEach(angular.mock.module('data-prep.datagrid', ($provide) => {
+		stateMock = { playground: { grid: {} } };
+		$provide.constant('state', stateMock);
+	}));
+
+	beforeEach(() => {
+		gridColumns = [
+			{ id: '0000', field: 'col0', tdpColMetadata: { id: '0000', name: 'col0', type: 'string' } },
+			{ id: '0001', field: 'col1', tdpColMetadata: { id: '0001', name: 'col1', type: 'integer' } },
+			{ id: '0002', field: 'col2', tdpColMetadata: { id: '0002', name: 'col2', type: 'string' } },
+			{ id: '0003', field: 'col3', tdpColMetadata: { id: '0003', name: 'col3', type: 'string' } },
+			{ id: '0004', field: 'col4', tdpColMetadata: { id: '0004', name: 'col4', type: 'string' } },
+			{ id: 'tdpId', field: 'tdpId', tdpColMetadata: { id: 'tdpId', name: '#' } },
+		];
+
+		gridMock = new SlickGridMock();
+		gridMock.initColumnsMock(gridColumns);
+
+		spyOn(gridMock.onClick, 'subscribe').and.returnValue();
+		spyOn(gridMock.onHeaderClick, 'subscribe').and.returnValue();
+		spyOn(gridMock.onHeaderContextMenu, 'subscribe').and.returnValue();
+		spyOn(gridMock.onActiveCellChanged, 'subscribe').and.returnValue();
+		spyOn(gridMock, 'resetActiveCell').and.returnValue();
+		spyOn(gridMock, 'invalidate').and.returnValue();
+	});
+
+	describe('reset cell styles', () => {
+		it('should reset cell styles configuration', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			DatagridStyleService.hightlightedColumnId = '0000';
+			DatagridStyleService.hightlightedContent = 'toto';
+
+			//when
+			DatagridStyleService.resetCellStyles();
+
+			//then
+			expect(DatagridStyleService.hightlightedColumnId).toBeFalsy();
+			expect(DatagridStyleService.hightlightedContent).toBeFalsy();
+		}));
+
+		it('should reset grid active cell', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+
+			//when
+			DatagridStyleService.resetCellStyles();
+
+			//then
+			expect(gridMock.resetActiveCell).toHaveBeenCalled();
+		}));
+	});
+
+	describe('highlight cells', () => {
+		it('should set highlight configuration', inject((DatagridStyleService) => {
+			//given
+			const colId = '0000';
+			const content = 'toto';
+
+			DatagridStyleService.init(gridMock);
+			expect(DatagridStyleService.hightlightedColumnId).toBeFalsy();
+			expect(DatagridStyleService.hightlightedContent).toBeFalsy();
+
+			//when
+			DatagridStyleService.highlightCellsContaining(colId, content);
+
+			//then
+			expect(DatagridStyleService.hightlightedColumnId).toBe(colId);
+			expect(DatagridStyleService.hightlightedContent).toBe(content);
+		}));
+
+		it('should invalidate all rows when there is no cell editor', inject((DatagridStyleService) => {
+			//given
+			const colId = '0000';
+			const content = 'toto';
+
+			gridMock.initCellEditorMock(null);
+			DatagridStyleService.init(gridMock);
+
+			expect(gridMock.invalidate).not.toHaveBeenCalled();
+
+			//when
+			DatagridStyleService.highlightCellsContaining(colId, content);
+
+			//then
+			expect(gridMock.invalidate).toHaveBeenCalled();
+		}));
+
+		it('should invalidate all rows except the currently edited one', inject((DatagridStyleService) => {
+			//given
+			const colId = '0000';
+			const content = 'toto';
+
+			spyOn(gridMock, 'invalidateRows');
+			spyOn(gridMock, 'render');
+
+			gridMock.initCellEditorMock({}); //truthy editor
+			gridMock.initRenderedRangeMock({ top: 20, bottom: 30 });
+			gridMock.initActiveCellMock({ row: 25 });
+
+			DatagridStyleService.init(gridMock);
+
+			expect(gridMock.invalidateRows).not.toHaveBeenCalled();
+			expect(gridMock.render).not.toHaveBeenCalled();
+
+			//when
+			DatagridStyleService.highlightCellsContaining(colId, content);
+
+			//then
+			expect(gridMock.invalidateRows).toHaveBeenCalledWith([20, 21, 22, 23, 24, /*missing 25*/ 26, 27, 28, 29, 30]);
+			expect(gridMock.render).toHaveBeenCalled();
+		}));
+	});
+
+	describe('update column styles', () => {
+		it('should set "selected" class on active column header', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			assertColumnsHasNoStyles();
+
+			//when
+			DatagridStyleService.updateColumnsClass([gridColumns[1]]);
+
+			//then
+			expect(gridColumns[0].headerCssClass).toBeFalsy();
+			expect(gridColumns[1].headerCssClass).toBe('selected');
+			expect(gridColumns[2].headerCssClass).toBeFalsy();
+			expect(gridColumns[3].headerCssClass).toBeFalsy();
+			expect(gridColumns[4].headerCssClass).toBeFalsy();
+			expect(gridColumns[5].headerCssClass).toBeFalsy();
+		}));
+
+		it('should set "selected" class on active cell column when this is NOT a preview', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			assertColumnsHasNoStyles();
+
+			//when
+			DatagridStyleService.updateColumnsClass([gridColumns[1]]);
+
+			//then
+			expect(gridColumns[0].cssClass).toBeFalsy();
+			expect(gridColumns[1].cssClass.indexOf('selected') > -1).toBe(true);
+			expect(gridColumns[2].cssClass).toBeFalsy();
+			expect(gridColumns[3].cssClass).toBeFalsy();
+			expect(gridColumns[4].cssClass).toBeFalsy();
+			expect(gridColumns[5].cssClass).toBe('index-column');
+		}));
+
+		it('should set "number" class on number column', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			assertColumnsHasNoStyles();
+
+			//when
+			DatagridStyleService.updateColumnsClass([]);
+
+			//then
+			expect(gridColumns[0].cssClass).toBeFalsy();
+			expect(gridColumns[1].cssClass.indexOf('number') > -1).toBe(true);
+			expect(gridColumns[2].cssClass).toBeFalsy();
+			expect(gridColumns[3].cssClass).toBeFalsy();
+			expect(gridColumns[4].cssClass).toBeFalsy();
+			expect(gridColumns[5].cssClass).toBe('index-column');
+		}));
+	});
+
+	describe('reset style', () => {
+		it('should reset cell styles', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			DatagridStyleService.hightlightedColumnId = '0000';
+			DatagridStyleService.hightlightedContent = 'toto';
+
+			//when
+			DatagridStyleService.resetStyles([gridColumns[1]]);
+
+			//then
+			expect(DatagridStyleService.hightlightedColumnId).toBeFalsy();
+			expect(DatagridStyleService.hightlightedContent).toBeFalsy();
+		}));
+
+		it('should update column styles', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			assertColumnsHasNoStyles();
+
+			//when
+			DatagridStyleService.resetStyles([gridColumns[1]]);
+
+			//then
+			expect(gridColumns[0].cssClass).toBeFalsy();
+			expect(gridColumns[1].cssClass.indexOf('selected') > -1).toBe(true);
+			expect(gridColumns[1].cssClass.indexOf('number') > -1).toBe(true);
+			expect(gridColumns[2].cssClass).toBeFalsy();
+			expect(gridColumns[3].cssClass).toBeFalsy();
+			expect(gridColumns[4].cssClass).toBeFalsy();
+			expect(gridColumns[5].cssClass).toBe('index-column');
+		}));
+	});
+
+	describe('column formatter', () => {
+		it('should adapt value into html with leading/trailing spaces management', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			const col = { quality: { invalidValues: [] } };
+			const value = '  my value     ';
+			const columnDef = gridColumns[1];
+			const dataContext = {};
+
+			//when
+			const formatter = DatagridStyleService.columnFormatter(col);
+			const result = formatter(null, null, value, columnDef, dataContext);
+
+			//then
+			expect(result.indexOf('<span class="hiddenChars">  </span>my value<span class="hiddenChars">     </span>') > 0).toBe(true);
+		}));
+
+		it('should adapt value into html on empty cell', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			const col = { quality: { invalidValues: [] } };
+			const value = '';
+			const columnDef = gridColumns[1];
+
+			//when
+			const formatter = DatagridStyleService.columnFormatter(col);
+			const result = formatter(null, null, value, columnDef, {});
+
+			//then
+			expect(result.indexOf('<div class=""></div>')).toBe(0);
+		}));
+
+		describe('indicator', () => {
+			it('should add invisible rectangle on valid value', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				const col = { quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = {};
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result.indexOf('<div class="invisible-rect"></div>') > 0).toBe(true);
+			}));
+
+			it('should add red rectangle on invalid value', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				const col = {};
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = { __tdpInvalid: gridColumns[1].id };
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result.indexOf('<div title="Invalid Value" class="red-rect"></div>') > 0).toBe(true);
+			}));
+		});
+
+		describe('new', () => {
+			it('should add "new" class on a new row', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				const col = { quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = { __tdpRowDiff: 'new' };
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result).toBe('<div class=" cellNewValue">my value</div><div class="invisible-rect"></div>');
+			}));
+
+			it('should add "new" class on a new cell', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				const col = { quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = { __tdpDiff: { '0001': 'new' } };
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result).toBe('<div class=" cellNewValue">my value</div><div class="invisible-rect"></div>');
+			}));
+		});
+
+		describe('update', () => {
+			it('should add "update" class on an updated cell', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				const col = { quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = { __tdpDiff: { '0001': 'update' } };
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result).toBe('<div class=" cellUpdateValue">my value</div><div class="invisible-rect"></div>');
+			}));
+		});
+
+		describe('deleted', () => {
+			it('should add "deleted" class on deleted row', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				const col = { quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = { __tdpRowDiff: 'delete' };
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result).toBe('<div class=" cellDeletedValue">my value</div><div class="invisible-rect"></div>');
+			}));
+
+			it('should add "delete" class on a deleted cell', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				const col = { quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = { __tdpDiff: { '0001': 'delete' } };
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result).toBe('<div class=" cellDeletedValue">my value</div><div class="invisible-rect"></div>');
+			}));
+		});
+
+		describe('highlight', () => {
+			it('should add "highlight" class', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				DatagridStyleService.hightlightedColumnId = '0001';
+				DatagridStyleService.hightlightedContent = 'my value';
+
+				const col = { id: '0001', quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = {};
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result).toBe('<div class="highlight">my value</div><div class="invisible-rect"></div>');
+			}));
+
+			it('should NOT add "highlight" class if the column is not the target', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				DatagridStyleService.hightlightedColumnId = '0000';
+				DatagridStyleService.hightlightedContent = 'my value';
+
+				const col = { id: '0001', quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = {};
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result).toBe('<div class="">my value</div><div class="invisible-rect"></div>');
+			}));
+
+			it('should NOT add "highlight" class if content does not match', inject((DatagridStyleService) => {
+				//given
+				DatagridStyleService.init(gridMock);
+				DatagridStyleService.hightlightedColumnId = '0001';
+				DatagridStyleService.hightlightedContent = 'my specific value';
+
+				const col = { id: '0001', quality: { invalidValues: [] } };
+				const value = 'my value';
+				const columnDef = gridColumns[1];
+				const dataContext = {};
+
+				//when
+				const formatter = DatagridStyleService.columnFormatter(col);
+				const result = formatter(null, null, value, columnDef, dataContext);
+
+				//then
+				expect(result).toBe('<div class="">my value</div><div class="invisible-rect"></div>');
+			}));
+		});
+	});
+
+	describe('column preview style', () => {
+		it('should return "new" column style', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			const col = { __tdpColumnDiff: 'new' };
+
+			//when
+			const diffClass = DatagridStyleService.getColumnPreviewStyle(col);
+
+			//then
+			expect(diffClass).toBe('newColumn');
+		}));
+
+		it('should return "deleted" column style', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			const col = { __tdpColumnDiff: 'delete' };
+
+			//when
+			const diffClass = DatagridStyleService.getColumnPreviewStyle(col);
+
+			//then
+			expect(diffClass).toBe('deletedColumn');
+		}));
+
+		it('should return "updated" column style', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			const col = { __tdpColumnDiff: 'update' };
+
+			//when
+			const diffClass = DatagridStyleService.getColumnPreviewStyle(col);
+
+			//then
+			expect(diffClass).toBe('updatedColumn');
+		}));
+
+		it('should return empty string on no change diff', inject((DatagridStyleService) => {
+			//given
+			DatagridStyleService.init(gridMock);
+			const col = {};
+
+			//when
+			const diffClass = DatagridStyleService.getColumnPreviewStyle(col);
+
+			//then
+			expect(diffClass).toBe('');
+		}));
+	});
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
There is no classname on the selected column header

**(Optional) What is the new behavior?**
The `selected`classname is added to the header container.
