### PR TITLE
fix(TDP-2839): ng-show on functions tab to avoid a selected tab sync bug

### DIFF
--- a/dataprep-webapp/src/app/components/suggestions-stats/actions-suggestions/actions-suggestions.html
+++ b/dataprep-webapp/src/app/components/suggestions-stats/actions-suggestions/actions-suggestions.html
@@ -37,7 +37,7 @@
         </div>
     </div>
 
-    <sc-tabs ng-if="!actionsSuggestionsCtrl.state.playground.suggestions.isLoading"
+    <sc-tabs ng-show="!actionsSuggestionsCtrl.state.playground.suggestions.isLoading"
              class="actions-scope"
              selected-tab="actionsSuggestionsCtrl.state.playground.suggestions.tab">
         <sc-tabs-item tab-title="{{'ACTIONS_TAB_COLUMN' | translate}}" is-default="true">


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2839
(don't pay attention to the branch name, I picked the wrong jira number)

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to

**(Optional) What is the current behavior?**
(Additional information to the Jira)
This PR only fix the susequent bug of TDP-2839, where the TAB is not switched on prep/dataset open + first click on index cell.
The error is du to a bug in sunchoke. The Tab component manage an internal state, but it can be changed by changing the `selected-tab` input.
But in TDP, we remove and instanciate it again using `ng-if`, this `selected-tab` input is not taken into account at component instanciation. So the selected tab is the first (by default) and don't reflect the selected tab we pass in TDP.

**(Optional) What is the new behavior?**
(Additional information to the Jira)
To avoid touching to sunchoke as it should disapear, the `ng-if` has been replaced by an `ng-show`. The perf is not that impacted.
