### PR TITLE
fix(TDP-4391): NullPointerException in migration from PE2.1 to 2.2

### DIFF
--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -295,7 +295,7 @@ public class PreparationService {
     private Stream<Preparation> searchByFolder(String folderId) {
         LOGGER.debug("looking for preparations in {}", folderId);
         final Stream<FolderEntry> entries = folderRepository.entries(folderId, PREPARATION);
-        return entries.map(e -> preparationRepository.get(e.getContentId(), Preparation.class));
+        return entries.map(e -> preparationRepository.get(e.getContentId(), Preparation.class)).filter(Objects::nonNull);
     }
 
     /**
@@ -314,7 +314,7 @@ public class PreparationService {
         case 1:
             Folder folder = foldersToSearch.iterator().next();
             final Stream<FolderEntry> entries = folderRepository.entries(folder.getId(), PREPARATION);
-            preparationStream = entries.map(e -> preparationRepository.get(e.getContentId(), Preparation.class));
+            preparationStream = entries.map(e -> preparationRepository.get(e.getContentId(), Preparation.class)).filter(Objects::nonNull);
             break;
         case 0:
             throw new TDPException(FOLDER_NOT_FOUND, ExceptionContext.build().put("path", path));


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4391

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
