### PR TITLE
feat(TDP-3502): allow to specify mongodb.uri as a whole instead of specifics parts

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/encrypt/AESEncryption.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/encrypt/AESEncryption.java
@@ -92,6 +92,13 @@ public class AESEncryption {
         return new String(decValue, ENCODING);
     }
 
+    /**
+     * Decrypts the password embedded in the supplied URI and returns the URI with its password decrypted.
+     *
+     * @param rawUri The URI that may or may not contain an encrypted password in its user info part.
+     * @return the URI with a decrypted password.
+     * @see URI#getUserInfo()
+     */
     public static String decryptUriPassword(final String rawUri) {
         URI uri;
         try {
@@ -114,6 +121,13 @@ public class AESEncryption {
         }
     }
 
+    /**
+     * Encrypt the password part of the URI if any and returns it.
+     *
+     * @param rawUri the URI that may contain a password in its user info part.
+     * @return the URI with its password part, if any, encrypted.
+     * @throws Exception if rawUri is not a valid URI or encryption fails.
+     */
     public static String encryptUriPassword(final String rawUri) throws Exception {
         URI uri = new URI(rawUri);
         UserInfo userInfo = extractCredentials(uri);

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/encrypt/AESEncryption.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/encrypt/AESEncryption.java
@@ -13,12 +13,16 @@
 package org.talend.dataprep.encrypt;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.Key;
 import java.util.Base64;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,6 +90,66 @@ public class AESEncryption {
         final byte[] decodedValue = Base64.getDecoder().decode(src);
         final byte[] decValue = c.doFinal(decodedValue);
         return new String(decValue, ENCODING);
+    }
+
+    public static String decryptUriPassword(final String rawUri) {
+        URI uri;
+        try {
+            uri = new URI(rawUri);
+        } catch (URISyntaxException e) {
+            LOGGER.info("Invalid URI {}", rawUri, e);
+            return rawUri;
+        }
+        UserInfo userInfo = extractCredentials(uri);
+        if (userInfo != null && userInfo.password != null) {
+            try {
+                userInfo.password = decrypt(userInfo.password);
+                return setCredentials(uri, userInfo).toString();
+            } catch (Exception e) {
+                LOGGER.info("Could not decrypt URI password.");
+                return rawUri;
+            }
+        } else {
+            return rawUri;
+        }
+    }
+
+    public static String encryptUriPassword(final String rawUri) throws Exception {
+        URI uri = new URI(rawUri);
+        UserInfo userInfo = extractCredentials(uri);
+        if (userInfo != null && userInfo.password != null) {
+            userInfo.password = encrypt(userInfo.password);
+            return setCredentials(uri, userInfo).toString();
+        } else {
+            return rawUri;
+        }
+    }
+
+    private static UserInfo extractCredentials(URI uri) {
+        String rawUserInfo = uri.getUserInfo();
+        if (StringUtils.isNotBlank(rawUserInfo)) {
+            String[] parts = rawUserInfo.split(":");
+            if (parts.length > 1) {
+                String part0 = parts[0];
+                return new UserInfo(part0, rawUserInfo.substring(part0.length() + 1));
+            }
+        }
+        return null;
+    }
+
+    private static URI setCredentials(URI uri, UserInfo userInfo) throws URISyntaxException {
+        return new URIBuilder(uri).setUserInfo(userInfo.userName, userInfo.password).build();
+    }
+
+    private static class UserInfo {
+        String userName;
+
+        String password;
+
+        public UserInfo(String userName, String password) {
+            this.userName = userName;
+            this.password = password;
+        }
     }
 
     /**

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/encrypt/PropertiesEncryption.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/encrypt/PropertiesEncryption.java
@@ -22,6 +22,7 @@ import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,15 +99,24 @@ public class PropertiesEncryption {
      * @return the encrypted string
      */
     private String encryptIfNot(String input) {
-        try {
-            AESEncryption.decrypt(input);
-            // If no exception is thrown it must be that it was already encrypted.
-            return input;
-        } catch (Exception e) {
+        if (isUri(input)) {
             try {
-                return AESEncryption.encrypt(input);
-            } catch (Exception e1) {
-                LOGGER.debug("Error encrypting value.", e1);
+                return AESEncryption.encryptUriPassword(input);
+            } catch (Exception e) {
+                LOGGER.debug("Error encrypting value.", e);
+                return input;
+            }
+        } else {
+            try {
+                AESEncryption.decrypt(input);
+                // If no exception is thrown it must be that it was already encrypted.
+                return input;
+            } catch (Exception e) {
+                try {
+                    return AESEncryption.encrypt(input);
+                } catch (Exception e1) {
+                    LOGGER.debug("Error encrypting value.", e1);
+                }
             }
         }
         return "";
@@ -119,12 +129,27 @@ public class PropertiesEncryption {
      * @return the decrypted string
      */
     private String decryptIfNot(String input) {
-        try {
-            return AESEncryption.decrypt(input);
-        } catch (Exception e) {
-            // Property was already decrypted
-            LOGGER.debug("Trying to decrypt a non encrypted property.", e);
-            return input;
+        if (isUri(input)) {
+            try {
+                return AESEncryption.decryptUriPassword(input);
+            } catch (Exception e) {
+                LOGGER.debug("Error encrypting value.", e);
+                return input;
+            }
+        } else {
+            try {
+                return AESEncryption.decrypt(input);
+            } catch (Exception e) {
+                // Property was already decrypted
+                LOGGER.debug("Trying to decrypt a non encrypted property.", e);
+                return input;
+            }
         }
     }
+
+    private static boolean isUri(String field) {
+        UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS + UrlValidator.ALLOW_ALL_SCHEMES + UrlValidator.ALLOW_2_SLASHES);
+        return urlValidator.isValid(field);
+    }
+
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/encrypt/PropertiesEncryption.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/encrypt/PropertiesEncryption.java
@@ -12,6 +12,8 @@
 
 package org.talend.dataprep.encrypt;
 
+import static org.apache.commons.validator.routines.UrlValidator.*;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -99,7 +101,7 @@ public class PropertiesEncryption {
      * @return the encrypted string
      */
     private String encryptIfNot(String input) {
-        if (isUri(input)) {
+        if (isUrl(input)) {
             try {
                 return AESEncryption.encryptUriPassword(input);
             } catch (Exception e) {
@@ -129,7 +131,7 @@ public class PropertiesEncryption {
      * @return the decrypted string
      */
     private String decryptIfNot(String input) {
-        if (isUri(input)) {
+        if (isUrl(input)) {
             try {
                 return AESEncryption.decryptUriPassword(input);
             } catch (Exception e) {
@@ -147,8 +149,8 @@ public class PropertiesEncryption {
         }
     }
 
-    private static boolean isUri(String field) {
-        UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS + UrlValidator.ALLOW_ALL_SCHEMES + UrlValidator.ALLOW_2_SLASHES);
+    private static boolean isUrl(String field) {
+        UrlValidator urlValidator = new UrlValidator(ALLOW_LOCAL_URLS + ALLOW_ALL_SCHEMES + ALLOW_2_SLASHES);
         return urlValidator.isValid(field);
     }
 

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/encrypt/AESEncryptionTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/encrypt/AESEncryptionTest.java
@@ -13,12 +13,18 @@
 
 package org.talend.dataprep.encrypt;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import javax.crypto.IllegalBlockSizeException;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 public class AESEncryptionTest {
+
+    public static final String DECRYPTED_URI = "mongodb://toto:truc@dataprep.org/dataprep-db?ssl=toto&truc=machin";
+
+    public static final String ENCRYPTED_URI = "mongodb://toto:qxjQWF%2FZsuzzeLzKIop2pQ==@dataprep.org/dataprep-db?ssl=toto&truc=machin";
 
     @Test
     public void should_get_the_same_string_after_encrypt_then_decrypt() throws Exception {
@@ -30,7 +36,7 @@ public class AESEncryptionTest {
         String decrypted = AESEncryption.decrypt(encrypted);
 
         // then
-        Assert.assertEquals(src, decrypted);
+        assertEquals(src, decrypted);
     }
 
     @Test(expected = IllegalBlockSizeException.class)
@@ -43,6 +49,23 @@ public class AESEncryptionTest {
 
         // then
         Assert.fail("should not reach this point");
+    }
+
+    @Test
+    public void encryptUriPassword_shouldEncryptCredentials() throws Exception {
+        String encrypted = AESEncryption.encryptUriPassword(DECRYPTED_URI);
+
+        // then
+        assertEquals(ENCRYPTED_URI, encrypted);
+    }
+
+    @Test
+    public void decryptUriPassword_shouldDecryptCredentials() throws Exception {
+        // when
+        String decrypted = AESEncryption.decryptUriPassword(ENCRYPTED_URI);
+
+        // then
+        assertEquals(DECRYPTED_URI, decrypted);
     }
 
 }

--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -48,6 +48,8 @@
         <!-- avro version must match the one in the studio -->
         <avro.version>1.7.7</avro.version>
         <apache.poi.version>3.15</apache.poi.version>
+        <java-semver.version>0.9.0</java-semver.version>
+        <commons-math3.version>3.5</commons-math3.version>
     </properties>
     <modules>
         <module>../dataprep-backend-common</module>
@@ -64,12 +66,12 @@
             <dependency>
                 <groupId>com.github.zafarkhaja</groupId>
                 <artifactId>java-semver</artifactId>
-                <version>0.9.0</version>
+                <version>${java-semver.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-math3</artifactId>
-                <version>3.5</version>
+                <version>${commons-math3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.talend.dataquality</groupId>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TDP-3502

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed

**(Optional) Other information**:
- add encryption capabilities for passwords in URIs
- enable password encryption in mongodb.uri
- use mongodb.uri property instead of port,user,...
