### PR TITLE
chore: frontend-maven-plugin support

### DIFF
--- a/dataprep-webapp/.gitignore
+++ b/dataprep-webapp/.gitignore
@@ -23,6 +23,7 @@ npm-debug.log
 .sass-cache/
 .tmp/
 build/
+bin/
 node/
 ngdoc/
 *.mine.json

--- a/dataprep-webapp/pom.xml
+++ b/dataprep-webapp/pom.xml
@@ -29,7 +29,7 @@
         <maven>3.1.0</maven>
     </prerequisites>
     <properties>
-        <docker.tools.image.name>kkarczmarczyk/node-yarn</docker.tools.image.name>
+        <docker.image.name>kkarczmarczyk/node-yarn</docker.image.name>
         <docker.path.dataprep>/data-prep</docker.path.dataprep>
         <node.version>v7.7.4</node.version>
         <yarn.version>v0.27.5</yarn.version>
@@ -157,7 +157,7 @@
                         <artifactId>exec-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>docker pull ${docker.tools.image.name}</id>
+                                <id>docker pull ${docker.image.name}</id>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -166,7 +166,7 @@
                                     <executable>docker</executable>
                                     <arguments>
                                         <argument>pull</argument>
-                                        <argument>${docker.tools.image.name}</argument>
+                                        <argument>${docker.image.name}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -183,7 +183,7 @@
                                         <argument>-v</argument>
                                         <argument>${basedir}:${docker.path.dataprep}</argument>
                                         <argument>--rm=true</argument>
-                                        <argument>${docker.tools.image.name}</argument>
+                                        <argument>${docker.image.name}</argument>
                                         <argument>/bin/sh</argument>
                                         <argument>-c</argument>
                                         <argument>cd ${docker.path.dataprep} &amp;&amp; yarn install --force</argument>
@@ -204,7 +204,7 @@
                                         <argument>-v</argument>
                                         <argument>${basedir}:${docker.path.dataprep}</argument>
                                         <argument>--rm=true</argument>
-                                        <argument>${docker.tools.image.name}</argument>
+                                        <argument>${docker.image.name}</argument>
                                         <argument>/bin/sh</argument>
                                         <argument>-c</argument>
                                         <argument>cd ${docker.path.dataprep} &amp;&amp; yarn run build:dist</argument>
@@ -224,7 +224,7 @@
                                         <argument>-v</argument>
                                         <argument>${basedir}:${docker.path.dataprep}</argument>
                                         <argument>--rm=true</argument>
-                                        <argument>${docker.tools.image.name}</argument>
+                                        <argument>${docker.image.name}</argument>
                                         <argument>/bin/sh</argument>
                                         <argument>-c</argument>
                                         <argument>cd ${docker.path.dataprep} &amp;&amp; yarn run test:ci</argument>

--- a/dataprep-webapp/pom.xml
+++ b/dataprep-webapp/pom.xml
@@ -29,8 +29,6 @@
         <maven>3.1.0</maven>
     </prerequisites>
     <properties>
-        <docker.registry.name>registry.datapwn.com</docker.registry.name>
-        <docker.tools.image.version>1.8</docker.tools.image.version>
         <docker.tools.image.name>kkarczmarczyk/node-yarn</docker.tools.image.name>
         <docker.path.dataprep>/data-prep</docker.path.dataprep>
         <node.version>v7.7.4</node.version>

--- a/dataprep-webapp/pom.xml
+++ b/dataprep-webapp/pom.xml
@@ -31,9 +31,12 @@
     <properties>
         <docker.registry.name>registry.datapwn.com</docker.registry.name>
         <docker.tools.image.version>1.8</docker.tools.image.version>
-        <docker.tools.image.name>${docker.registry.name}/talend/data-prep-webapp-tools:${docker.tools.image.version}</docker.tools.image.name>
-        <docker.user>1000</docker.user>
+        <docker.tools.image.name>kkarczmarczyk/node-yarn</docker.tools.image.name>
         <docker.path.dataprep>/data-prep</docker.path.dataprep>
+        <node.version>v7.7.4</node.version>
+        <yarn.version>v0.27.5</yarn.version>
+        <git.branch.name></git.branch.name>
+        <git.commit.id.abbrev></git.commit.id.abbrev>
     </properties>
     <profiles>
         <profile>
@@ -46,65 +49,47 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.5</version>
                         <executions>
                             <execution>
-                                <id>npm prune</id>
+                                <id>install node and yarn</id>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>install-node-and-yarn</goal>
                                 </goals>
-                                <phase>clean</phase>
                                 <configuration>
-                                    <executable>npm</executable>
-                                    <arguments>
-                                        <argument>prune
-                                        </argument>
-                                    </arguments>
+                                    <nodeVersion>${node.version}</nodeVersion>
+                                    <yarnVersion>${yarn.version}</yarnVersion>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>npm install</id>
+                                <id>yarn install</id>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>yarn</goal>
                                 </goals>
-                                <phase>initialize</phase>
                                 <configuration>
-                                    <executable>npm</executable>
-                                    <arguments>
-                                        <argument>
-                                            install
-                                        </argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                            <!-- generate the dist application (it is not used for the tests) but during the docker packaging it is and it a good test to know the build passes. -->
-                            <execution>
-                                <id>npm run build</id>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <phase>compile</phase>
-                                <configuration>
-                                    <executable>npm</executable>
-                                    <arguments>
-                                        <argument>run</argument>
-                                        <argument>build:dist</argument>
-                                    </arguments>
+                                    <arguments>install --force --prefer-offline</arguments>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>npm test</id>
+                                <id>yarn run build:dist</id>
+                                <phase>generate-resources</phase>
                                 <goals>
-                                    <goal>exec</goal>
+                                    <goal>yarn</goal>
                                 </goals>
+                                <configuration>
+                                    <arguments>run build:dist</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>yarn test</id>
                                 <phase>test</phase>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
                                 <configuration>
-                                    <skip>${skipTests}</skip>
-                                    <executable>npm</executable>
-                                    <arguments>
-                                        <argument>test</argument>
-                                    </arguments>
+                                    <arguments>test</arguments>
                                 </configuration>
                             </execution>
                         </executions>
@@ -142,11 +127,15 @@
                         <configuration>
                             <filesets>
                                 <fileset>
-                                    <directory>node_modules</directory>
+                                    <directory>bin</directory>
                                     <followSymlinks>false</followSymlinks>
                                 </fileset>
                                 <fileset>
                                     <directory>node</directory>
+                                    <followSymlinks>false</followSymlinks>
+                                </fileset>
+                                <fileset>
+                                    <directory>node_modules</directory>
                                     <followSymlinks>false</followSymlinks>
                                 </fileset>
                             </filesets>
@@ -174,7 +163,7 @@
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
-                                <phase>none</phase>
+                                <phase>pre-clean</phase>
                                 <configuration>
                                     <executable>docker</executable>
                                     <arguments>
@@ -184,29 +173,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>(docker) npm prune</id>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <phase>clean</phase>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>run</argument>
-                                        <argument>--user</argument>
-                                        <argument>${docker.user}</argument>
-                                        <argument>-v</argument>
-                                        <argument>${basedir}:${docker.path.dataprep}</argument>
-                                        <argument>--rm=true</argument>
-                                        <argument>${docker.tools.image.name}</argument>
-                                        <argument>/bin/sh</argument>
-                                        <argument>-c</argument>
-                                        <argument>npm prune</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>(docker) npm install</id>
+                                <id>(docker) yarn install</id>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -215,21 +182,19 @@
                                     <executable>docker</executable>
                                     <arguments>
                                         <argument>run</argument>
-                                        <argument>--user</argument>
-                                        <argument>${docker.user}</argument>
                                         <argument>-v</argument>
                                         <argument>${basedir}:${docker.path.dataprep}</argument>
                                         <argument>--rm=true</argument>
                                         <argument>${docker.tools.image.name}</argument>
                                         <argument>/bin/sh</argument>
                                         <argument>-c</argument>
-                                        <argument>npm install</argument>
+                                        <argument>cd ${docker.path.dataprep} &amp;&amp; yarn install --force</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
                             <!-- generate the dist application (it is not used for the tests) but during the docker packaging it is and it a good test to know the build passes. -->
                             <execution>
-                                <id>(docker) npm run build</id>
+                                <id>(docker) yarn run build:dist</id>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -238,38 +203,33 @@
                                     <executable>docker</executable>
                                     <arguments>
                                         <argument>run</argument>
-                                        <argument>--user</argument>
-                                        <argument>${docker.user}</argument>
                                         <argument>-v</argument>
                                         <argument>${basedir}:${docker.path.dataprep}</argument>
                                         <argument>--rm=true</argument>
                                         <argument>${docker.tools.image.name}</argument>
                                         <argument>/bin/sh</argument>
                                         <argument>-c</argument>
-                                        <argument>npm run build:dist</argument>
+                                        <argument>cd ${docker.path.dataprep} &amp;&amp; yarn run build:dist</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>(docker) npm run test:ci</id>
+                                <id>(docker) yarn run test:ci</id>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
                                 <phase>test</phase>
                                 <configuration>
-                                    <skip>${skipTests}</skip>
                                     <executable>docker</executable>
                                     <arguments>
                                         <argument>run</argument>
-                                        <argument>--user</argument>
-                                        <argument>${docker.user}</argument>
                                         <argument>-v</argument>
                                         <argument>${basedir}:${docker.path.dataprep}</argument>
                                         <argument>--rm=true</argument>
                                         <argument>${docker.tools.image.name}</argument>
                                         <argument>/bin/sh</argument>
                                         <argument>-c</argument>
-                                        <argument>npm run test:ci</argument>
+                                        <argument>cd ${docker.path.dataprep} &amp;&amp; yarn run test:ci</argument>
                                     </arguments>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

According to @rmannibucau's suggestion in #718, we can use `frontend-maven-plugin` instead of waiting a node installation.

**What is the chosen solution to this problem?**

Add `frontend-maven-plugin` support and use yarn docker image to be consistent.

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [x] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
