### PR TITLE
fix(TDP-3709): set header column details height to 48px

### DIFF
--- a/dataprep-webapp/src/app/components/suggestions-stats/actions-suggestions/_action-suggestions.scss
+++ b/dataprep-webapp/src/app/components/suggestions-stats/actions-suggestions/_action-suggestions.scss
@@ -10,7 +10,7 @@
   9 rue Pages 92150 Suresnes, France
 
   ============================================================================*/
-$header-col-details: 38px;
+$header-col-details: $navbar-height;
 $header-tabs-height: 29px;
 $search-actions-height: 25px;
 


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-3709

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)
A double scrollbar appears on actions part. 

**(Optional) What is the new behavior?**
(Additional information to the Jira)
Only one scrollbar appears after setting the right height.