### PR TITLE
feat(TDP-3414): handle SCIM exceptions in client

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/CommonErrorCodes.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/CommonErrorCodes.java
@@ -83,7 +83,11 @@ public enum CommonErrorCodes implements ErrorCode {
     /**
      * If we are unable to connect to streams
      */
-    UNABLE_TO_CONNECT_TO_STREAMS(BAD_GATEWAY.value());
+    UNABLE_TO_CONNECT_TO_STREAMS(BAD_GATEWAY.value()),
+    /**
+     * If unable to access SCIM server whatever the reason. It will encapsulate the {@link org.talend.iam.common.exception.SCIMException}.
+     */
+    SCIM_CLIENT_ERROR(INTERNAL_SERVER_ERROR.value(), "message");
 
     /** The http status to use. */
     private int httpStatus;
@@ -93,7 +97,7 @@ public enum CommonErrorCodes implements ErrorCode {
 
     /**
      * default constructor.
-     * 
+     *
      * @param httpStatus the http status to use.
      */
     CommonErrorCodes(int httpStatus) {

--- a/dataprep-backend-service/src/main/resources/org/talend/dataprep/error_messages.properties
+++ b/dataprep-backend-service/src/main/resources/org/talend/dataprep/error_messages.properties
@@ -425,6 +425,9 @@ UNABLE_CREATE_SAMPLE.MESSAGE=Error building sample
 UNABLE_TO_CONNECT_TO_STREAMS.TITLE=Unable to connect to Streams
 UNABLE_TO_CONNECT_TO_STREAMS.MESSAGE=Unable to connect to Streams
 
+SCIM_CLIENT_ERROR.TITLE=Unable to connect to SCIM server
+SCIM_CLIENT_ERROR.MESSAGE=Unable to connect to SCIM server, error was: {0}
+
 UNABLE_TO_PERFORM_EXPORT.TITLE=Unable to run export
 UNABLE_TO_PERFORM_EXPORT.MESSAGE=Unable to run export
 


### PR DESCRIPTION
SCIM client used to fetch users and groups through SCIM API for sharing
now catch SCIM Exceptions and wrap them in TDPException with a relevant
message.

https://jira.talendforge.org/browse/TDP-3414

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
