### PR TITLE
fix(TDP-4291): handle edge case in filter deserialization

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/filter/SimpleFilterService.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/filter/SimpleFilterService.java
@@ -122,13 +122,16 @@ public class SimpleFilterService implements FilterService {
         if (columnId == null && allowFullFilter(operation)) {
             // Full data set filter (no column)
             final List<ColumnMetadata> columns = rowMetadata.getColumns();
-            Predicate<DataSetRow> predicate = null;
+            Predicate<DataSetRow> predicate;
             if (!columns.isEmpty()) {
                 predicate = buildOperationFilter(currentNode, rowMetadata, columns.get(0).getId(), operation, value);
                 for (int i = 1; i < columns.size(); i++) {
                     predicate = predicate
                             .or(buildOperationFilter(currentNode, rowMetadata, columns.get(i).getId(), operation, value));
                 }
+            } else {
+                // We can't return a null filter, default to the neutral value
+                predicate = dsr -> true;
             }
             return predicate;
         } else {

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/api/filter/SimpleFilterServiceTest.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/api/filter/SimpleFilterServiceTest.java
@@ -1067,4 +1067,15 @@ public class SimpleFilterServiceTest {
         assertThat(filter.test(datasetRowFromValues), is(true));
     }
 
+    @Test
+    public void TDP_4291_shouldNotThrowAnException() throws Exception {
+        // given
+        final String filtersDefinition = "{\"or\":[{\"invalid\":{}},{\"empty\":{}}]}";
+
+        // when
+        service.build(filtersDefinition, new RowMetadata());
+
+        // then no NPE
+    }
+
 }


### PR DESCRIPTION
- When creating filter without supplying metadata, handle the edge case of
  filtering on no column
- also simplified a tableau writer stream statement

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4291

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted
