### PR TITLE
bugfix(TDP-3718) : preparation versioning deal with deleted steps

### DIFF
--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -550,7 +550,9 @@ public class PreparationService {
 
         // specify the step id if provided
         if (!StringUtils.equals("head", stepId)) {
-            if (preparation.getSteps().stream().map(s -> s.getId()).anyMatch(s -> s.equals(stepId))) {
+            // just make sure the step does exist
+            final Step step = preparationRepository.get(stepId, Step.class);
+            if (step != null) {
                 preparation.setHeadId(stepId);
             } else {
                 throw new TDPException(PREPARATION_STEP_DOES_NOT_EXIST, build().put("id", preparation).put("stepId", stepId));
@@ -707,6 +709,9 @@ public class PreparationService {
      * <li>3. Set preparation head to STD's parent, so STD will be excluded</li>
      * <li>4. Append each action after the new preparation head</li>
      * </ul>
+     *
+     * @param id the preparation id.
+     * @param stepToDeleteId the step id to delete.
      */
     public void deleteAction(final String id, final String stepToDeleteId) {
         if (rootStep.getId().equals(stepToDeleteId)) {
@@ -1167,8 +1172,8 @@ public class PreparationService {
     /**
      * Append a single appendStep after the preparation head
      *
-     * @param preparation The preparation
-     * @param appendStep The appendStep to apply
+     * @param preparation The preparation.
+     * @param appendStep The appendStep to apply.
      */
     private void appendStepToHead(final Preparation preparation, final AppendStep appendStep) {
         // Add new actions after head

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/task/OrphanStepsFinder.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/task/OrphanStepsFinder.java
@@ -1,0 +1,29 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.preparation.task;
+
+import java.util.Set;
+
+import org.talend.dataprep.api.preparation.Step;
+
+/**
+ * Interface that defines a way to retrieve orphan steps (steps that are not used anymore).
+ */
+public interface OrphanStepsFinder {
+
+    /**
+     * @return all orphan steps.
+     */
+    Set<Step> getOrphanSteps();
+}

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/task/PreparationOrphanStepsFinder.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/task/PreparationOrphanStepsFinder.java
@@ -1,0 +1,66 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.preparation.task;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.annotation.Resource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.talend.dataprep.api.preparation.Preparation;
+import org.talend.dataprep.api.preparation.PreparationUtils;
+import org.talend.dataprep.api.preparation.Step;
+import org.talend.dataprep.preparation.store.PreparationRepository;
+
+/**
+ * Preparation based implementation of the OrphanStepsFinder.
+ */
+@Component
+public class PreparationOrphanStepsFinder implements OrphanStepsFinder {
+
+    @Autowired
+    private PreparationRepository repository;
+
+    @Autowired
+    private PreparationUtils preparationUtils;
+
+    /** The root step. */
+    @Resource(name = "rootStep")
+    private Step rootStep;
+
+    @Override
+    public Set<Step> getOrphanSteps() {
+
+        final Collection<Step> steps = repository.list(Step.class).collect(toList());
+        final Set<String> preparationStepIds = getUsedSteps();
+
+        final Predicate<Step> isNotRootStep = step -> !rootStep.getId().equals(step.getId());
+        final Predicate<Step> isOrphan = step -> !preparationStepIds.contains(step.getId());
+
+        return steps.stream().filter(isNotRootStep).filter(isOrphan).collect(toSet());
+    }
+
+    private Set<String> getUsedSteps() {
+        return repository.list(Preparation.class) //
+                .flatMap(prep -> preparationUtils.listStepsIds(prep.getHeadId(), repository).stream()) //
+                .collect(toSet());
+    }
+
+}

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/service/PreparationControllerTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/service/PreparationControllerTest.java
@@ -337,7 +337,7 @@ public class PreparationControllerTest extends BasePreparationTest {
         try {
             // when
             clientTest.getDetails(preparationId, "toutouyoutou");
-            fail("well done, you managed to get the details out of an unkown step !");
+            fail("well done, you managed to get the details out of an unknown step !");
         } catch (MockTDPException e) {
             // then
             assertEquals(404, e.getStatusCode());

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/task/PreparationOrphanStepsFinderTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/task/PreparationOrphanStepsFinderTest.java
@@ -1,0 +1,67 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.preparation.task;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.talend.dataprep.api.preparation.Preparation;
+import org.talend.dataprep.api.preparation.Step;
+import org.talend.dataprep.preparation.BasePreparationTest;
+import org.talend.dataprep.preparation.FixedIdPreparationContent;
+
+/**
+ * Unit tests for the PreparationOrphanStepFinder.
+ *
+ * @see PreparationOrphanStepsFinder
+ */
+public class PreparationOrphanStepsFinderTest extends BasePreparationTest {
+
+    @Autowired
+    private PreparationOrphanStepsFinder finder;
+
+    @Before
+    public void localSetup() throws Exception {
+        repository.clear();
+    }
+
+    @Test
+    public void shouldListOrphanSteps() {
+
+        // given
+        final Step firstStep = new Step(rootStep, new FixedIdPreparationContent("first"), "2.1");
+        final Step secondStep = new Step(firstStep, new FixedIdPreparationContent("second"), "2.1");
+        final Preparation preparation = new Preparation("#123", "1", secondStep.id(), "2.1");
+
+        repository.add(firstStep);
+        repository.add(secondStep);
+        repository.add(preparation);
+
+        final Step orphanStep = new Step(rootStep, new FixedIdPreparationContent("orphan"), "2.1");
+        repository.add(orphanStep);
+
+        // when
+        final Set<Step> orphanSteps = finder.getOrphanSteps();
+
+        // then
+        assertNotNull(orphanSteps);
+        assertEquals(1, orphanSteps.size());
+        assertEquals(orphanStep, orphanSteps.iterator().next());
+    }
+}

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/test/PreparationClientTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/test/PreparationClientTest.java
@@ -132,6 +132,14 @@ public class PreparationClientTest {
     }
 
     /**
+     * @param preparationId the wanted preparation id.
+     * @return the preparation details from its id.
+     */
+    public PreparationMessage getDetails(String preparationId) {
+        return getDetails(preparationId, null);
+    }
+
+    /**
      * Return the details of a preparation at a given (optional) step.
      *
      * @param preparationId the wanted preparation id.
@@ -206,5 +214,9 @@ public class PreparationClientTest {
      */
     public void setPreparationHead(String preparationId, String headId) {
         put("/preparations/{id}/head/{headId}", preparationId, headId);
+    }
+
+    public void deleteStep(String prepId, String stepIdToRemove) {
+        when().delete("/preparations/{id}/actions/{action}", prepId, stepIdToRemove);
     }
 }


### PR DESCRIPTION
 * AppendStep now have the previous step id (when available)
 * replaceHistory method is overriden in EEPreparationService to update versions steps id.

**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-3718

**Please check if the PR fulfills these requirements**
- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [X] The new code does not introduce new technical issues (sonar / eslint)
- [X] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [X] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)


**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:
