### PR TITLE
chore: provide mechanism for OS / EE service version

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/VersionServiceAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/VersionServiceAPI.java
@@ -1,15 +1,14 @@
-//  ============================================================================
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
 //
-//  Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
 //
-//  This source code is available under agreement available at
-//  https://github.com/Talend/data-prep/blob/master/LICENSE
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
 //
-//  You should have received a copy of the agreement
-//  along with this program; if not, write to Talend SA
-//  9 rue Pages 92150 Suresnes, France
-//
-//  ============================================================================
+// ============================================================================
 
 package org.talend.dataprep.api.service;
 
@@ -24,9 +23,9 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.talend.dataprep.api.service.command.info.VersionCommand;
+import org.talend.dataprep.api.service.info.VersionService;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
-import org.talend.dataprep.info.ManifestInfo;
 import org.talend.dataprep.info.Version;
 import org.talend.dataprep.metrics.Timed;
 import org.talend.dataprep.security.PublicAPI;
@@ -38,6 +37,9 @@ import io.swagger.annotations.ApiOperation;
 
 @RestController
 public class VersionServiceAPI extends APIService {
+
+    @Autowired
+    private VersionService versionService;
 
     @Autowired
     private ObjectMapper mapper;
@@ -61,10 +63,11 @@ public class VersionServiceAPI extends APIService {
     @Timed
     @PublicAPI
     public Version[] allVersions() {
-        Version[] versions = new Version[4];
-        ManifestInfo manifestInfo = ManifestInfo.getInstance();
+        final Version[] versions = new Version[4];
 
-        versions[0] = new Version(manifestInfo.getVersionId(), manifestInfo.getBuildId(), "API");
+        final Version apiVersion = versionService.version();
+        apiVersion.setServiceName("API");
+        versions[0] = apiVersion;
         versions[1] = callVersionService(datasetServiceUrl, "DATASET");
         versions[2] = callVersionService(preparationServiceUrl, "PREPARATION");
         versions[3] = callVersionService(transformationServiceUrl, "TRANSFORMATION");

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/api/service/info/VersionService.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/api/service/info/VersionService.java
@@ -1,24 +1,30 @@
-//  ============================================================================
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
 //
-//  Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
 //
-//  This source code is available under agreement available at
-//  https://github.com/Talend/data-prep/blob/master/LICENSE
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
 //
-//  You should have received a copy of the agreement
-//  along with this program; if not, write to Talend SA
-//  9 rue Pages 92150 Suresnes, France
-//
-//  ============================================================================
+// ============================================================================
 
 package org.talend.dataprep.api.service.info;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.talend.dataprep.info.ManifestInfo;
+import org.talend.dataprep.info.ManifestInfoProvider;
 import org.talend.dataprep.info.Version;
 import org.talend.dataprep.metrics.Timed;
 import org.talend.dataprep.security.PublicAPI;
@@ -26,16 +32,57 @@ import org.talend.dataprep.security.PublicAPI;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
+/**
+ * Rest controller that returns current version of the Data Prep service.
+ *
+ * @see ManifestInfoProvider
+ * @see Version
+ */
 @RestController
 @Api(value = "version", basePath = "/version", description = "versions of running application")
 public class VersionService {
 
+    @Autowired(required = false)
+    List<ManifestInfoProvider> manifestInfoProviders;
+
+    /**
+     * @param manifestInfoProviders The new {@link ManifestInfoProvider providers} to use to extract build id and version id
+     * from.
+     */
+    public void setManifestInfoProviders(List<ManifestInfoProvider> manifestInfoProviders) {
+        this.manifestInfoProviders = manifestInfoProviders;
+    }
+
+    /**
+     * @return A {@link Version} built following these conventions:
+     * <ul>
+     * <li>Concatenation of all {@link ManifestInfo} build ids (as returned by {@link ManifestInfo#getBuildId()}), separated
+     * by "-". Value to be returned by {@link Version#getBuildId()}.</li>
+     * <li>Concatenation of all <b>unique</b>{@link ManifestInfo} versions ids (as returned by
+     * {@link ManifestInfo#getVersionId()} ()}), separated by "-" (when more than one version found). Value to be returned by {@link Version#getVersionId()}</li>
+     * </ul>
+     */
     @RequestMapping(value = "/version", method = GET)
     @ApiOperation(value = "Get the version of the service", produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
     @PublicAPI
     public Version version() {
-        ManifestInfo manifestInfo = ManifestInfo.getInstance();
-        return new Version(manifestInfo.getVersionId(), manifestInfo.getBuildId());
+        String buildId = manifestInfoProviders.stream() //
+                .map(ManifestInfoProvider::getManifestInfo) //
+                .map(ManifestInfo::getBuildId) //
+                .collect(Collectors.joining("-"));
+        final Optional<String> uniqueVersions = manifestInfoProviders.stream() //
+                .map(ManifestInfoProvider::getManifestInfo) //
+                .map(ManifestInfo::getVersionId) //
+                .filter(versionId -> !StringUtils.equals("N/A", versionId)) //
+                .reduce((s, s2) -> {
+                    if (StringUtils.equals(s, s2)) {
+                        return s;
+                    }
+                    return s + '-' + s2;
+                });
+        String versionId = uniqueVersions.orElse("N/A");
+
+        return new Version(versionId, buildId);
     }
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Versions.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Versions.java
@@ -1,0 +1,36 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.talend.dataprep.info.ClassPathManifestInfoProvider;
+import org.talend.dataprep.info.ManifestInfo;
+import org.talend.dataprep.info.ManifestInfoProvider;
+
+/**
+ * The configuration file for loading {@link ManifestInfo} in context.
+ */
+@Configuration
+public class Versions {
+
+    @Bean
+    public ManifestInfoProvider baseProvider() {
+        return new ClassPathManifestInfoProvider("/dataprep-git.properties");
+    }
+
+    @Bean
+    public ManifestInfoProvider opsProvider() {
+        return new ClassPathManifestInfoProvider("/dataprep-ops-git.properties");
+    }
+}

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/BeanConversionService.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/BeanConversionService.java
@@ -12,7 +12,12 @@
 
 package org.talend.dataprep.conversions;
 
-import static java.util.stream.Stream.of;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.stereotype.Service;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
@@ -20,12 +25,7 @@ import java.lang.reflect.Type;
 import java.util.*;
 import java.util.function.BiFunction;
 
-import org.springframework.beans.BeanUtils;
-import org.springframework.beans.BeanWrapper;
-import org.springframework.beans.BeanWrapperImpl;
-import org.springframework.core.convert.ConversionService;
-import org.springframework.core.convert.TypeDescriptor;
-import org.springframework.stereotype.Service;
+import static java.util.stream.Stream.of;
 
 /**
  * This service provides methods to convert beans to other beans (DTOs, transient beans...). This service helps code to
@@ -134,7 +134,7 @@ public class BeanConversionService implements ConversionService {
 
             List<Registration<Object>> registrationsFound = getRegistrationsForSourceClass(source.getClass());
 
-            List<BiFunction<? super Object, U, U>> customs = new ArrayList<>();
+            List<BiFunction<Object, U, U>> customs = new ArrayList<>();
             for (Registration<Object> registrationFound : registrationsFound) {
                 customs.addAll(getRegistrationFunctions(targetClass, registrationFound));
             }
@@ -162,12 +162,12 @@ public class BeanConversionService implements ConversionService {
     }
 
     /** Get all available transformations in this registration. */
-    private <T, U> List<BiFunction<? super T, U, U>> getRegistrationFunctions(Class<U> targetClass,
+    private <T, U> List<BiFunction<T, U, U>> getRegistrationFunctions(Class<U> targetClass,
                                                                                   Registration<T> registration) {
-        List<BiFunction<? super T, U, U>> customs = new ArrayList<>();
+        List<BiFunction<T, U, U>> customs = new ArrayList<>();
         Class<U> currentClass = targetClass;
         while (currentClass != null) {
-            final BiFunction<? super T, U, U> custom = registration.getCustom(currentClass);
+            final BiFunction<T, U, U> custom = registration.getCustom(currentClass);
             if (custom != null) {
                 customs.add(custom);
             }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/info/ClassPathManifestInfoProvider.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/info/ClassPathManifestInfoProvider.java
@@ -1,0 +1,50 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.info;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClassPathManifestInfoProvider implements ManifestInfoProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClassPathManifestInfoProvider.class);
+
+    private final String resource;
+
+    public ClassPathManifestInfoProvider(String resource) {
+        this.resource = resource;
+    }
+
+    @Override
+    public ManifestInfo getManifestInfo() {
+        final Properties properties = new Properties();
+        final InputStream gitProperties = ClassPathManifestInfoProvider.class.getResourceAsStream(resource);
+        if (gitProperties != null) {
+            try {
+                properties.load(gitProperties);
+            } catch (IOException e) {
+                LOGGER.debug("Unable to read from resource '{}'.", resource, e);
+            }
+        } else {
+            LOGGER.debug("Resource '{}' does not exist.", resource);
+        }
+        final String versionId = Optional.ofNullable(properties.getProperty("git.build.version")).orElse("N/A");
+        final String buildId = Optional.ofNullable(properties.getProperty("git.commit.id.abbrev")).orElse("N/A");
+        return new ManifestInfo(versionId, buildId);
+    }
+}

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/info/ManifestInfo.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/info/ManifestInfo.java
@@ -13,60 +13,24 @@
 
 package org.talend.dataprep.info;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Contains the information info the version of running application
  */
 public class ManifestInfo {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ManifestInfo.class);
-
     /**
      * The version ID
      */
-    private String versionId;
+    private final String versionId;
 
     /**
      * The ID (from the SCM) of the source's version of the running application
      */
-    private String buildId;
+    private final String buildId;
 
-    /**
-     * The unique instance of this singleton class
-     */
-    private static ManifestInfo instance = new ManifestInfo();
-
-    private ManifestInfo() {
-        Properties properties = new Properties();
-        final InputStream gitProperties = ManifestInfo.class.getResourceAsStream("/dataprep-git.properties");
-        if (gitProperties != null) {
-            try {
-                properties.load(gitProperties);
-                versionId = properties.getProperty("git.build.version");
-                buildId = properties.getProperty("git.commit.id.abbrev");
-            } catch (IOException ie) {
-                LOGGER.debug("Unable to read from git.properties.", ie);
-                versionId = "????";
-                buildId = "????";
-            }
-        } else {
-            LOGGER.debug("No git.properties found, most likely using a locally built service.");
-            versionId = "LOCAL";
-            buildId = "N/A";
-        }
-    }
-
-    /**
-     * @return Return the unique instance.
-     */
-    public static ManifestInfo getInstance() {
-        return instance;
+    public ManifestInfo(String versionId, String buildId) {
+        this.versionId = versionId;
+        this.buildId = buildId;
     }
 
     /**

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/info/ManifestInfoProvider.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/info/ManifestInfoProvider.java
@@ -1,0 +1,25 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.info;
+
+/**
+ * A provider of {@link ManifestInfo} that may read from any source (a file, for example).
+ */
+@FunctionalInterface
+public interface ManifestInfoProvider {
+
+    /**
+     * @return An instance of {@link ManifestInfo} that corresponds to current context.
+     */
+    ManifestInfo getManifestInfo();
+}

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/api/service/info/VersionServiceTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/api/service/info/VersionServiceTest.java
@@ -1,0 +1,103 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.api.service.info;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.talend.dataprep.info.ManifestInfo;
+import org.talend.dataprep.info.ManifestInfoProvider;
+import org.talend.dataprep.info.Version;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VersionServiceTest {
+
+    @InjectMocks
+    private VersionService versionService;
+
+    @Test
+    public void shouldAggregateBuildId() throws Exception {
+        // given
+        final ManifestInfoProvider provider1 = mock(ManifestInfoProvider.class);
+        final ManifestInfoProvider provider2 = mock(ManifestInfoProvider.class);
+        when(provider1.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
+        when(provider2.getManifestInfo()).thenReturn(new ManifestInfo("v1", "5678"));
+        versionService.setManifestInfoProviders(asList(provider1, provider2));
+
+        // when
+        final Version version = versionService.version();
+
+        // then
+        assertEquals("v1", version.getVersionId());
+        assertEquals("1234-5678", version.getBuildId());
+    }
+
+    @Test
+    public void shouldAggregateSameBuildId() throws Exception {
+        // given
+        final ManifestInfoProvider provider1 = mock(ManifestInfoProvider.class);
+        final ManifestInfoProvider provider2 = mock(ManifestInfoProvider.class);
+        when(provider1.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
+        when(provider2.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
+        versionService.setManifestInfoProviders(asList(provider1, provider2));
+
+        // when
+        final Version version = versionService.version();
+
+        // then
+        assertEquals("v1", version.getVersionId());
+        assertEquals("1234-1234", version.getBuildId());
+    }
+
+    @Test
+    public void shouldAggregateVersionId() throws Exception {
+        // given
+        final ManifestInfoProvider provider1 = mock(ManifestInfoProvider.class);
+        final ManifestInfoProvider provider2 = mock(ManifestInfoProvider.class);
+        when(provider1.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
+        when(provider2.getManifestInfo()).thenReturn(new ManifestInfo("v2", "1234"));
+        versionService.setManifestInfoProviders(asList(provider1, provider2));
+
+        // when
+        final Version version = versionService.version();
+
+        // then
+        assertEquals("v1-v2", version.getVersionId());
+        assertEquals("1234-1234", version.getBuildId());
+    }
+
+    @Test
+    public void shouldShouldSkipMissingVersionId() throws Exception {
+        // given
+        final ManifestInfoProvider provider1 = mock(ManifestInfoProvider.class);
+        final ManifestInfoProvider provider2 = mock(ManifestInfoProvider.class);
+        when(provider1.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
+        when(provider2.getManifestInfo()).thenReturn(new ManifestInfo("N/A", "1234"));
+        versionService.setManifestInfoProviders(asList(provider1, provider2));
+
+        // when
+        final Version version = versionService.version();
+
+        // then
+        assertEquals("v1", version.getVersionId());
+        assertEquals("1234-1234", version.getBuildId());
+    }
+
+
+}

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/info/ClassPathManifestInfoProviderTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/info/ClassPathManifestInfoProviderTest.java
@@ -1,0 +1,47 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.info;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ClassPathManifestInfoProviderTest {
+
+    @Test
+    public void shouldReadFromFile() throws Exception {
+        // given
+        final ClassPathManifestInfoProvider provider = new ClassPathManifestInfoProvider("/git.properties");
+
+        // when
+        final ManifestInfo manifestInfo = provider.getManifestInfo();
+
+        // then
+        assertEquals("1.0.0", manifestInfo.getVersionId());
+        assertEquals("abcd1234", manifestInfo.getBuildId());
+    }
+
+    @Test
+    public void shouldReadFromMissingFile() throws Exception {
+        // given
+        final ClassPathManifestInfoProvider provider = new ClassPathManifestInfoProvider("/intentionally_missing_file.properties");
+
+        // when
+        final ManifestInfo manifestInfo = provider.getManifestInfo();
+
+        // then
+        assertEquals("N/A", manifestInfo.getVersionId());
+        assertEquals("N/A", manifestInfo.getBuildId());
+    }
+
+}

--- a/dataprep-backend-service/src/test/resources/git.properties
+++ b/dataprep-backend-service/src/test/resources/git.properties
@@ -1,0 +1,16 @@
+#
+# ============================================================================
+# Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+#
+# This source code is available under agreement available at
+# https://github.com/Talend/data-prep/blob/master/LICENSE
+#
+# You should have received a copy of the agreement
+# along with this program; if not, write to Talend SA
+# 9 rue Pages 92150 Suresnes, France
+#
+# ============================================================================
+#
+
+git.build.version=1.0.0
+git.commit.id.abbrev=abcd1234


### PR DESCRIPTION

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-XXXX (no jira)

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)

* Extensible mechanism to read versions (ManifestInfoProvider).
* Add to EE build (generates new version file).
