### PR TITLE
fix(TDP-4391): NullPointerException in migration from PE2.1 to 2.2

### DIFF
--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -299,7 +299,7 @@ public class PreparationService {
         LOGGER.debug("looking for preparations in {}", folderId);
         final Iterable<FolderEntry> entries = folderRepository.entries(folderId, PREPARATION);
         return StreamSupport.stream(entries.spliterator(), false) //
-                .map(e -> preparationRepository.get(e.getContentId(), Preparation.class));
+                .map(e -> preparationRepository.get(e.getContentId(), Preparation.class)).filter(Objects::nonNull);
     }
 
     /**
@@ -315,16 +315,16 @@ public class PreparationService {
         int size = foldersToSearch.size();
         Stream<Preparation> preparationStream;
         switch (size) {
-        case 1:
-            Folder folder = foldersToSearch.iterator().next();
-            final Iterable<FolderEntry> entries = folderRepository.entries(folder.getId(), PREPARATION);
-            preparationStream = StreamSupport.stream(entries.spliterator(), false) //
-                    .map(e -> preparationRepository.get(e.getContentId(), Preparation.class));
-            break;
-        case 0:
-            throw new TDPException(FOLDER_NOT_FOUND, ExceptionContext.build().put("path", path));
-        default:
-            throw new TDPException(UNEXPECTED_EXCEPTION, ExceptionContext.build().put("message", "Two folders found for the same path: " + path));
+            case 1:
+                Folder folder = foldersToSearch.iterator().next();
+                final Iterable<FolderEntry> entries = folderRepository.entries(folder.getId(), PREPARATION);
+                preparationStream = StreamSupport.stream(entries.spliterator(), false) //
+                        .map(e -> preparationRepository.get(e.getContentId(), Preparation.class)).filter(Objects::nonNull);
+                break;
+            case 0:
+                throw new TDPException(FOLDER_NOT_FOUND, ExceptionContext.build().put("path", path));
+            default:
+                throw new TDPException(UNEXPECTED_EXCEPTION, ExceptionContext.build().put("message", "Two folders found for the same path: " + path));
         }
         return preparationStream;
     }
@@ -1126,7 +1126,7 @@ public class PreparationService {
      * @return The adapted steps
      */
     private List<AppendStep> getStepsWithShiftedColumnIds(final List<String> stepsIds, final String afterStepId,
-            final List<String> deletedColumns, final int shiftColumnAfterId, final int shiftNumber) {
+                                                          final List<String> deletedColumns, final int shiftColumnAfterId, final int shiftNumber) {
         Stream<AppendStep> stream = extractActionsAfterStep(stepsIds, afterStepId).stream();
 
         // rule 1 : remove all steps that modify one of the created columns


### PR DESCRIPTION
(cherry picked from commit 11ebd11)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4391

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
