### PR TITLE
Fix/tdp 3715 Preparation is created although close the dataset without saving preparation

### DIFF
--- a/dataprep-webapp/src/app/components/playground/playground-controller.js
+++ b/dataprep-webapp/src/app/components/playground/playground-controller.js
@@ -169,8 +169,10 @@ export default function PlaygroundCtrl($state, $stateParams, state, StateService
 	 * @description Discard implicit preparation save. This trigger a preparation delete.
 	 */
 	vm.discardSaveOnClose = () => {
-		PreparationService.delete(state.playground.preparation);
-		PlaygroundService.close();
+		PlaygroundService.startLoader();
+		PreparationService.delete(state.playground.preparation)
+			.then(PlaygroundService.close)
+			.finally(PlaygroundService.stopLoader);
 	};
 
 	/**

--- a/dataprep-webapp/src/app/components/playground/playground-controller.spec.js
+++ b/dataprep-webapp/src/app/components/playground/playground-controller.spec.js
@@ -357,6 +357,7 @@ describe('Playground controller', () => {
 			it('should call startLoader', inject((PlaygroundService) => {
 				// given
 				spyOn(PlaygroundService, 'startLoader');
+
 				// when
 				ctrl.discardSaveOnClose();
 
@@ -367,6 +368,7 @@ describe('Playground controller', () => {
 			it('should call stopLoader', inject((PlaygroundService) => {
 				// given
 				spyOn(PlaygroundService, 'stopLoader');
+
 				// when
 				ctrl.discardSaveOnClose();
 				scope.$digest();

--- a/dataprep-webapp/src/app/components/playground/playground-controller.spec.js
+++ b/dataprep-webapp/src/app/components/playground/playground-controller.spec.js
@@ -354,6 +354,27 @@ describe('Playground controller', () => {
 		});
 
 		describe('discard preparation', () => {
+			it('should call startLoader', inject((PlaygroundService) => {
+				// given
+				spyOn(PlaygroundService, 'startLoader');
+				// when
+				ctrl.discardSaveOnClose();
+
+				// then
+				expect(PlaygroundService.startLoader).toHaveBeenCalled();
+			}));
+
+			it('should call stopLoader', inject((PlaygroundService) => {
+				// given
+				spyOn(PlaygroundService, 'stopLoader');
+				// when
+				ctrl.discardSaveOnClose();
+				scope.$digest();
+
+				// then
+				expect(PlaygroundService.stopLoader).toHaveBeenCalled();
+			}));
+
 			it('should delete current preparation', inject((PreparationService) => {
 				// when
 				ctrl.discardSaveOnClose();


### PR DESCRIPTION
**Link to the JIRA issue**
e.g. https://jira.talendforge.org/browse/TDP-3715

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)


**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:
