### PR TITLE
fix(TDP-3508): Save preparation modal - cursor on link NoThanks shoul…

### DIFF
--- a/dataprep-webapp/src/app/components/playground/_playground.scss
+++ b/dataprep-webapp/src/app/components/playground/_playground.scss
@@ -210,8 +210,20 @@ $playground-height: '100vh - ' + ($navigation-all-height);
 	}
 }
 
-.preparation-picker-modal {
-	.modal .modal-inner {
-		width: 70vw;
+.preparation-modal {
+	&.preparation-picker-modal {
+		.modal .modal-inner {
+			width: 70vw;
+		}
+	}
+
+	&.preparation-save-discard-modal {
+		.btn-link {
+			text-transform: inherit;
+			font-size: inherit;
+			letter-spacing: inherit;
+			line-height: inherit;
+			padding: inherit;
+		}
 	}
 }

--- a/dataprep-webapp/src/app/components/playground/playground-controller.js
+++ b/dataprep-webapp/src/app/components/playground/playground-controller.js
@@ -168,7 +168,8 @@ export default function PlaygroundCtrl($state, $stateParams, state, StateService
 	 * @description Discard implicit preparation save. This trigger a preparation delete.
 	 */
 	vm.discardSaveOnClose = () => {
-		PreparationService.delete(state.playground.preparation).then(PlaygroundService.close);
+		PreparationService.delete(state.playground.preparation);
+		PlaygroundService.close();
 	};
 
 	/**

--- a/dataprep-webapp/src/app/components/playground/playground.html
+++ b/dataprep-webapp/src/app/components/playground/playground.html
@@ -91,6 +91,7 @@
 </div>
 
 <talend-modal
+        class="preparation-modal preparation-save-discard-modal"
         fullscreen="false"
         ng-if="playgroundCtrl.showNameValidation"
         state="playgroundCtrl.showNameValidation"
@@ -121,9 +122,11 @@
         </div>
 
         <div class="modal-buttons">
-            <a class="modal-secondary-button"
-               ng-click="playgroundCtrl.discardSaveOnClose()"
-               translate-once="NO_THANKS"></a>
+            <button ng-click="playgroundCtrl.discardSaveOnClose()"
+                    type="button"
+                    class="btn modal-secondary-button btn-link"
+                    translate-once="NO_THANKS">
+            </button>
 
             <talend-button-loader button-class="btn modal-primary-button btn-primary"
                                   disable-condition="playgroundCtrl.savePreparationForm.$invalid || playgroundCtrl.state.playground.isSavingPreparation"
@@ -136,7 +139,7 @@
 </talend-modal>
 
 <talend-modal
-            class="preparation-picker-modal"
+            class="preparation-modal preparation-picker-modal"
             fullscreen="false"
             state="playgroundCtrl.displayPreparationPicker"
             close-button="true"


### PR DESCRIPTION
TDP-3508 - Save preparation modal - cursor on link NoThanks should be "clickable"

https://jira.talendforge.org/browse/TDP-3508

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)