### PR TITLE
fix: dont set icon in dropdown when not necessary

### DIFF
--- a/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-controller.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/inventory-list/inventory-list-controller.js
@@ -186,11 +186,13 @@ export default class InventoryListCtrl {
 		const actionSettings = this.appSettings.actions[actionName];
 		const baseAction = {
 			id: actionSettings.id,
-			icon: !isDropdownItem && actionSettings.icon,
 			label: actionSettings.name,
 			bsStyle: actionSettings.bsStyle,
 			tooltipLabel: actionSettings.toolTip || actionSettings.name,
 		};
+		if (!isDropdownItem) {
+			baseAction.icon = actionSettings.icon;
+		}
 		if (actionSettings.displayMode) {
 			baseAction.displayMode = actionSettings.displayMode;
 		}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
```
Warning: Failed prop type: Invalid prop `items[0].icon` of type `boolean` supplied to `ActionSplitDropdown`, expected `string`.
```


**(Optional) What is the new behavior?**
No errors.


**(Optional) Other information**:
