### PR TITLE
feat(TDP-3332) : fix number of steps displayed for version

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/PreparationRepositoryConfiguration.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/PreparationRepositoryConfiguration.java
@@ -15,6 +15,7 @@ package org.talend.dataprep.configuration;
 import static org.talend.dataprep.conversions.BeanConversionService.RegistrationBuilder.fromBean;
 
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -24,6 +25,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.preparation.Preparation;
 import org.talend.dataprep.api.preparation.PreparationActions;
+import org.talend.dataprep.api.preparation.PreparationUtils;
 import org.talend.dataprep.api.preparation.Step;
 import org.talend.dataprep.conversions.BeanConversionService;
 import org.talend.dataprep.preparation.store.PersistentPreparation;
@@ -74,69 +76,93 @@ public class PreparationRepositoryConfiguration {
             // Preparation -> PersistentPreparation
             conversionService.register(fromBean(Preparation.class) //
                     .toBeans(PersistentPreparation.class) //
-                    .using(PersistentPreparation.class, (preparation, persistentPreparation) -> {
-                        final List<Step> steps = preparation.getSteps();
-                        if (steps != null) {
-                            final List<String> stepIds = steps.stream() //
-                                    .map(Step::getId) //
-                                    .collect(Collectors.toList());
-                            persistentPreparation.setSteps(stepIds);
-                        }
-                        return persistentPreparation;
-                    }) //
                     .build());
             // PersistentPreparation -> Preparation
             conversionService.register(fromBean(PersistentPreparation.class) //
                     .toBeans(Preparation.class) //
-                    .using(Preparation.class, (persistentPreparation, preparation) -> {
-                        final PreparationRepository repository = getPreparationRepository(applicationContext);
-                        final List<String> persistentPreparationSteps = persistentPreparation.getSteps();
-                        if (persistentPreparationSteps != null) {
-                            final List<Step> steps = persistentPreparationSteps.stream() //
-                                    .map(step -> conversionService.convert(repository.get(step, PersistentStep.class),
-                                            Step.class)) //
-                                    .collect(Collectors.toList());
-                            preparation.setSteps(steps);
-                        }
-                        return preparation;
-                    }) //
+                    .using(Preparation.class, toPreparation(conversionService, applicationContext)) //
                     .build());
             // Step -> PersistentStep
             conversionService.register(fromBean(Step.class) //
                     .toBeans(PersistentStep.class) //
-                    .using(PersistentStep.class, (step, persistentStep) -> {
-                        if (step.getParent() != null) {
-                            persistentStep.setParentId(step.getParent().getId());
-                        } else {
-                            final String rootStepId = Step.ROOT_STEP.getId();
-                            if (!rootStepId.equals(step.getId())) {
-                                persistentStep.setParentId(rootStepId);
-                            }
-                        }
-                        persistentStep.setContent(step.getContent().getId());
-                        return persistentStep;
-                    }) //
+                    .using(PersistentStep.class, toPersistentStep()) //
                     .build());
             // PersistentStep -> Step
             conversionService.register(fromBean(PersistentStep.class) //
                     .toBeans(Step.class) //
-                    .using(Step.class, (persistentStep, step) -> {
-                        final PreparationRepository repository = getPreparationRepository(applicationContext);
-                        if (!Step.ROOT_STEP.getId().equals(persistentStep.getId())) {
-                            step.setParent(conversionService
-                                    .convert(repository.get(persistentStep.getParentId(), PersistentStep.class), Step.class));
-                        }
-                        final PreparationActions content = repository.get(persistentStep.getContent(),
-                                PreparationActions.class);
-                        step.setContent(content);
-                        return step;
-                    }) //
+                    .using(Step.class, toStep(conversionService, applicationContext)) //
                     .build());
             return conversionService;
         }
 
+        /**
+         * Return a BiFunction that convert a PersistentStep into a Step.
+         *
+         * @param conversionService the famous conversionService.
+         * @param applicationContext the spring application context.
+         * @return a BiFunction that convert a PersistentStep into a Step.
+         */
+        private BiFunction<PersistentStep, Step, Step> toStep(BeanConversionService conversionService,
+                ApplicationContext applicationContext) {
+            return (persistentStep, step) -> {
+                final PreparationRepository repository = getPreparationRepository(applicationContext);
+                if (!Step.ROOT_STEP.getId().equals(persistentStep.getId())) {
+                    step.setParent(conversionService.convert(repository.get(persistentStep.getParentId(), PersistentStep.class),
+                            Step.class));
+                }
+                final PreparationActions content = repository.get(persistentStep.getContent(), PreparationActions.class);
+                step.setContent(content);
+                return step;
+            };
+        }
+
+        /**
+         * @return a BiFunction In charge of converting steps to PersistentStep.
+         */
+        private BiFunction<Step, PersistentStep, PersistentStep> toPersistentStep() {
+            return (step, persistentStep) -> {
+                if (step.getParent() != null) {
+                    persistentStep.setParentId(step.getParent().getId());
+                } else {
+                    final String rootStepId = Step.ROOT_STEP.getId();
+                    if (!rootStepId.equals(step.getId())) {
+                        persistentStep.setParentId(rootStepId);
+                    }
+                }
+                persistentStep.setContent(step.getContent().getId());
+                return persistentStep;
+            };
+        }
+
+        /**
+         * BiFunction in charge of converting PersistentPreparation to Preparation.
+         *
+         * @param conversionService the conversion service.
+         * @param applicationContext the one and only application context.
+         * @return the BiFunction that converts PeristentPreparation to Preparation.
+         */
+        private BiFunction<PersistentPreparation, Preparation, Preparation> toPreparation(BeanConversionService conversionService,
+                ApplicationContext applicationContext) {
+            return (persistentPreparation, preparation) -> {
+                final PreparationRepository repository = getPreparationRepository(applicationContext);
+                final PreparationUtils utils = getPreparationUtils(applicationContext);
+                final List<String> stepsIds = utils.listStepsIds(preparation.getHeadId(), repository);
+                if (stepsIds != null) {
+                    final List<Step> steps = stepsIds.stream() //
+                            .map(step -> conversionService.convert(repository.get(step, PersistentStep.class), Step.class)) //
+                            .collect(Collectors.toList());
+                    preparation.setSteps(steps);
+                }
+                return preparation;
+            };
+        }
+
         private PreparationRepository getPreparationRepository(ApplicationContext applicationContext) {
             return applicationContext.getBean(PreparationRepository.class);
+        }
+
+        private PreparationUtils getPreparationUtils(ApplicationContext applicationContext) {
+            return applicationContext.getBean(PreparationUtils.class);
         }
     }
 

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/preparation/store/PersistentPreparation.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/preparation/store/PersistentPreparation.java
@@ -12,8 +12,6 @@
 
 package org.talend.dataprep.preparation.store;
 
-import java.util.List;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.talend.dataprep.api.dataset.RowMetadata;
 
@@ -55,25 +53,10 @@ public class PersistentPreparation extends PersistentIdentifiable {
     @JsonProperty("app-version")
     private String appVersion;
 
-    /** List of the steps id for this preparation. */
-    private List<String> steps;
-
     /**
      * Default empty constructor.
      */
     public PersistentPreparation() {
-    }
-
-    /**
-     * @return List of the steps id for this preparation.
-     * @see org.talend.dataprep.preparation.store.PreparationRepository#get(String, Class)
-     */
-    public List<String> getSteps() {
-        return steps;
-    }
-
-    public void setSteps(List<String> steps) {
-        this.steps = steps;
     }
 
     public String getName() {

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/api/preparation/PreparationUtilsTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/api/preparation/PreparationUtilsTest.java
@@ -311,13 +311,15 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         // Given
         final Preparation preparation = new Preparation();
         preparation.setId("prep-1234");
-        final Step step1 = new FixedIdStep("step-1234");
-        final Step step2 = new FixedIdStep("step-5678");
+        final Step step1 = new FixedIdStep("step-1234", rootStep);
+        final Step step2 = new FixedIdStep("step-5678", step1);
         final PreparationActions actions1 = new FixedIdPreparationContent("actions-1234");
         final PreparationActions actions2 = new FixedIdPreparationContent("actions-5678");
         step1.setContent(actions1);
         step2.setContent(actions2);
-        preparation.setSteps(Arrays.asList(step1, step2));
+        final List<Step> expectedSteps = Arrays.asList(rootStep, step1, step2);
+        preparation.setSteps(expectedSteps);
+        preparation.setHeadId(step2.getId());
 
         // When
         repository.add(preparation);
@@ -326,13 +328,11 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         // Then
         assertEquals(PersistentPreparationRepository.class, repository.getClass());
         assertEquals(preparation.getId(), savedPreparation.getId());
-        assertEquals(2, savedPreparation.getSteps().size());
-        assertEquals("step-1234", savedPreparation.getSteps().get(0).getId());
-        assertEquals("step-5678", savedPreparation.getSteps().get(1).getId());
-        assertNotNull(savedPreparation.getSteps().get(0).getContent());
-        assertNotNull(savedPreparation.getSteps().get(1).getContent());
-        assertEquals("actions-1234", savedPreparation.getSteps().get(0).getContent().getId());
-        assertEquals("actions-5678", savedPreparation.getSteps().get(1).getContent().getId());
+        final List<Step> actualSteps = savedPreparation.getSteps();
+        assertEquals(expectedSteps.size(), actualSteps.size());
+        assertEquals(rootStep, actualSteps.get(0));
+        assertEquals(step1.getId(), actualSteps.get(1).getId());
+        assertEquals(step2.getId(), actualSteps.get(2).getId());
     }
 
 

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/preparation/FixedIdStep.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/preparation/FixedIdStep.java
@@ -23,6 +23,11 @@ public class FixedIdStep extends Step {
         this.fixedId = fixedId;
     }
 
+    public FixedIdStep(String fixedId, Step parent) {
+        super(parent, null, null);
+        this.fixedId = fixedId;
+    }
+
     @Override
     public String id() {
         return fixedId;


### PR DESCRIPTION
Remove the list of steps id from the PersistentStep object and browse the steps tree from mongodb every time a preparation is read

**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-3332

**Please check if the PR fulfills these requirements**
- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [X] The new code does not introduce new technical issues (sonar / eslint)
- [X] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [X] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)


**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:
