### PR TITLE
fix(TDP-4033): resolve appsettings configurer conflict

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/settings/AppSettingsService.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/settings/AppSettingsService.java
@@ -49,6 +49,14 @@ public class AppSettingsService {
     @Autowired(required = false)
     private AppSettingsConfigurer<UriSettings>[] urisConfigurers;
 
+    public AppSettingsConfigurer<ActionSettings>[] getActionsConfigurers() {
+        return actionsConfigurers;
+    }
+
+    public void setActionsConfigurers(AppSettingsConfigurer<ActionSettings>... actionsConfigurers) {
+        this.actionsConfigurers = actionsConfigurers;
+    }
+
     /**
      * Generate the app settings
      */
@@ -72,7 +80,7 @@ public class AppSettingsService {
 
     /**
      * Build a Setting mapper Function from a given AppSettingsConfigurer
-     * 
+     *
      * @param configurer The setting configurer
      * @return The function
      */
@@ -82,7 +90,7 @@ public class AppSettingsService {
 
     /**
      * Get all the static settings as a stream
-     * 
+     *
      * @return Stream that will process all static settings
      */
     private <T> Stream<T> getStaticSettingsStream(final AppSettingsProvider<T>[] providers) {
@@ -91,7 +99,7 @@ public class AppSettingsService {
 
     /**
      * Get all the configured settings as a stream
-     * 
+     *
      * @param providers The array of settings providers
      * @param configurers The array of settings configurers
      * @param <T> ActionSettings | ViewSettings


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4033

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

**(Optional) What is the current behavior?**
-There are 2 configurers (OS and EE) that are applied for the same action. It does not generate the same configurations based on the order of execution.


**(Optional) What is the new behavior?**
-Only one is applied based on the version OS or EE


**(Optional) Other information**:
