### PR TITLE
fix(TDP-1761): save aggregation after renaming a preparation

### DIFF
--- a/dataprep-webapp/src/app/services/preparation/preparation-service.js
+++ b/dataprep-webapp/src/app/services/preparation/preparation-service.js
@@ -102,15 +102,11 @@ export default function PreparationService($q, $state, $window, $stateParams, St
 	 * @param {string} preparationId The preparation id
 	 * @param {string} name The preparation name
 	 * @description Create a new preparation if no preparation is loaded, update the name otherwise
-	 * @returns {promise} The POST promise
+	 * @returns {promise} The PUT promise
 	 */
 	function setName(preparationId, name) {
 		return PreparationRestService.update(preparationId, { name })
-			.then(preparationId => PreparationRestService.getDetails(preparationId))
-			.then((preparation) => {
-				StorageService.moveAggregations(preparation.dataSetId, preparationId, preparation.id);
-				return preparation;
-			});
+			.then(preparationId => PreparationRestService.getDetails(preparationId));
 	}
 
 	/**

--- a/dataprep-webapp/src/app/services/preparation/preparation-service.spec.js
+++ b/dataprep-webapp/src/app/services/preparation/preparation-service.spec.js
@@ -45,7 +45,6 @@ describe('Preparation Service', () => {
 
         spyOn(StorageService, 'savePreparationAggregationsFromDataset').and.returnValue();
         spyOn(StorageService, 'removeAllAggregations').and.returnValue();
-        spyOn(StorageService, 'moveAggregations').and.returnValue();
     }));
 
     afterEach(inject((StateService) => {
@@ -112,20 +111,6 @@ describe('Preparation Service', () => {
 
                 //then
                 expect(PreparationRestService.update).toHaveBeenCalledWith(preparationId, {name});
-            }));
-
-            it('should move aggregations to the new preparation id key in localStorage', inject(($rootScope, PreparationService, StorageService) => {
-                //given
-                const preparationId = '6cd546546548a745';
-                const name = 'my preparation';
-                expect(StorageService.moveAggregations).not.toHaveBeenCalled();
-
-                //when
-                PreparationService.setName(preparationId, name);
-                $rootScope.$digest();
-
-                //then
-                expect(StorageService.moveAggregations).toHaveBeenCalledWith(updatedDatasetId, preparationId, newPreparationId);
             }));
         });
 

--- a/dataprep-webapp/src/app/services/utils/storage/storage-service.js
+++ b/dataprep-webapp/src/app/services/utils/storage/storage-service.js
@@ -289,44 +289,6 @@ export default class StorageService {
 		});
 	}
 
-    /**
-     * @ngdoc method
-     * @name moveAggregations
-     * @methodOf data-prep.services.utils.service:StorageService
-     * @param {string} datasetId The dataset id
-     * @param {string} oldPreparationId The new preparation id
-     * @param {string} newPreparationId The old preparation id
-     * @description Move all preparation aggregation to another preparation id
-     */
-	moveAggregations(datasetId, oldPreparationId, newPreparationId) {
-		const preparationAggregationPrefix = this.getAggregationKey(
-            datasetId,
-            oldPreparationId,
-            ''
-        );
-		const aggregationsToMove = [];
-
-		for (let i = 0, len = this.$window.localStorage.length; i < len; i++) {
-			const key = this.$window.localStorage.key(i);
-			if (key.indexOf(preparationAggregationPrefix) === 0) {
-				aggregationsToMove.push({
-					columnId: key.substring(key.lastIndexOf('.') + 1),
-					aggregation: this.getItem(key),
-				});
-			}
-		}
-
-		aggregationsToMove.forEach((aggregDef) => {
-			this.setAggregation(
-                datasetId,
-                newPreparationId,
-                aggregDef.columnId,
-                aggregDef.aggregation
-            );
-			this.removeAggregation(datasetId, oldPreparationId, aggregDef.columnId);
-		});
-	}
-
     // --------------------------------------------------------------------------------------------
     // -------------------------------------------Lookup-------------------------------------------
     // --------------------------------------------------------------------------------------------

--- a/dataprep-webapp/src/app/services/utils/storage/storage-service.spec.js
+++ b/dataprep-webapp/src/app/services/utils/storage/storage-service.spec.js
@@ -261,44 +261,6 @@ describe('Storage service', () => {
 			expect($window.localStorage.getItem(prepKey1)).toBe(aggregation1);
 			expect($window.localStorage.getItem(prepKey2)).toBe(aggregation2);
 		}));
-
-		it('should move all preparation aggregations to the new preparation id', inject(($window, StorageService) => {
-			// given
-			const datasetId = '87a646f763bd545b684';
-			const oldPreparationId = '72515d3212cf565b624';
-			const newPreparationId = '8ef6254d6214554bb68';
-			const aggregation1 = JSON.stringify({
-				aggregation: 'MAX',
-				aggregationColumnId: '0002',
-			});
-			const aggregation2 = JSON.stringify({
-				aggregation: 'SUM',
-				aggregationColumnId: '0003',
-			});
-			const otherAggregation = JSON.stringify({
-				aggregation: 'MIN',
-				aggregationColumnId: '0003',
-			});
-
-			const oldPrepKey1 = 'org.talend.dataprep.aggregation.87a646f763bd545b684.72515d3212cf565b624.0001';
-			const oldPrepKey2 = 'org.talend.dataprep.aggregation.87a646f763bd545b684.72515d3212cf565b624.0002';
-			const otherKey = 'org.talend.dataprep.aggregation.9b87564ef564e651.56ef46541e32251a25.0002';
-			$window.localStorage.setItem(oldPrepKey1, aggregation1);
-			$window.localStorage.setItem(oldPrepKey2, aggregation2);
-			$window.localStorage.setItem(otherKey, otherAggregation);
-
-			// when
-			StorageService.moveAggregations(datasetId, oldPreparationId, newPreparationId);
-
-			// then
-			const newPrepKey1 = 'org.talend.dataprep.aggregation.87a646f763bd545b684.8ef6254d6214554bb68.0001';
-			const newPrepKey2 = 'org.talend.dataprep.aggregation.87a646f763bd545b684.8ef6254d6214554bb68.0002';
-			expect($window.localStorage.getItem(oldPrepKey1)).toBeFalsy();
-			expect($window.localStorage.getItem(oldPrepKey2)).toBeFalsy();
-			expect($window.localStorage.getItem(newPrepKey1)).toBe(aggregation1);
-			expect($window.localStorage.getItem(newPrepKey2)).toBe(aggregation2);
-			expect($window.localStorage.getItem(otherKey)).toBe(otherAggregation);
-		}));
 	});
 
 	describe('lookup', () => {


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-1761

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)
Formerly backend used to edit the preparation ID after a PUT request, so had to deal with the new ID in the Frontend side. This adaptation was causing the bug.

**(Optional) What is the new behavior?**
(Additional information to the Jira)
Deleted useless frontend code


**(Optional) Other information**:
