### PR TITLE
fix(TDP-2956): doc url is now back in the functions definition

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/AbstractActionMetadata.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/AbstractActionMetadata.java
@@ -101,6 +101,11 @@ public abstract class AbstractActionMetadata implements InternalActionDefinition
         return ActionsBundle.INSTANCE.actionDescription(this, Locale.ENGLISH, getName());
     }
 
+    @Override
+    public String getDocUrl() {
+        return ActionsBundle.INSTANCE.docUrl(this, Locale.ENGLISH, getName());
+    }
+
     /**
      * Defines the list of scopes this action belong to.
      * <p>

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/AbstractActionMetadata.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/AbstractActionMetadata.java
@@ -103,7 +103,7 @@ public abstract class AbstractActionMetadata implements InternalActionDefinition
 
     @Override
     public String getDocUrl() {
-        return ActionsBundle.INSTANCE.docUrl(this, Locale.ENGLISH, getName());
+        return ActionsBundle.INSTANCE.actionDocUrl(this, Locale.ENGLISH, getName());
     }
 
     /**

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/InternalActionDefinition.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/InternalActionDefinition.java
@@ -15,7 +15,6 @@ package org.talend.dataprep.transformation.actions.common;
 
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
 import org.talend.dataprep.api.action.ActionDefinition;
 import org.talend.dataprep.transformation.actions.category.ActionScope;
 
@@ -43,9 +42,5 @@ public interface InternalActionDefinition extends ActionDefinition {
      */
     // Only here for JSON serialization purposes.
     boolean isDynamic();
-
-    default String getDocUrl() {
-        return StringUtils.EMPTY;
-    }
 
 }

--- a/dataprep-actions/src/test/java/org/talend/dataprep/i18n/ActionsBundleTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/i18n/ActionsBundleTest.java
@@ -31,6 +31,16 @@ public class ActionsBundleTest {
     }
 
     @Test
+    public void actionDocUrl() throws Exception {
+        assertEquals("https://help.talend.com/pages/viewpage.action?pageId=266307174&utm_medium=dpdesktop&utm_source=func", ActionsBundle.INSTANCE.docUrl(this, Locale.US, "replace_on_value"));
+    }
+
+    @Test
+    public void emptyActionDocUrl() throws Exception {
+        assertEquals("", ActionsBundle.INSTANCE.docUrl(this, Locale.US, "uppercase"));
+    }
+
+    @Test
     public void parameterLabel() throws Exception {
         assertEquals("Dataset name", ActionsBundle.INSTANCE.parameterLabel(this, Locale.US, "name"));
     }

--- a/dataprep-actions/src/test/java/org/talend/dataprep/i18n/ActionsBundleTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/i18n/ActionsBundleTest.java
@@ -32,12 +32,12 @@ public class ActionsBundleTest {
 
     @Test
     public void actionDocUrl() throws Exception {
-        assertEquals("https://help.talend.com/pages/viewpage.action?pageId=266307174&utm_medium=dpdesktop&utm_source=func", ActionsBundle.INSTANCE.docUrl(this, Locale.US, "replace_on_value"));
+        assertEquals("https://help.talend.com/pages/viewpage.action?pageId=266307174&utm_medium=dpdesktop&utm_source=func", ActionsBundle.INSTANCE.actionDocUrl(this, Locale.US, "replace_on_value"));
     }
 
     @Test
     public void emptyActionDocUrl() throws Exception {
-        assertEquals("", ActionsBundle.INSTANCE.docUrl(this, Locale.US, "uppercase"));
+        assertEquals("", ActionsBundle.INSTANCE.actionDocUrl(this, Locale.US, "uppercase"));
     }
 
     @Test

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/action/ActionDefinition.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/action/ActionDefinition.java
@@ -52,6 +52,11 @@ public interface ActionDefinition extends Serializable {
     String getDescription();
 
     /**
+     * @return The action documentation url.
+     */
+    String getDocUrl();
+
+    /**
      * @return The list of parameters required for this Action to be executed.
      **/
     List<Parameter> getParameters();

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/i18n/ActionsBundle.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/i18n/ActionsBundle.java
@@ -42,6 +42,8 @@ public class ActionsBundle implements MessagesBundle {
 
     private static final String DESCRIPTION_SUFFIX = ".desc";
 
+    private static final String URL_SUFFIX = ".url";
+
     private static final String LABEL_SUFFIX = ".label";
 
     private static final String PARAMETER_PREFIX = "parameter.";
@@ -135,6 +137,19 @@ public class ActionsBundle implements MessagesBundle {
     public String actionDescription(Object action, Locale locale, String actionName, Object... values) {
         final String actionDescriptionKey = ACTION_PREFIX + actionName + DESCRIPTION_SUFFIX;
         return getMessage(action, locale, actionDescriptionKey, values);
+    }
+
+    /**
+     * Fetches action doc url at {@code action.<action_name>.url} in the dataprep actions resource bundle.
+     * If there is no doc for this action, an empty string is returned.
+     */
+    public String docUrl(Object action, Locale locale, String actionName) {
+        final String actionDocUrlKey = ACTION_PREFIX + actionName + URL_SUFFIX;
+        final ResourceBundle bundle = findBundle(action, locale);
+        if (bundle.containsKey(actionDocUrlKey)) {
+            return bundle.getString(actionDocUrlKey);
+        }
+        return StringUtils.EMPTY;
     }
 
     /**

--- a/dataprep-transformation/src/test/resources/org/talend/dataprep/transformation/suggestions/date_column_string_type_suggestions.json
+++ b/dataprep-transformation/src/test/resources/org/talend/dataprep/transformation/suggestions/date_column_string_type_suggestions.json
@@ -521,7 +521,7 @@
     "description": "Change the date format to use in a date column",
     "label": "Change date format",
     "actionScope": [],
-    "docUrl": ""
+    "docUrl": "https://help.talend.com/pages/viewpage.action?pageId=266307181&utm_medium=dpdesktop&utm_source=func"
   },
   {
     "name": "compute_time_since",
@@ -898,6 +898,6 @@
     "description": "Replace the cells that have a specific value",
     "label": "Replace the cells that match",
     "actionScope": [],
-    "docUrl": ""
+    "docUrl": "https://help.talend.com/pages/viewpage.action?pageId=266307174&utm_medium=dpdesktop&utm_source=func"
   }
 ]

--- a/dataprep-transformation/src/test/resources/org/talend/dataprep/transformation/suggestions/date_column_suggestions.json
+++ b/dataprep-transformation/src/test/resources/org/talend/dataprep/transformation/suggestions/date_column_suggestions.json
@@ -521,7 +521,7 @@
     "description": "Change the date format to use in a date column",
     "label": "Change date format",
     "actionScope": [],
-    "docUrl": ""
+    "docUrl": "https://help.talend.com/pages/viewpage.action?pageId=266307181&utm_medium=dpdesktop&utm_source=func"
   },
   {
     "name": "compute_time_since",


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2956

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
