### PR TITLE
hmdebenque/fix/tdp 4253 dataset filter on name (#741)

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/SearchAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/SearchAPI.java
@@ -14,6 +14,7 @@ package org.talend.dataprep.api.service;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.talend.dataprep.exception.error.APIErrorCodes.INVALID_SEARCH_NAME;
 import static org.talend.dataprep.exception.error.APIErrorCodes.UNABLE_TO_SEARCH_DATAPREP;
 
 import java.io.IOException;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+import org.talend.daikon.exception.ExceptionContext;
 import org.talend.dataprep.api.service.delegate.SearchDelegate;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.i18n.MessagesBundle;
@@ -67,6 +69,9 @@ public class SearchAPI extends APIService {
             @ApiParam(value = "filter") @RequestParam(required = false) final List<String> filter,
             @ApiParam(value = "strict") @RequestParam(defaultValue = "false", required = false) final boolean strict) {
     //@formatter:on
+        if (name != null && name.contains("'")) {
+            throw new TDPException(INVALID_SEARCH_NAME, ExceptionContext.withBuilder().put("name", name).build());
+        }
         return output -> doSearch(name, filter, strict, output);
     }
 

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/APIErrorCodes.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/APIErrorCodes.java
@@ -13,6 +13,8 @@
 
 package org.talend.dataprep.exception.error;
 
+import static org.springframework.http.HttpStatus.*;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -20,8 +22,6 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.talend.daikon.exception.error.ErrorCode;
-
-import static org.springframework.http.HttpStatus.*;
 
 public enum APIErrorCodes implements ErrorCode {
     UNABLE_TO_DELETE_PREPARATION(BAD_REQUEST),
@@ -70,7 +70,11 @@ public enum APIErrorCodes implements ErrorCode {
     DATASET_REDIRECT(MOVED_PERMANENTLY),
     INVALID_HEAD_STEP_USING_DELETED_DATASET(FORBIDDEN),
     UNABLE_TO_IMPORT_PREPARATIONS(BAD_REQUEST),
-    UNABLE_TO_OVERWRITE_PREPARATIONS(BAD_REQUEST);
+    UNABLE_TO_OVERWRITE_PREPARATIONS(BAD_REQUEST),
+    /**
+     * When a search request ask for an invalid name.
+     */
+    INVALID_SEARCH_NAME(BAD_REQUEST, "name");
 
     /**
      * The http status to use.

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/DataSetErrorCodes.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/DataSetErrorCodes.java
@@ -193,8 +193,11 @@ public enum DataSetErrorCodes implements ErrorCode {
     /**
      * A lookup dataSet used by a preparation with a given name have not the expected format.
      */
-    PREPARATION_LOOKUP_BAD_FORMAT(NOT_FOUND.value(), "name")
-    ;
+    PREPARATION_LOOKUP_BAD_FORMAT(NOT_FOUND.value(), "name"),
+    /**
+     * A lookup dataSet used by a preparation with a given name have not the expected format.
+     */
+    INVALID_DATASET_NAME(BAD_REQUEST.value(), "name");
 
     /**
      * The http status to use.

--- a/dataprep-backend-service/src/main/resources/org/talend/dataprep/error_messages.properties
+++ b/dataprep-backend-service/src/main/resources/org/talend/dataprep/error_messages.properties
@@ -280,6 +280,8 @@ UNABLE_TO_IMPORT_PREPARATIONS.TITLE = Preparation import failed
 UNABLE_TO_IMPORT_PREPARATIONS.MESSAGE = Preparation import failed, see the cause bellow
 UNABLE_TO_OVERWRITE_PREPARATIONS.TITLE=Preparation import failed
 UNABLE_TO_OVERWRITE_PREPARATIONS.MESSAGE=Preparation import failed
+INVALID_SEARCH_NAME.TITLE=Invalid name
+INVALID_SEARCH_NAME.MESSAGE=Cannot use name "{0}" containing quote ("'") character.
 
 ######################################### DATASET ERROR_CODES #########################################
 UNEXPECTED_IO_EXCEPTION.TITLE = Unexpected error
@@ -404,6 +406,9 @@ PREPARATION_DATASET_BAD_FORMAT.MESSAGE=The dataset "{0}" format does not match t
 
 PREPARATION_LOOKUP_BAD_FORMAT.TITLE = Preparation import failed
 PREPARATION_LOOKUP_BAD_FORMAT.MESSAGE=The dataset, used as lookup, "{0}" format does not match the one expected by the preparation
+
+INVALID_DATASET_NAME.TITLE=Invalid data set name
+INVALID_DATASET_NAME.MESSAGE=The data set name "{0}" is invalid. It is not possible to create data sets with blank name or containing single quote ("'") characters.
 
 EXPORTED_PREPARATION_VERSION_NOT_SUPPORTED.TITLE = Preparation import failed
 EXPORTED_PREPARATION_VERSION_NOT_SUPPORTED.MESSAGE=Unable to import a preparation in version "{0}" to a Data Preparation version "{1}"

--- a/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/DataSetImportTest.java
+++ b/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/DataSetImportTest.java
@@ -19,8 +19,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
 import java.io.IOException;
@@ -163,7 +163,7 @@ public class DataSetImportTest extends DataSetBaseTest {
             try {
                 dataSetId = given().body(
                         IOUtils.toString(DataSetImportTest.class.getResourceAsStream("tagada.csv"), UTF_8))
-                        .queryParam("Content-Type", "text/csv").when().post("/datasets").asString();
+                        .queryParam(CONTENT_TYPE, "text/csv").when().post("/datasets").asString();
                 LOGGER.debug("testCannotOpenDataSetBeingImported dataset created #{}", dataSetId);
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -173,8 +173,12 @@ public class DataSetImportTest extends DataSetBaseTest {
         Thread creationThread = new Thread(creation);
         creationThread.start();
         // Wait for creation of data set object
+        int iterations = 0;
         while (dataSetMetadataRepository.size() == 0) {
             TimeUnit.MILLISECONDS.sleep(20);
+            if (iterations++ > 100) {
+                fail();
+            }
         }
         // Find data set being imported...
         final Iterator<DataSetMetadata> iterator = dataSetMetadataRepository.list().iterator();


### PR DESCRIPTION
* feat(TDP-4253): escaping data set name parameter in regex search

* feat(TDP-4253): factorize search endpoints

(cherry picked from commit 0388e5e)

* Add check to protect against names with quotes

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4256

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [x] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
