### PR TITLE
fix(TDP-3801): Support code for versioned preparations

### DIFF
--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/ExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/ExportStrategy.java
@@ -208,6 +208,7 @@ public abstract class ExportStrategy {
 
     /**
      * @param preparationId the wanted preparation id.
+     * @param stepId the preparation step (might be different from head's to navigate through versions).
      * @return the preparation out of its id.
      */
     protected PreparationMessage getPreparation(String preparationId, String stepId) {

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/ExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/ExportStrategy.java
@@ -203,15 +203,22 @@ public abstract class ExportStrategy {
      * @return the preparation out of its id.
      */
     protected PreparationMessage getPreparation(String preparationId) {
+        return getPreparation(preparationId, null);
+    }
+
+    /**
+     * @param preparationId the wanted preparation id.
+     * @return the preparation out of its id.
+     */
+    protected PreparationMessage getPreparation(String preparationId, String stepId) {
         final PreparationDetailsGet preparationDetailsGet = applicationContext.getBean(PreparationDetailsGet.class,
-                preparationId);
+                preparationId, stepId);
         try (InputStream details = preparationDetailsGet.execute()) {
             return mapper.readerFor(PreparationMessage.class).readValue(details);
         } catch (Exception e) {
             LOGGER.error("Unable to read preparation {}", preparationId, e);
             throw new TDPException(UNABLE_TO_READ_PREPARATION, e, build().put("id", preparationId));
         }
-
     }
 
 }


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3801

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)

* Add way to retrieve preparation at given step (overload of getPreparation(...)).