### PR TITLE
fix: better check for the no steps message

### DIFF
--- a/dataprep-webapp/src/app/components/recipe/recipe-controller.js
+++ b/dataprep-webapp/src/app/components/recipe/recipe-controller.js
@@ -225,6 +225,17 @@ export default class RecipeCtrl {
 		this.PlaygroundService.toggleStep(step);
 	}
 
+	/**
+	 * @ngdoc method
+	 * @name hasSteps
+	 * @methodOf data-prep.recipe.controller:RecipeCtrl
+	 * @description Return if the recipe has steps
+	 */
+	hasParameters() {
+		const current = this.state.playground.recipe.current;
+		return current && current.reorderedSteps && current.reorderedSteps.length > 0;
+	}
+
 	//---------------------------------------------------------------------------------------------
 	// --------------------------------------------REORDER----------------------------------------
 	//---------------------------------------------------------------------------------------------

--- a/dataprep-webapp/src/app/components/recipe/recipe-controller.js
+++ b/dataprep-webapp/src/app/components/recipe/recipe-controller.js
@@ -231,7 +231,7 @@ export default class RecipeCtrl {
 	 * @methodOf data-prep.recipe.controller:RecipeCtrl
 	 * @description Return if the recipe has steps
 	 */
-	hasParameters() {
+	hasSteps() {
 		const current = this.state.playground.recipe.current;
 		return current && current.reorderedSteps && current.reorderedSteps.length > 0;
 	}

--- a/dataprep-webapp/src/app/components/recipe/recipe-controller.spec.js
+++ b/dataprep-webapp/src/app/components/recipe/recipe-controller.spec.js
@@ -154,6 +154,43 @@ describe('Recipe controller', () => {
 			expect(PlaygroundService.updateStep).toHaveBeenCalledWith(step, parameters);
 		}));
 
+		it('should return true if recipe has steps', inject((PlaygroundService) => {
+			// given
+			const ctrl = createController();
+
+
+			// when
+			stateMock.playground.recipe.current.reorderedSteps = steps;
+			const hasSteps = ctrl.hasSteps();
+
+			// then
+			expect(hasSteps).toBeTruthy();
+		}));
+
+		it('should return false if recipe has no steps', inject((PlaygroundService) => {
+			// given
+			const ctrl = createController();
+
+			// when
+			stateMock.playground.recipe.current.reorderedSteps = [];
+			const hasSteps = ctrl.hasSteps();
+
+			// then
+			expect(hasSteps).toBeFalsy();
+		}));
+
+		it('should return false if reorderedSteps in not defined', inject((PlaygroundService) => {
+			// given
+			const ctrl = createController();
+
+			// when
+			stateMock.playground.recipe.current = null;
+			const hasSteps = ctrl.hasSteps();
+
+			// then
+			expect(hasSteps).toBeFalsy();
+		}));
+
 		describe('preview', () => {
 			it('should do nothing on update preview if the step is inactive', inject(($rootScope, PreviewService) => {
 				// given

--- a/dataprep-webapp/src/app/components/recipe/recipe.html
+++ b/dataprep-webapp/src/app/components/recipe/recipe.html
@@ -25,7 +25,7 @@
      while-dragging="$ctrl.isDragStart"
 >
     <div class="empty-message"
-         ng-if="$ctrl.state.playground.recipe.current.reorderedSteps.length === 0"
+         ng-if="!$ctrl.hasSteps()"
          translate-once="NO_PREPARATION_STEPS">
     </div>
     <sc-accordion>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
An error can be thrown if the `reorderedSteps` property is not defined.

**(Optional) What is the new behavior?**
No error is thrown if the `reorderedSteps` property is not defined.


**(Optional) Other information**:
