### PR TITLE
fix(TDP-3964): fix preparations versions import

### DIFF
--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/test/APIClientTest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/test/APIClientTest.java
@@ -13,6 +13,7 @@
 
 package org.talend.dataprep.api.service.test;
 
+import static com.jayway.restassured.RestAssured.expect;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -36,6 +37,7 @@ import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.dataset.RowMetadata;
 import org.talend.dataprep.api.preparation.Action;
 import org.talend.dataprep.api.preparation.MixedContentMap;
+import org.talend.dataprep.api.preparation.Preparation;
 import org.talend.dataprep.api.service.PreparationAPITest;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -178,6 +180,22 @@ public class APIClientTest {
         given().contentType(JSON.withCharset(UTF_8)).content(actions) //
                 .when().post("/api/preparations/{id}/actions", preparationId) //
                 .then().statusCode(is(200));
+    }
+
+    /**
+     * Fetch the preparation metadata.
+     *
+     * @param preparationId id of the preparation to fetch
+     * @return the preparation details
+     * @throws IOException if a connexion or parsing error happen
+     */
+    public Preparation getPreparation(String preparationId) throws IOException {
+        String json = //
+                expect() //
+                        .statusCode(200).log().ifValidationFails() //
+                        .when() //
+                        .get("/api/preparations/{id}/details", new Object[] { preparationId }).asString();
+        return mapper.readerFor(Preparation.class).readValue(json);
     }
 
     /**

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/conversions/BeanConversionServiceTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/conversions/BeanConversionServiceTest.java
@@ -157,11 +157,13 @@ public class BeanConversionServiceTest {
         // Given
         conversionService.register(fromBean(ModelA.class).toBeans(ModelA1.class, ModelA2.class).build());
 
-        // Then
+        // When
         final ModelA1 convert = conversionService.convert(new ModelA("test"), ModelA1.class, (modelA, modelA1) -> {
             modelA1.setProperty("On the fly modified value");
             return modelA1;
         });
+
+        // Then
         assertEquals(ModelA1.class, convert.getClass());
         assertEquals("On the fly modified value", convert.getProperty());
     }
@@ -199,6 +201,5 @@ public class BeanConversionServiceTest {
         assertEquals("test", modelA2.getProperty());
         assertEquals("custom", modelA2.getCustom());
     }
-
 
 }


### PR DESCRIPTION
- bean conversion with "on the fly" apply registered conversions beforehand
- add tests in integration suite
- extract interface for bean conversion modules

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3964

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
