### PR TITLE
fix(TDP-3553) update DQ libs to include latest bug fixes

### DIFF
--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -31,12 +31,12 @@
         <junit.version>4.12</junit.version>
         <tika.version>1.12</tika.version>
         <org.talend.daikon.version>0.13.0</org.talend.daikon.version>
-        <org.talend.dataquality.common.version>1.5.7</org.talend.dataquality.common.version>
-        <org.talend.dataquality.semantic.version>1.5.7</org.talend.dataquality.semantic.version>
-        <org.talend.dataquality.statistics.version>1.5.7</org.talend.dataquality.statistics.version>
-        <org.talend.dataquality.record.linkage.version>3.2.7</org.talend.dataquality.record.linkage.version>
-        <org.talend.dataquality.sampling.version>2.3.7</org.talend.dataquality.sampling.version>
-        <org.talend.dataquality.standardization.version>3.2.7</org.talend.dataquality.standardization.version>
+        <org.talend.dataquality.common.version>1.5.8-SNAPSHOT</org.talend.dataquality.common.version>
+        <org.talend.dataquality.semantic.version>1.5.8-SNAPSHOT</org.talend.dataquality.semantic.version>
+        <org.talend.dataquality.statistics.version>1.5.8-SNAPSHOT</org.talend.dataquality.statistics.version>
+        <org.talend.dataquality.record.linkage.version>3.2.8-SNAPSHOT</org.talend.dataquality.record.linkage.version>
+        <org.talend.dataquality.sampling.version>2.3.8-SNAPSHOT</org.talend.dataquality.sampling.version>
+        <org.talend.dataquality.standardization.version>3.2.8-SNAPSHOT</org.talend.dataquality.standardization.version>
         <spring-boot.version>1.4.2.RELEASE</spring-boot.version>
         <project.inceptionYear>2015</project.inceptionYear>
         <project.organization>Talend</project.organization>


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3553 (aka. https://jira.talendforge.org/browse/TDQ-13467) UK Postcode falsely marked as invalid

new DQ libs also contains fixes for the following jiras:
https://jira.talendforge.org/browse/TDQ-13297 Adding an invalid regex breaks Dataprep and TDS. 
https://jira.talendforge.org/browse/TDQ-13046 provide serializable object to hold regexes

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
(Additional information to the Jira)


**(Optional) What is the new behavior?**
(Additional information to the Jira)


**(Optional) Other information**:
