### PR TITLE
fix(TDP-3927): serialize nextId in RowMetadata

### DIFF
--- a/dataprep-api/src/test/resources/org/talend/dataprep/api/service/dataset/bug_TDP-3927_import-col-not-deleted_truncated.csv
+++ b/dataprep-api/src/test/resources/org/talend/dataprep/api/service/dataset/bug_TDP-3927_import-col-not-deleted_truncated.csv
@@ -1,0 +1,11 @@
+id;first_name;last_name;email;company;city;country;date
+470788;Mildred;Hudson;mhudson0@last.fm;Kazio;IporÃ£;Brazil;31/12/2014
+857729;WALTER;MYERS;wmyers1@spiegel.de;Gabcube;Aibura;Indonesia;5/25/2015
+529929;Eugene;Cook;ecook2@yelp.com;Gigabox;Jinqu;China;10-13-2015
+269130;Pamela;Owens;powens3@goo.ne.jp;Leenti;Changmaoling;China;5/25/2015
+544790;Chris;Chapman;cchapman4@theguardian.com;Ozu;Sapiranga;Brazil;3/22/2015
+741711;Margaret;Morris;mmorris5@studiopress.com;Jabbertype;Venlo;Netherlands;3/20/2015
+860052;johnny;peters;jpeters6@hp.com;Divape;El Hamma;Tunisia;8/24/2015
+849916;Roy;Price;rprice7@thetimes.co.uk;Skippad;Tiá»?n Háº£i;Vietnam;06/07/2015
+101171;Diana;Cole;dcole8@baidu.com;Zoonder;JifnÄ?;Palestinian Territory;4/23/2015
+540096;Ashley;Cox;acox9@arstechnica.com;Geba;Mabusag;Philippines;06/03/2015

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/RowMetadata.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/RowMetadata.java
@@ -53,6 +53,7 @@ public class RowMetadata implements Serializable {
     @JsonDeserialize(using = ColumnContextDeserializer.class)
     private final List<ColumnMetadata> columns = new ArrayList<>();
 
+    @JsonProperty("nextId")
     private int nextId = 0;
 
     /**

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/api/dataset/RowMetadataTest.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/api/dataset/RowMetadataTest.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 import org.talend.dataprep.api.dataset.row.Flag;
 import org.talend.dataprep.api.type.Type;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * Unit test for the RowMetadata class.
  *
@@ -307,6 +309,25 @@ public class RowMetadataTest {
     public void shouldReturnTrueForRowMetadata() throws Exception {
         assertThat(RowMetadata.class, isSerializable());
     }
+
+    @Test
+    public void shouldSerializeNextId_TDP3927() throws Exception {
+
+        RowMetadata value = new RowMetadata();
+        value.addColumn(getColumnMetadata("toto"));
+        value.deleteColumnById("0000");
+
+        ObjectMapper mapper = new ObjectMapper();
+        String valueAsString = mapper.writeValueAsString(value);
+        value = mapper.readValue(valueAsString, RowMetadata.class);
+
+        ColumnMetadata addedColumn = new ColumnMetadata();
+        addedColumn.setName("added_column");
+        value.addColumn(addedColumn);
+
+        assertEquals("0001", addedColumn.getId());
+    }
+
 
     /**
      * @param name the column name.

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
@@ -282,18 +282,21 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
             );
             LOGGER.debug("Previous content cache key: " + transformationCacheKey.getKey());
             LOGGER.debug("Previous content cache key details: " + transformationCacheKey.toString());
-            final InputStream inputStream = contentCache.get(transformationCacheKey);
-            try {
+
+            return isCachePresent() ? this : null;
+        }
+
+        private boolean isCachePresent() throws IOException {
+            boolean cachePresent;
+            try (final InputStream inputStream = contentCache.get(transformationCacheKey)) {
                 if (inputStream == null) {
                     LOGGER.debug("No content cached for previous version '{}'", previousVersion);
-                    return null;
-                }
-            } finally {
-                if (inputStream != null) {
-                    inputStream.close();
+                    cachePresent = false;
+                } else {
+                    cachePresent = true;
                 }
             }
-            return this;
+            return cachePresent;
         }
     }
 


### PR DESCRIPTION
- add cool tests methods in testClient
- add integration test in PreparationAPITest
- make RowMetadata.nextId field serializable by jackson
- add TU to RowMetadata
- small refacto in OptimizedExportStrategy

The bug came from the OptimizedExportStrategy that base its transformation on
cached data. when applying the transformation, RowMetadata had its nextId
field reset and new column ids where not the same as without optimization.
Correction makes nextId serialized in cache.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3927

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ x Tests for the changes have been added (for bug fixes / features)
- [ x Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
