### PR TITLE
fix/TDP-3388 use more strict date patterns which do not allow padding…

### DIFF
--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/DateParserTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/DateParserTest.java
@@ -104,7 +104,8 @@ public class DateParserTest extends BaseDateTest {
     @Test
     public void shouldComputePatternFromDQ() {
         final ColumnMetadata column = ActionMetadataTestUtils.getColumn(Type.DATE);
-        assertEquals(new DatePattern("d/M/yyyy", 1), action.guessPattern("01/02/2015", column));
+        assertEquals(new DatePattern("dd/MM/yyyy", 1), action.guessPattern("01/02/2015", column));
+        assertEquals(new DatePattern("d/M/yyyy", 1), action.guessPattern("1/2/2015", column));
         assertEquals(new DatePattern("yyyy-MM-dd", 1), action.guessPattern("2015-01-02", column));
         assertEquals(new DatePattern("9999", 1), action.guessPattern("2015", column));
         assertEquals(new DatePattern("MMMM d yyyy", 1), action.guessPattern("July 14 2015", column));
@@ -140,6 +141,6 @@ public class DateParserTest extends BaseDateTest {
         // then
         final List<PatternFrequency> actual = column.getStatistics().getPatternFrequencies();
         assertEquals(2, actual.size());
-        assertEquals(new PatternFrequency("d/M/yyyy", 1), actual.get(1));
+        assertEquals(new PatternFrequency("dd/MM/yyyy", 1), actual.get(1));
     }
 }

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/fill/FillWithDateIfEmptyTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/fill/FillWithDateIfEmptyTest.java
@@ -75,7 +75,7 @@ public class FillWithDateIfEmptyTest extends AbstractMetadataBaseTest {
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
-        assertEquals("1/1/1970 10:00:00", row.get("0001"));
+        assertEquals("01/01/1970 10:00:00", row.get("0001"));
         assertEquals("David Bowie", row.get("0000"));
     }
 

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/fill/FillWithDateTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/fill/FillWithDateTest.java
@@ -71,7 +71,7 @@ public class FillWithDateTest extends AbstractMetadataBaseTest {
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
-        assertEquals("1/1/1970 10:00:00", row.get("0001"));
+        assertEquals("01/01/1970 10:00:00", row.get("0001"));
         assertEquals("David Bowie", row.get("0000"));
     }
 
@@ -90,7 +90,7 @@ public class FillWithDateTest extends AbstractMetadataBaseTest {
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
-        assertEquals("1/1/1970 10:00:00", row.get("0001"));
+        assertEquals("01/01/1970 10:00:00", row.get("0001"));
         assertEquals("David Bowie", row.get("0000"));
     }
 

--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -32,12 +32,12 @@
         <junit.version>4.12</junit.version>
         <tika.version>1.12</tika.version>
         <org.talend.daikon.version>0.16.0</org.talend.daikon.version>
-        <org.talend.dataquality.common.version>1.6.1</org.talend.dataquality.common.version>
-        <org.talend.dataquality.semantic.version>1.6.1</org.talend.dataquality.semantic.version>
-        <org.talend.dataquality.statistics.version>1.6.1</org.talend.dataquality.statistics.version>
-        <org.talend.dataquality.record.linkage.version>3.3.1</org.talend.dataquality.record.linkage.version>
-        <org.talend.dataquality.sampling.version>2.4.1</org.talend.dataquality.sampling.version>
-        <org.talend.dataquality.standardization.version>3.3.1</org.talend.dataquality.standardization.version>
+        <org.talend.dataquality.common.version>1.6.2</org.talend.dataquality.common.version>
+        <org.talend.dataquality.semantic.version>1.6.2</org.talend.dataquality.semantic.version>
+        <org.talend.dataquality.statistics.version>1.6.2</org.talend.dataquality.statistics.version>
+        <org.talend.dataquality.record.linkage.version>3.3.2</org.talend.dataquality.record.linkage.version>
+        <org.talend.dataquality.sampling.version>2.4.2</org.talend.dataquality.sampling.version>
+        <org.talend.dataquality.standardization.version>3.3.2</org.talend.dataquality.standardization.version>
         <org.talend.dataquality.converters.version>1.0.1</org.talend.dataquality.converters.version>
         <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
         <project.inceptionYear>2015</project.inceptionYear>

--- a/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/analysis/asynchronous/StatisticsAnalysisTest.java
+++ b/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/analysis/asynchronous/StatisticsAnalysisTest.java
@@ -62,11 +62,9 @@ public class StatisticsAnalysisTest extends DataSetBaseTest {
         assertThat(dateOfBirth.getType(), is("date"));
         final List<PatternFrequency> patternFrequencies = dateOfBirth.getStatistics().getPatternFrequencies();
         final List<String> patterns = patternFrequencies.stream().map(pf -> pf.getPattern()).collect(Collectors.toList());
-        assertThat(patterns.size(), is(7));
+        assertThat(patterns.size(), is(5));
         assertTrue(patterns.contains("MM/dd/yyyy"));
-        assertTrue(patterns.contains("d/M/yyyy"));
-        assertTrue(patterns.contains("d/M/yyyy"));
-        assertTrue(patterns.contains("M/d/yyyy"));
+        assertTrue(patterns.contains("dd/MM/yyyy"));
         assertTrue(patterns.contains("aaaaa"));
         assertTrue(patterns.contains("yyyy-MM-dd"));
         assertTrue(patterns.contains("yyyy-M-d"));

--- a/dataprep-dataset/src/test/resources/org/talend/dataprep/dataset/date_time_pattern_expected.json
+++ b/dataprep-dataset/src/test/resources/org/talend/dataprep/dataset/date_time_pattern_expected.json
@@ -33,10 +33,6 @@
   ],
   "patternFrequencyTable": [
     {
-      "pattern": "d/M/yyyy H:mm:ss",
-      "occurrences": 5
-    },
-    {
       "pattern": "dd/MM/yyyy HH:mm:ss",
       "occurrences": 5
     },
@@ -49,20 +45,24 @@
       "occurrences": 5
     },
     {
-      "pattern": "M/d/yyyy HH:mm:ss",
+      "pattern": "MM/dd/yyyy H:mm:ss",
       "occurrences": 5
+    },
+    {
+      "pattern": "d/M/yyyy H:mm:ss",
+      "occurrences": 2
+    },
+    {
+      "pattern": "M/d/yyyy HH:mm:ss",
+      "occurrences": 2
     },
     {
       "pattern": "M/d/yyyy H:mm:ss",
-      "occurrences": 5
+      "occurrences": 2
     },
     {
       "pattern": "d/M/yyyy HH:mm:ss",
-      "occurrences": 5
-    },
-    {
-      "pattern": "MM/dd/yyyy H:mm:ss",
-      "occurrences": 5
+      "occurrences": 2
     }
   ],
   "quantiles": {


### PR DESCRIPTION
… zeroes for single M and/or d

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3388
https://jira.talendforge.org/browse/TDQ-13369

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)


**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:
