### PR TITLE
fix(TDP-2780): remove deprecated commons-httpclient 3.1

### DIFF
--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -57,8 +57,6 @@
         <!-- See http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#appendix-dependency-versions -->
         <validation-api.version>1.1.0.Final</validation-api.version>
         <httpclient.version>4.5.3</httpclient.version>
-        <!-- Deprecated and should not be used. Not updated since 2007-->
-        <commons-httpclient.version>3.1</commons-httpclient.version>
         <httpclient.tests.version>4.3.6</httpclient.tests.version>
         <start-class>fill.this.value.in.service.module</start-class>
     </properties>
@@ -455,13 +453,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${httpclient.version}</version>
-            </dependency>
-            <dependency>
-                <!-- This should not be used for new code as this apache project is deprecated -->
-                <!-- see http://hc.apache.org/httpclient-3.x/ -->
-                <groupId>commons-httpclient</groupId>
-                <artifactId>commons-httpclient</artifactId>
-                <version>${commons-httpclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>

--- a/dataprep-dataset/pom.xml
+++ b/dataprep-dataset/pom.xml
@@ -29,13 +29,6 @@
         <stack.param.name>DataPrepDatasetFQIN</stack.param.name>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-        </dependency>
-    </dependencies>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2780

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted
