### PR TITLE
Ncomont/fix/tdp 4194 spaces are badly encoded in file name

### DIFF
--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/ExportAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/ExportAPITest.java
@@ -101,7 +101,7 @@ public class ExportAPITest extends ApiServiceTestBase {
 
         // then
         assertTrue(response.getContentType().startsWith("text/csv"));
-        assertEquals(response.getHeader("Content-Disposition"), "attachment; filename=\"testHeaders.csv\"");
+        assertEquals(response.getHeader("Content-Disposition"), "attachment; filename*=UTF-8''testHeaders.csv");
     }
 
     @Test
@@ -119,7 +119,7 @@ public class ExportAPITest extends ApiServiceTestBase {
         // then
         assertTrue(response.getContentType().startsWith("text/csv"));
         // Expect URL encoded filename
-        assertEquals(response.getHeader("Content-Disposition"), "attachment; filename=\"_UTF-8%20%E4%BD%8F%E6%89%80.csv\"");
+        assertEquals(response.getHeader("Content-Disposition"), "attachment; filename*=UTF-8''_UTF-8%20%E4%BD%8F%E6%89%80.csv");
     }
 
     @Test
@@ -330,7 +330,7 @@ public class ExportAPITest extends ApiServiceTestBase {
 
         // then
         String contentDispositionHeaderValue = export.getHeader("Content-Disposition");
-        Assertions.assertThat(contentDispositionHeaderValue).contains("filename=\"" + fileName);
+        Assertions.assertThat(contentDispositionHeaderValue).contains("filename*=UTF-8''" + fileName);
 
     }
 
@@ -354,7 +354,7 @@ public class ExportAPITest extends ApiServiceTestBase {
 
         // then
         String contentDispositionHeaderValue = export.getHeader("Content-Disposition");
-        Assertions.assertThat(contentDispositionHeaderValue).contains("filename=\"" + fileName);
+        Assertions.assertThat(contentDispositionHeaderValue).contains("filename*=UTF-8''" + fileName);
 
     }
 

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/ExportUtils.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/ExportUtils.java
@@ -23,8 +23,14 @@ public class ExportUtils {
         // TDP-2925 a multi-byte file name cannot export the file correctly
         // Current [RFC 2045] grammar restricts parameter values (and hence Content-Disposition filenames) to US-ASCII
         try {
-            HttpResponseContext.header(HttpHeaders.CONTENT_DISPOSITION,
-                    "attachment; filename=\"" + UriUtils.encodePath(exportName, UTF_8.toString()) + format.getExtension() + "\"");
+            HttpResponseContext.header(
+                HttpHeaders.CONTENT_DISPOSITION,
+                String.format(
+                    "attachment; filename*=%s''%s",
+                    UTF_8.toString(),
+                    UriUtils.encodePath(exportName, UTF_8.toString()) + format.getExtension()
+                )
+            );
         } catch (UnsupportedEncodingException e) {
             LOGGER.error("Can't encode '{}' from UTF-8", exportName);
             throw new RuntimeException(e);

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/BaseTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/BaseTest.java
@@ -103,7 +103,7 @@ public class BaseTest extends TransformationServiceBaseTest {
 
             // then
             Assert.assertTrue(response.getContentType().startsWith("text/csv"));
-            assertEquals(response.getHeader("Content-Disposition"), "attachment; filename=\"myPrep.csv\"");
+            assertEquals(response.getHeader("Content-Disposition"), "attachment; filename*=UTF-8''myPrep.csv");
         }
     }
 }


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-XXXX

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
