### PR TITLE
feat(TDP-4362): Add access to preparation metadata

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreparationGetMetadata.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreparationGetMetadata.java
@@ -1,0 +1,55 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.api.service.command.preparation;
+
+import static org.talend.dataprep.command.Defaults.convertResponse;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.http.client.methods.HttpGet;
+import org.springframework.context.annotation.Scope;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.talend.dataprep.api.dataset.DataSetMetadata;
+import org.talend.dataprep.command.GenericCommand;
+
+/**
+ * Command used to retrieve the preparation content.
+ */
+@Component
+@Scope("request")
+public class PreparationGetMetadata extends GenericCommand<DataSetMetadata> {
+
+    /** The preparation id. */
+    private final String id;
+
+    /** The preparation version. */
+    private final String version;
+
+    /**
+     * @param id the preparation id.
+     * @param version the preparation version.
+     */
+    private PreparationGetMetadata(String id, String version) {
+        super(PREPARATION_GROUP);
+        this.id = id;
+        this.version = version;
+        execute(() -> new HttpGet(transformationServiceUrl + "/apply/preparation/" + id + "/" + version + "/metadata"));
+    }
+
+    @PostConstruct
+    public void init() {
+        on(HttpStatus.OK).then(convertResponse(objectMapper, DataSetMetadata.class));
+    }
+
+}

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -691,6 +691,20 @@ public class PreparationAPITest extends ApiServiceTestBase {
     }
 
     @Test
+    public void testPreparationInitialMetadata() throws Exception {
+        // given
+        final String preparationId = testClient.createPreparationFromFile("dataset/dataset.csv", "testPreparationContentGet", home.getId());
+
+        final InputStream expected = PreparationAPITest.class.getResourceAsStream("dataset/expected_dataset_with_columns.json");
+
+        // when
+        final String content = when().get("/api/preparations/{id}/metadata", preparationId).asString();
+
+        // then
+        assertThat(content, sameJSONAsFile(expected));
+    }
+
+    @Test
     public void testPreparationContentWithActions() throws Exception {
         // given
         final String preparationId = testClient.createPreparationFromFile("dataset/dataset.csv", "testPreparationContentGet", home.getId());

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/TransformationErrorCodes.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/TransformationErrorCodes.java
@@ -46,7 +46,8 @@ public enum TransformationErrorCodes implements ErrorCode {
     UNABLE_TO_PERFORM_PREVIEW(500),
     UNABLE_TO_PERFORM_EXPORT(500),
     EXPORT_NOT_FOUND(404, "id"),
-    UNABLE_TO_RESUME_EXECUTION(400, "id");
+    UNABLE_TO_RESUME_EXECUTION(400, "id"),
+    METADATA_NOT_FOUND(500);
 
     /** The http status to use. */
     private int httpStatus;

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -15,7 +15,9 @@ package org.talend.dataprep.transformation.service;
 import static java.util.Collections.singletonList;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
-import static org.springframework.web.bind.annotation.RequestMethod.*;
+import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static org.talend.daikon.exception.ExceptionContext.build;
 import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
@@ -26,8 +28,17 @@ import static org.talend.dataprep.transformation.actions.category.ScopeCategory.
 import static org.talend.dataprep.transformation.actions.category.ScopeCategory.LINE;
 import static org.talend.dataprep.transformation.format.JsonFormat.JSON;
 
-import java.io.*;
-import java.util.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
@@ -43,7 +54,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.talend.daikon.exception.ExceptionContext;
 import org.talend.dataprep.api.action.ActionDefinition;
@@ -186,6 +203,9 @@ public class TransformationService extends BaseTransformationService {
     @VolumeMetered
     public DataSetMetadata executeMetadata(@PathVariable("preparationId") String preparationId,
                                            @PathVariable("stepId") String stepId) {
+
+        LOG.debug("getting preparation metadata for #{}, step {}", preparationId, stepId);
+
         final Preparation preparation = getPreparation(preparationId);
         if (preparation.getSteps().size() > 1) {
             String headId = "head".equalsIgnoreCase(stepId) ? preparation.getHeadId() : stepId;

--- a/dataprep-webapp/src/app/services/playground/playground-service.js
+++ b/dataprep-webapp/src/app/services/playground/playground-service.js
@@ -265,14 +265,12 @@ export default function PlaygroundService($state, $rootScope, $q, $translate, $t
 	 */
 	function getMetadata() {
 		if (state.playground.preparation) {
-			return PreparationService.getContent(state.playground.preparation.id, 'head', state.playground.sampleType)
+			return PreparationService.getMetadata(state.playground.preparation.id, 'head')
 				.then((response) => {
-					if (!response.metadata.columns[0].statistics.frequencyTable.length) {
+					if (!response.columns[0].statistics.frequencyTable.length) {
 						return $q.reject();
 					}
-
-					StateService.updateDatasetRecord(response.records.length);
-					return response.metadata;
+					return response;
 				});
 		}
 		else {

--- a/dataprep-webapp/src/app/services/playground/playground-service.spec.js
+++ b/dataprep-webapp/src/app/services/playground/playground-service.spec.js
@@ -116,7 +116,7 @@ describe('Playground Service', () => {
 				},
 			},
 			inventory: {
-				homeFolder: { id: 'Lw=='},
+				homeFolder: { id: 'Lw==' },
 				currentFolder: { path: 'test' },
 				folder: {
 					metadata: {
@@ -555,7 +555,6 @@ describe('Playground Service', () => {
 		beforeEach(inject((StateService, StatisticsService) => {
 			spyOn(StatisticsService, 'updateStatistics').and.returnValue();
 			spyOn(StateService, 'updateDatasetStatistics').and.returnValue();
-			spyOn(StateService, 'updateDatasetRecord').and.returnValue();
 
 			stateMock.playground.preparation = { id: 'abc' };
 			stateMock.playground.dataset = { id: '1324d56456b84ef154', records: 15 };
@@ -563,21 +562,20 @@ describe('Playground Service', () => {
 
 		it('should get metadata and set its statistics in state', inject(($rootScope, $q, PlaygroundService, PreparationService, StateService) => {
 			// given
-			spyOn(PreparationService, 'getContent').and.returnValue($q.when(preparationMetadata));
+			spyOn(PreparationService, 'getMetadata').and.returnValue($q.when(preparationMetadata.metadata));
 
 			// when
 			PlaygroundService.updateStatistics();
 			$rootScope.$digest();
 
 			// then
-			expect(PreparationService.getContent).toHaveBeenCalledWith('abc', 'head', 'HEAD');
+			expect(PreparationService.getMetadata).toHaveBeenCalledWith('abc', 'head');
 			expect(StateService.updateDatasetStatistics).toHaveBeenCalledWith(preparationMetadata.metadata);
-			expect(StateService.updateDatasetRecord).toHaveBeenCalledWith(1);
 		}));
 
 		it('should trigger statistics update', inject(($rootScope, $q, PreparationService, PlaygroundService, StatisticsService) => {
 			// given
-			spyOn(PreparationService, 'getContent').and.returnValue($q.when(preparationMetadata));
+			spyOn(PreparationService, 'getMetadata').and.returnValue($q.when(preparationMetadata.metadata));
 
 			// when
 			PlaygroundService.updateStatistics();
@@ -590,7 +588,7 @@ describe('Playground Service', () => {
 		it('should reject promise when the statistics are not computed yet', inject(($rootScope, $q, PlaygroundService, PreparationService, StateService) => {
 			// given
 			let rejected = false;
-			spyOn(PreparationService, 'getContent').and.returnValue($q.when(preparationMetadataWithoutStatistics));
+			spyOn(PreparationService, 'getMetadata').and.returnValue($q.when(preparationMetadataWithoutStatistics.metadata));
 
 			// when
 			PlaygroundService.updateStatistics()

--- a/dataprep-webapp/src/app/services/preparation/preparation-service.js
+++ b/dataprep-webapp/src/app/services/preparation/preparation-service.js
@@ -27,6 +27,7 @@ export default function PreparationService($q, $state, $window, $stateParams, St
 	return {
 		// details, content
 		getContent: PreparationRestService.getContent,
+		getMetadata: PreparationRestService.getMetadata,
 		getDetails: PreparationRestService.getDetails,
 
 		// preparation lifecycle

--- a/dataprep-webapp/src/app/services/preparation/rest/preparation-rest-service.js
+++ b/dataprep-webapp/src/app/services/preparation/rest/preparation-rest-service.js
@@ -40,6 +40,7 @@ export default function PreparationRestService($http, RestURLs) {
         // getter : list, content, details
 		getContent,
 		getDetails,
+		getMetadata,
 
         // preview
 		getPreviewDiff,
@@ -57,11 +58,25 @@ export default function PreparationRestService($http, RestURLs) {
      * @param {string} preparationId The preparation id to load
      * @param {string} stepId The step id to load
      * @param {string} sampleType The sample type
-     * @description Get preparation records at the specific step
+     * @description Get preparation records/metadata at the specific step
      * @returns {promise} The GET promise
      */
 	function getContent(preparationId, stepId, sampleType) {
 		const url = `${RestURLs.preparationUrl}/${preparationId}/content?version=${stepId}&from=${sampleType}`;
+		return $http.get(url).then(res => res.data);
+	}
+
+	/**
+	 * @ngdoc method
+	 * @name getMetadata
+	 * @methodOf data-prep.services.preparation.service:PreparationRestService
+	 * @param {string} preparationId The preparation id to load
+	 * @param {string} stepId The step id to load
+	 * @description Get preparation metadata at the specific step
+	 * @returns {promise} The GET promise
+	 */
+	function getMetadata(preparationId, stepId) {
+		const url = `${RestURLs.preparationUrl}/${preparationId}/metadata?version=${stepId}`;
 		return $http.get(url).then(res => res.data);
 	}
 

--- a/dataprep-webapp/src/app/services/preparation/rest/preparation-rest-service.spec.js
+++ b/dataprep-webapp/src/app/services/preparation/rest/preparation-rest-service.spec.js
@@ -227,6 +227,26 @@ describe('Preparation REST Service', () => {
 			// then
 			expect(content).toEqual(records);
 		}));
+
+		it('should get the requested version of preparation metadata', inject(($rootScope, RestURLs, PreparationRestService) => {
+			// given
+			let content = null;
+			const preparationId = 'fbaa18e82e913e97e5f0e9d40f04413412be1126';
+			$httpBackend
+				.expectGET(RestURLs.preparationUrl + '/' + preparationId + '/metadata?version=head')
+				.respond(200, records);
+
+			//when
+			PreparationRestService.getMetadata(preparationId, 'head')
+				.then((response) => {
+					content = response;
+				});
+			$httpBackend.flush();
+			$rootScope.$digest();
+
+			// then
+			expect(content).toEqual(records);
+		}));
 	});
 
 	describe('preparation step lifecycle', () => {


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4362

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

* Add new REST service to retrieve preparation metadata