### PR TITLE
[chores] Simplify basic bean post processors

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/text/ReplaceCellValue.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/text/ReplaceCellValue.java
@@ -1,5 +1,4 @@
 // ============================================================================
-//
 // Copyright (C) 2006-2016 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
@@ -122,7 +121,7 @@ public class ReplaceCellValue extends AbstractActionMetadata implements CellActi
         final String columnId = context.getColumnId();
         final String oldValue = row.get(columnId);
         row.set(columnId, replacement);
-        LOGGER.info("{} replaced by {} in row {}, column {}", oldValue, replacement, row.getTdpId(), columnId);
+        LOGGER.debug("{} replaced by {} in row {}, column {}", oldValue, replacement, row.getTdpId(), columnId);
 
         // all done
         context.setActionStatus(ActionContext.ActionStatus.DONE);

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
@@ -114,22 +114,19 @@ public class GenericCommand<T> extends HystrixCommand<T> {
     /** Default onError behaviour. */
     private Function<Exception, RuntimeException> onError = Defaults.passthrough();
 
-    private HttpStatus status;//
-//
-//
-    public static final HttpStatus[] SUCCESS_STATUS = Stream.of(HttpStatus.values()) //
+    private HttpStatus status;
+
+    private static final HttpStatus[] SUCCESS_STATUS = Stream.of(HttpStatus.values()) //
             .filter(HttpStatus::is2xxSuccessful) //
             .collect(Collectors.toList()) //
-            .toArray(new HttpStatus[0]);//
-//
-//
-    public static final HttpStatus[] REDIRECT_STATUS = Stream.of(HttpStatus.values()) //
+            .toArray(new HttpStatus[0]);
+
+    private static final HttpStatus[] REDIRECT_STATUS = Stream.of(HttpStatus.values()) //
             .filter(HttpStatus::is3xxRedirection) //
             .collect(Collectors.toList()) //
-            .toArray(new HttpStatus[0]);//
-//
-//
-    public static final HttpStatus[] INFO_STATUS = Stream.of(HttpStatus.values()) //
+            .toArray(new HttpStatus[0]);
+
+    private static final HttpStatus[] INFO_STATUS = Stream.of(HttpStatus.values()) //
             .filter(HttpStatus::is1xxInformational) //
             .collect(Collectors.toList()) //
             .toArray(new HttpStatus[0]);

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/ExportFormatConversions.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/ExportFormatConversions.java
@@ -14,63 +14,34 @@ package org.talend.dataprep.configuration;
 
 import static org.talend.dataprep.conversions.BeanConversionService.RegistrationBuilder.fromBean;
 
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.BeanPostProcessor;
+import java.util.Locale;
+
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.conversions.BeanConversionService;
 import org.talend.dataprep.format.export.ExportFormat;
 import org.talend.dataprep.format.export.ExportFormatMessage;
 import org.talend.dataprep.i18n.MessagesBundle;
+import org.talend.dataprep.processor.BeanConversionServiceWrapper;
 
-import java.util.Locale;
+@Component
+public class ExportFormatConversions extends BeanConversionServiceWrapper {
 
-@Configuration
-public class ExportFormatConversions {
-
-    /**
-     * <h1>{@link BeanPostProcessor} notice</h1>
-     * Don't use any {@link org.springframework.beans.factory.annotation.Autowired} in the
-     * configuration as it will prevent autowired beans to be processed by BeanPostProcessor.
-     */
-    @Component
-    public class Conversions implements BeanPostProcessor, ApplicationContextAware {
-
-        private ApplicationContext applicationContext;
-
-        @Override
-        public Object postProcessBeforeInitialization(Object bean, String beanName) {
-            if (bean instanceof BeanConversionService) {
-                final BeanConversionService conversionService = (BeanConversionService) bean;
-                final MessagesBundle messagesBundle = applicationContext.getBean(MessagesBundle.class);
-                conversionService //
-                        .register(fromBean(ExportFormat.class) //
-                                .toBeans(ExportFormatMessage.class) //
-                                .using(ExportFormatMessage.class, (exportFormat, exportFormatMessage) -> {
-                                    exportFormatMessage.setId(exportFormat.getName());
-                                    exportFormatMessage.setName(messagesBundle.getString(Locale.ENGLISH, "export." + exportFormat.getName() + ".display"));
-                                    exportFormatMessage.setSupportSampling(exportFormat.supportSampling());
-                                    return exportFormatMessage;
-                                }) //
-                                .build()
-                        );
-                return conversionService;
-            }
-            return bean;
-        }
-
-        @Override
-        public Object postProcessAfterInitialization(Object bean, String beanName) {
-            return bean;
-        }
-
-        @Override
-        public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-            this.applicationContext = applicationContext;
-        }
+    @Override
+    public BeanConversionService doWith(BeanConversionService conversionService, String beanName, ApplicationContext applicationContext) {
+        final MessagesBundle messagesBundle = applicationContext.getBean(MessagesBundle.class);
+        conversionService.register(fromBean(ExportFormat.class) //
+                .toBeans(ExportFormatMessage.class) //
+                .using(ExportFormatMessage.class, (exportFormat, exportFormatMessage) -> {
+                    final String code = "export." + exportFormat.getName() + ".display";
+                    final String displayName = messagesBundle.getString(Locale.ENGLISH, code);
+                    exportFormatMessage.setId(exportFormat.getName());
+                    exportFormatMessage.setName(displayName);
+                    exportFormatMessage.setSupportSampling(exportFormat.supportSampling());
+                    return exportFormatMessage;
+                }) //
+                .build());
+        return conversionService;
     }
-
 
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/processor/BeanConversionServiceWrapper.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/processor/BeanConversionServiceWrapper.java
@@ -1,0 +1,26 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.processor;
+
+import org.talend.dataprep.conversions.BeanConversionService;
+
+/**
+ * A super class for all configurations that registers conversions to {@link BeanConversionService}.
+ */
+public abstract class BeanConversionServiceWrapper implements Wrapper<BeanConversionService> {
+
+    @Override
+    public Class<BeanConversionService> wrapped() {
+        return BeanConversionService.class;
+    }
+}

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/processor/Wrapper.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/processor/Wrapper.java
@@ -1,0 +1,52 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.processor;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * <p>
+ * Ease declaration of {@link org.springframework.beans.factory.config.BeanPostProcessor} when you want to target a
+ * specific class.
+ * </p>
+ * <p>
+ * Implementation should not use {@link org.springframework.beans.factory.annotation.Autowired} fields since this breaks
+ * {@link org.springframework.beans.factory.config.BeanPostProcessor}.
+ * </p>
+ *
+ * @param <T> The targeted class for this wrapper.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public interface Wrapper<T> {
+
+    /**
+     * @return The class of the object to watch for.
+     */
+    Class<T> wrapped();
+
+    /**
+     * Work on a being created object. Implementations of this {@link Wrapper} are only called for the <code>T</code>
+     * instances.
+     *
+     * @param instance The instance to be wrapped.
+     * @param beanName The instance bean name.
+     * @param applicationContext An {@link ApplicationContext} to use to look up in context.
+     * @return The modified bean or a bean that replaces the one passed as parameter.
+     */
+    T doWith(T instance, String beanName, ApplicationContext applicationContext);
+
+}

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/processor/WrapperProcessor.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/processor/WrapperProcessor.java
@@ -1,0 +1,54 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.processor;
+
+import java.util.Map;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * A {@link BeanPostProcessor} that processes {@link Wrapper wrappers}.
+ *
+ * @see BeanPostProcessor#postProcessAfterInitialization(Object, String)
+ */
+@Component
+public class WrapperProcessor implements BeanPostProcessor, ApplicationContextAware {
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        final Map<String, Wrapper> wrappers = applicationContext.getBeansOfType(Wrapper.class);
+        Object current = bean;
+        for (Wrapper wrapper : wrappers.values()) {
+            if (wrapper.wrapped().isAssignableFrom(bean.getClass())) {
+                current = wrapper.doWith(bean, beanName, applicationContext);
+            }
+        }
+        return current;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/processor/WrapperProcessorTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/processor/WrapperProcessorTest.java
@@ -1,0 +1,61 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.processor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import org.talend.ServiceBaseTest;
+
+public class WrapperProcessorTest extends ServiceBaseTest {
+
+    @Test
+    public void shouldProcessComponentWithType() throws Exception {
+        assertTrue(ToBeProcessed.processed);
+    }
+
+    @Test
+    public void shouldNotProcessComponentWithType() throws Exception {
+        assertFalse(NotToBeProcessed.processed);
+    }
+
+    @Component
+    public static class ToBeProcessed {
+
+        static boolean processed = false;
+    }
+
+    @Component
+    public static class NotToBeProcessed {
+
+        static boolean processed = false;
+    }
+
+    @Component
+    public static class ProcessedWrapper implements Wrapper<ToBeProcessed> {
+
+        @Override
+        public Class<ToBeProcessed> wrapped() {
+            return ToBeProcessed.class;
+        }
+
+        @Override
+        public ToBeProcessed doWith(ToBeProcessed instance, String beanName, ApplicationContext applicationContext) {
+            ToBeProcessed.processed = true;
+            return instance;
+        }
+    }
+}

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/configuration/DataSetConversions.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/configuration/DataSetConversions.java
@@ -15,17 +15,14 @@ package org.talend.dataprep.dataset.configuration;
 import static org.talend.dataprep.conversions.BeanConversionService.RegistrationBuilder.fromBean;
 
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.dataset.DataSetMetadata;
 import org.talend.dataprep.api.share.Owner;
 import org.talend.dataprep.api.user.UserData;
 import org.talend.dataprep.conversions.BeanConversionService;
 import org.talend.dataprep.dataset.service.UserDataSetMetadata;
+import org.talend.dataprep.processor.BeanConversionServiceWrapper;
 import org.talend.dataprep.security.Security;
 import org.talend.dataprep.user.store.UserDataRepository;
 
@@ -33,58 +30,32 @@ import org.talend.dataprep.user.store.UserDataRepository;
  * A configuration for {@link DataSetMetadata} conversions. It adds all transient information (e.g. favorite flags)
  */
 @Configuration
-public class DataSetConversions {
+public class DataSetConversions extends BeanConversionServiceWrapper {
 
-    /**
-     * <h1>{@link BeanPostProcessor} notice</h1>
-     * Don't use any {@link org.springframework.beans.factory.annotation.Autowired} in the
-     * configuration as it will prevent autowired beans to be processed by BeanPostProcessor.
-     */
-    @Component
-    private class DataSetMetadataConversions implements BeanPostProcessor, ApplicationContextAware {
+    @Override
+    public BeanConversionService doWith(BeanConversionService conversionService, String beanName, ApplicationContext applicationContext) {
+        conversionService.register(fromBean(DataSetMetadata.class) //
+                .toBeans(UserDataSetMetadata.class) //
+                .using(UserDataSetMetadata.class, (dataSetMetadata, userDataSetMetadata) -> {
+                    final Security security = applicationContext.getBean(Security.class);
+                    final UserDataRepository userDataRepository = applicationContext.getBean(UserDataRepository.class);
+                    String userId = security.getUserId();
 
-        private ApplicationContext applicationContext;
+                    // update the dataset favorites
+                    final UserData userData = userDataRepository.get(userId);
+                    if (userData != null) {
+                        userDataSetMetadata.setFavorite(userData.getFavoritesDatasets().contains(dataSetMetadata.getId()));
+                    }
 
-        @Override
-        public Object postProcessBeforeInitialization(Object bean, String beanName) {
-            if (bean instanceof BeanConversionService) {
-                final BeanConversionService conversionService = (BeanConversionService) bean;
-                conversionService.register(fromBean(DataSetMetadata.class) //
-                        .toBeans(UserDataSetMetadata.class) //
-                        .using(UserDataSetMetadata.class, (dataSetMetadata, userDataSetMetadata) -> {
-                            final Security security = applicationContext.getBean(Security.class);
-                            final UserDataRepository userDataRepository = applicationContext.getBean(UserDataRepository.class);
-                            String userId = security.getUserId();
+                    // and the owner (if not already present).
+                    if (userDataSetMetadata.getOwner() == null) {
+                        userDataSetMetadata.setOwner(new Owner(userId, security.getUserDisplayName(), StringUtils.EMPTY));
+                    }
 
-                            // update the dataset favorites
-                            final UserData userData = userDataRepository.get(userId);
-                            if (userData != null) {
-                                userDataSetMetadata.setFavorite(userData.getFavoritesDatasets().contains(dataSetMetadata.getId()));
-                            }
-
-                            // and the owner (if not already present).
-                            if (userDataSetMetadata.getOwner() == null) {
-                                userDataSetMetadata.setOwner(new Owner(userId, security.getUserDisplayName(), StringUtils.EMPTY));
-                            }
-
-                            return userDataSetMetadata;
-                        }) //
-                        .build()
-                );
-                return conversionService;
-            }
-            return bean;
-        }
-
-        @Override
-        public Object postProcessAfterInitialization(Object bean, String beanName) {
-            return bean;
-        }
-
-        @Override
-        public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-            this.applicationContext = applicationContext;
-        }
+                    return userDataSetMetadata;
+                }) //
+                .build());
+        return conversionService;
     }
 
 }

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/configuration/PreparationConversions.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/configuration/PreparationConversions.java
@@ -22,11 +22,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.action.ActionDefinition;
 import org.talend.dataprep.api.preparation.*;
@@ -35,142 +31,118 @@ import org.talend.dataprep.conversions.BeanConversionService;
 import org.talend.dataprep.preparation.service.UserPreparation;
 import org.talend.dataprep.preparation.store.PersistentPreparation;
 import org.talend.dataprep.preparation.store.PreparationRepository;
+import org.talend.dataprep.processor.BeanConversionServiceWrapper;
 import org.talend.dataprep.security.Security;
 import org.talend.dataprep.transformation.pipeline.ActionRegistry;
 
 /**
- * A configuration for {@link Preparation} conversions. It adds all transient information (e.g. owner, action metadata...)
+ * A configuration for {@link Preparation} conversions. It adds all transient information (e.g. owner, action
+ * metadata...)
  */
-@Configuration
-public class PreparationConversions {
+@Component
+public class PreparationConversions extends BeanConversionServiceWrapper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PreparationConversions.class);
 
-    /**
-     * <h1>{@link BeanPostProcessor} notice</h1>
-     * Don't use any {@link org.springframework.beans.factory.annotation.Autowired} in the
-     * configuration as it will prevent autowired beans to be processed by BeanPostProcessor.
-     */
-    @Component
-    public class Conversions implements BeanPostProcessor, ApplicationContextAware {
+    @Override
+    public BeanConversionService doWith(BeanConversionService conversionService, String beanName, ApplicationContext applicationContext) {
+        conversionService.register(fromBean(Preparation.class) //
+                .toBeans(PreparationMessage.class, UserPreparation.class, PersistentPreparation.class) //
+                .using(PreparationMessage.class, (s, t) -> toPreparationMessage(s, t, applicationContext)) //
+                .using(PreparationSummary.class, (s, t) -> toStudioPreparation(s, t, applicationContext)) //
+                .using(UserPreparation.class, (s, t) -> toUserPreparation(t, applicationContext)) //
+                .build());
+        return conversionService;
+    }
 
-        private ApplicationContext applicationContext;
-
-        @Override
-        public Object postProcessBeforeInitialization(Object bean, String beanName) {
-            if (bean instanceof BeanConversionService) {
-                final BeanConversionService conversionService = (BeanConversionService) bean;
-                conversionService //
-                        .register(fromBean(Preparation.class) //
-                        .toBeans(PreparationMessage.class, UserPreparation.class, PersistentPreparation.class) //
-                                .using(PreparationMessage.class, this::toPreparationMessage) //
-                                .using(PreparationSummary.class, this::toStudioPreparation) //
-                                .using(UserPreparation.class, (source, target) -> toUserPreparation(target)) //
-                        .build()
-                );
-                return conversionService;
-            }
-            return bean;
+    private PreparationSummary toStudioPreparation(Preparation source, PreparationSummary target,
+            ApplicationContext applicationContext) {
+        if (target.getOwner() == null) {
+            final Security security = applicationContext.getBean(Security.class);
+            Owner owner = new Owner(security.getUserId(), security.getUserDisplayName(), StringUtils.EMPTY);
+            target.setOwner(owner);
         }
 
-        private PreparationSummary toStudioPreparation(Preparation source, PreparationSummary target) {
-            if (target.getOwner() == null) {
-                final Security security = applicationContext.getBean(Security.class);
-                Owner owner = new Owner(security.getUserId(), security.getUserDisplayName(), StringUtils.EMPTY);
-                target.setOwner(owner);
-            }
+        final PreparationRepository preparationRepository = applicationContext.getBean(PreparationRepository.class);
+        final ActionRegistry actionRegistry = applicationContext.getBean(ActionRegistry.class);
 
-            final PreparationRepository preparationRepository = applicationContext.getBean(PreparationRepository.class);
-            final ActionRegistry actionRegistry = applicationContext.getBean(ActionRegistry.class);
+        // Get preparation actions
+        PreparationActions prepActions = preparationRepository.get(source.getHeadId(), PreparationActions.class);
+        if (prepActions != null) {
+            List<Action> actions = prepActions.getActions();
+            boolean allowDistributedRun = true;
+            for (Action action : actions) {
+                final ActionDefinition actionDefinition = actionRegistry.get(action.getName());
+                if (actionDefinition.getBehavior().contains(ActionDefinition.Behavior.FORBID_DISTRIBUTED)) {
+                    allowDistributedRun = false; // Disallow distributed run
+                    break;
+                }
+            }
+            target.setAllowDistributedRun(allowDistributedRun);
+        }
+
+        return target;
+    }
+
+    private UserPreparation toUserPreparation(UserPreparation target, ApplicationContext applicationContext) {
+        if (target.getOwner() == null) {
+            final Security security = applicationContext.getBean(Security.class);
+            Owner owner = new Owner(security.getUserId(), security.getUserDisplayName(), StringUtils.EMPTY);
+            target.setOwner(owner);
+        }
+        return target;
+    }
+
+    private PreparationMessage toPreparationMessage(Preparation source, PreparationMessage target,
+            ApplicationContext applicationContext) {
+        final PreparationUtils preparationUtils = applicationContext.getBean(PreparationUtils.class);
+        final PreparationRepository preparationRepository = applicationContext.getBean(PreparationRepository.class);
+        final ActionRegistry actionRegistry = applicationContext.getBean(ActionRegistry.class);
+
+        final List<Step> steps = preparationUtils.listSteps(source.getHeadId(), preparationRepository);
+        target.setSteps(steps);
+
+        // Steps diff metadata
+        final List<StepDiff> diffs = steps.stream() //
+                .filter(step -> !Step.ROOT_STEP.id().equals(step.id())) //
+                .map(Step::getDiff) //
+                .collect(toList());
+        target.setDiff(diffs);
+
+        // Actions
+        final Step head = preparationRepository.get(source.getHeadId(), Step.class);
+        if (head != null && head.getContent() != null) {
+            // Get preparation actions
+            PreparationActions prepActions = preparationRepository.get(head.getContent().id(), PreparationActions.class);
+            target.setActions(prepActions.getActions());
+            List<Action> actions = prepActions.getActions();
 
             // Allow distributed run
-            // Get preparation actions
-            PreparationActions prepActions = preparationRepository.get(source.getHeadId(), PreparationActions.class);
-            if (prepActions != null) {
-                List<Action> actions = prepActions.getActions();
-                boolean allowDistributedRun = true;
-                for (Action action : actions) {
-                    final ActionDefinition actionDefinition = actionRegistry.get(action.getName());
-                    if (actionDefinition.getBehavior().contains(ActionDefinition.Behavior.FORBID_DISTRIBUTED)) {
-                        allowDistributedRun = false;
-                        break;
-                    }
+            boolean allowDistributedRun = true;
+            for (Action action : actions) {
+                final ActionDefinition actionDefinition = actionRegistry.get(action.getName());
+                if (actionDefinition.getBehavior().contains(ActionDefinition.Behavior.FORBID_DISTRIBUTED)) {
+                    allowDistributedRun = false;
+                    break;
                 }
-                target.setAllowDistributedRun(allowDistributedRun);
             }
+            target.setAllowDistributedRun(allowDistributedRun);
 
-            return target;
-        }
-
-        private UserPreparation toUserPreparation(UserPreparation target) {
-            if (target.getOwner() == null) {
-                final Security security = applicationContext.getBean(Security.class);
-                Owner owner = new Owner(security.getUserId(), security.getUserDisplayName(), StringUtils.EMPTY);
-                target.setOwner(owner);
-            }
-            return target;
-        }
-
-        private PreparationMessage toPreparationMessage(Preparation source, PreparationMessage target) {
-            final PreparationUtils preparationUtils = applicationContext.getBean(PreparationUtils.class);
-            final PreparationRepository preparationRepository = applicationContext.getBean(PreparationRepository.class);
-            final ActionRegistry actionRegistry = applicationContext.getBean(ActionRegistry.class);
-
-            final List<Step> steps = preparationUtils.listSteps(source.getHeadId(), preparationRepository);
-            target.setSteps(steps);
-
-            // Steps diff metadata
-            final List<StepDiff> diffs = steps.stream() //
-                    .filter(step -> !Step.ROOT_STEP.id().equals(step.id())) //
-                    .map(Step::getDiff) //
-                    .collect(toList());
-            target.setDiff(diffs);
-
-            // Actions
-            final Step head = preparationRepository.get(source.getHeadId(), Step.class);
-            if (head != null && head.getContent() != null) {
-                // Get preparation actions
-                PreparationActions prepActions = preparationRepository.get(head.getContent().id(), PreparationActions.class);
-                target.setActions(prepActions.getActions());
-                List<Action> actions = prepActions.getActions();
-
-                // Allow distributed run
-                boolean allowDistributedRun = true;
-                for (Action action : actions) {
-                    final ActionDefinition actionDefinition = actionRegistry.get(action.getName());
-                    if (actionDefinition.getBehavior().contains(ActionDefinition.Behavior.FORBID_DISTRIBUTED)) {
-                        allowDistributedRun = false;
-                        break;
-                    }
-                }
-                target.setAllowDistributedRun(allowDistributedRun);
-
-                // Actions metadata
-                if (actionRegistry == null) {
-                    LOGGER.debug("No action metadata available, unable to serialize action metadata for preparation {}.",
-                            source.id());
-                } else {
-                    List<ActionDefinition> actionDefinitions = actions.stream() //
-                            .map(a -> actionRegistry.get(a.getName())) //
-                            .collect(Collectors.toList());
-                    target.setMetadata(actionDefinitions);
-                }
+            // Actions metadata
+            if (actionRegistry == null) {
+                LOGGER.debug("No action metadata available, unable to serialize action metadata for preparation {}.",
+                        source.id());
             } else {
-                target.setActions(Collections.emptyList());
-                target.setSteps(Collections.singletonList(Step.ROOT_STEP));
-                target.setMetadata(Collections.emptyList());
+                List<ActionDefinition> actionDefinitions = actions.stream() //
+                        .map(a -> actionRegistry.get(a.getName())) //
+                        .collect(Collectors.toList());
+                target.setMetadata(actionDefinitions);
             }
-            return target;
+        } else {
+            target.setActions(Collections.emptyList());
+            target.setSteps(Collections.singletonList(Step.ROOT_STEP));
+            target.setMetadata(Collections.emptyList());
         }
-
-        @Override
-        public Object postProcessAfterInitialization(Object bean, String beanName) {
-            return bean;
-        }
-
-        @Override
-        public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-            this.applicationContext = applicationContext;
-        }
+        return target;
     }
 }


### PR DESCRIPTION
**Link to the JIRA issue**
No Jira

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] No, and no need to (backend changes only)

**What is the current behavior?**
Each BeanConversionService usage were using custom BeanPostProcessors that were very similar. In addition finding all classes that register new conversions was hard to find (no common super class for that).

**What is the new behavior?**
A simplified BeanPostProcessor interface was introduced (Wrapper) and an abstract class of this Wrapper interface helps finding all the BeanConversionService registrations.

**Other information**:

Commit message

* Removes duplicated code in all DP's bean processors.
* All BeanConversionService configuration now inherit from a common class to ease finding them.

[Misc]
* Improve file creation in preparation repository).
* Code format in GenericCommand.
