### PR TITLE
fix: dropdown items should not have icons

### DIFF
--- a/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-controller.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-controller.js
@@ -182,11 +182,11 @@ export default class InventoryListCtrl {
 		return this.SettingsActionsService.createDispatcher(action);
 	}
 
-	createBaseAction(actionName) {
+	createBaseAction(actionName, isDropdownItem) {
 		const actionSettings = this.appSettings.actions[actionName];
 		const baseAction = {
 			id: actionSettings.id,
-			icon: actionSettings.icon,
+			icon: !isDropdownItem && actionSettings.icon,
 			label: actionSettings.name,
 			bsStyle: actionSettings.bsStyle,
 			tooltipLabel: actionSettings.toolTip || actionSettings.name,
@@ -199,7 +199,7 @@ export default class InventoryListCtrl {
 
 	createDropdownItemAction(item, actionName) {
 		const itemOnClick = this.getActionDispatcher(actionName);
-		const itemAction = this.createBaseAction(actionName);
+		const itemAction = this.createBaseAction(actionName, true);
 		itemAction.onClick = event => itemOnClick(event, item);
 		return itemAction;
 	}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
When monorepo version will be >= 0.86.0, icons will be shown in front of the dropdown items.
![image](https://user-images.githubusercontent.com/26482371/27629640-4a5e20ae-5bf3-11e7-8e23-60cc8cdc59e8.png)

**(Optional) What is the new behavior?**
Dropdown items icons are hidden in prevision of monorepo update.

**(Optional) Other information**:
