### PR TITLE
fix: Declare all used Forms props

### DIFF
--- a/dataprep-webapp/src/app/components/widgets-containers/widgets-containers-module.js
+++ b/dataprep-webapp/src/app/components/widgets-containers/widgets-containers-module.js
@@ -58,7 +58,16 @@ angular.module(MODULE_NAME,
 	.directive('iconsProvider', ['reactDirective', reactDirective => reactDirective(IconsProvider)])
 	.directive('icon', ['reactDirective', reactDirective => reactDirective(Icon)])
 	.directive('httpError', ['reactDirective', reactDirective => reactDirective(HttpError)])
-	.directive('talendForm', ['reactDirective', reactDirective => reactDirective(Form)])
+	.directive('talendForm', ['reactDirective', reactDirective => reactDirective(Form, [
+		// We need to declare each used props in order to pass them to React component in prod mode
+		// @see https://github.com/ngReact/ngReact/issues/193
+		'autocomplete',
+		'data',
+		'actions',
+		'onTrigger',
+		'onSubmit',
+		'showErrorList',
+	])])
 	.component('appHeaderBar', AppHeaderBarContainer)
 	.component('breadcrumbs', BreadcrumbContainer)
 	.component('collapsiblePanel', CollapsiblePanelContainer)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
In production mode, we don't have any propTypes defined.  
If ngReact cannot read them then it will not dealing with them

**(Optional) What is the new behavior?**
I just duplicate all used props in order to pass values.

**(Optional) Other information**:
Linked to https://github.com/ngReact/ngReact/issues/193