### PR TITLE
bugfix (TDP-4443): Export current sample make export full data

### DIFF
--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/TransformAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/TransformAPITest.java
@@ -15,7 +15,11 @@ package org.talend.dataprep.api.service;
 import static com.jayway.restassured.RestAssured.given;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 import static org.talend.dataprep.test.SameJSONFile.sameJSONAsFile;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
@@ -404,7 +408,9 @@ public class TransformAPITest extends ApiServiceTestBase {
                 preparationId, //
                 preparation.getHeadId(), //
                 "JSON", //
-                HEAD);
+                HEAD, //
+                "" // no filter
+        );
         assertTrue(contentCache.has(transformationCacheKey));
 
         // when

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/node/LimitNode.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/node/LimitNode.java
@@ -1,0 +1,78 @@
+// ============================================================================
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.transformation.pipeline.node;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.slf4j.Logger;
+import org.talend.dataprep.api.dataset.RowMetadata;
+import org.talend.dataprep.api.dataset.row.DataSetRow;
+import org.talend.dataprep.transformation.pipeline.Node;
+
+/**
+ * Node that limit input.
+ * When the input limit received is reached, a callback can be triggered.
+ */
+public class LimitNode extends BasicNode {
+
+    /** This class' logger. */
+    private static final Logger LOGGER = getLogger(LimitNode.class);
+
+    private int count = 0;
+
+    private final long limit;
+
+    private final Runnable callback;
+
+    public LimitNode(final long limit) {
+        this(limit, null);
+        LOGGER.trace("Limit set to {}", limit);
+    }
+
+    public LimitNode(final long limit, final Runnable callback) {
+        this.limit = limit;
+        this.callback = callback;
+    }
+
+    @Override
+    public void receive(final DataSetRow row, final RowMetadata metadata) {
+        if (count >= limit) {
+            return;
+        }
+
+        super.receive(row, metadata);
+        increment();
+    }
+
+    @Override
+    public void receive(final DataSetRow[] rows, final RowMetadata[] metadatas) {
+        if (count >= limit) {
+            return;
+        }
+
+        super.receive(rows, metadatas);
+        increment();
+    }
+
+    private void increment() {
+        if (++count == limit && callback != null) {
+            LOGGER.debug("limit {} reached", limit);
+            callback.run();
+        }
+    }
+
+    @Override
+    public Node copyShallow() {
+        return new LimitNode(limit, callback);
+    }
+}

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/api/export/ExportParameters.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/api/export/ExportParameters.java
@@ -87,10 +87,6 @@ public class ExportParameters implements AsyncGroupKey {
     @JsonRawValue
     private Object filter;
 
-    @JsonProperty("outFilter")
-    @JsonRawValue
-    private Object outFilter;
-
     private Map<String, String> unmappedProperties = new HashMap<>();
 
     private DataSet content;
@@ -178,19 +174,6 @@ public class ExportParameters implements AsyncGroupKey {
         }
     }
 
-    @JsonRawValue
-    public String getOutFilter() {
-        return outFilter == null ? null : outFilter.toString();
-    }
-
-    public void setOutFilter(JsonNode outFilter) {
-        if (outFilter == null || outFilter.isNull()) {
-            this.outFilter = null;
-        } else {
-            this.outFilter = outFilter;
-        }
-    }
-
     public Map<String, String> any() {
         return unmappedProperties;
     }
@@ -228,7 +211,6 @@ public class ExportParameters implements AsyncGroupKey {
                 ", exportName='" + exportName + '\'' + //
                 ", arguments=" + arguments + //
                 ", filter=" + filter + //
-                ", outFilter=" + outFilter + //
                 '}';
     }
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/configuration/Configuration.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/configuration/Configuration.java
@@ -77,6 +77,9 @@ public class Configuration {
 
     private PreparationMessage preparation;
 
+    /** Limit the output number of rows. */
+    private Long limit = null;
+
     /**
      * Constructor for the transformer configuration.
      */
@@ -92,7 +95,8 @@ public class Configuration {
                             final String stepId, //
                             boolean allowMetadataChange, //
                             boolean globalStatistics, //
-                            final Volume dataVolume) {
+            final Volume dataVolume, //
+            final Long limit) {
         this.output = output;
         this.filter = filter;
         this.outFilter = outFilter;
@@ -106,6 +110,7 @@ public class Configuration {
         this.allowMetadataChange = allowMetadataChange;
         this.globalStatistics = globalStatistics;
         this.dataVolume = dataVolume;
+        this.limit = limit;
     }
 
     /**
@@ -183,6 +188,10 @@ public class Configuration {
         return preparation;
     }
 
+    public Long getLimit() {
+        return limit;
+    }
+
     public enum Volume {
         LARGE,
         SMALL
@@ -237,6 +246,9 @@ public class Configuration {
 
         private boolean globalStatistics = true;
 
+        /** Limit the output number of rows. */
+        private Long limit = null;
+
         public Builder monitor(Supplier<Node> monitorSupplier) {
             this.monitorSupplier = monitorSupplier;
             return this;
@@ -255,7 +267,8 @@ public class Configuration {
          * @return a new {@link Configuration} from the mapper setup.
          */
         public Configuration build() {
-            return new Configuration(output, filter, outFilter, monitorSupplier, sourceType, format, actions, arguments, preparation, stepId, allowMetadataChange, globalStatistics, dataVolume);
+            return new Configuration(output, filter, outFilter, monitorSupplier, sourceType, format, actions, arguments,
+                    preparation, stepId, allowMetadataChange, globalStatistics, dataVolume, limit);
         }
 
         /**
@@ -337,6 +350,11 @@ public class Configuration {
 
         public Builder outFilter(Function<RowMetadata, Predicate<DataSetRow>> outFilter) {
             this.outFilter = outFilter;
+            return this;
+        }
+
+        public Builder limit(Long limit) {
+            this.limit = limit;
             return this;
         }
     }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/configuration/PreviewConfiguration.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/configuration/PreviewConfiguration.java
@@ -32,7 +32,7 @@ public class PreviewConfiguration extends Configuration {
 
     protected PreviewConfiguration(Configuration configuration, String previewActions, List<Long> indexes) {
         super(configuration.output(), configuration.getFilter(), configuration.getOutFilter(), configuration.getMonitor(), configuration.getSourceType(), configuration.formatId(), configuration.getActions(), configuration.getArguments(),
-                configuration.getPreparation(), configuration.stepId(), false, false, configuration.volume());
+                configuration.getPreparation(), configuration.stepId(), false, false, configuration.volume(), null);
         this.previewActions = previewActions;
         this.indexes = indexes;
     }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineTransformer.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineTransformer.java
@@ -93,13 +93,15 @@ public class PipelineTransformer implements Transformer {
         final Function<Step, RowMetadata> rowMetadataSupplier = s -> Optional.ofNullable(s.getRowMetadata()) //
                 .map(id -> preparationUpdater.get(id)) //
                 .orElse(null);
-        final Pipeline pipeline = Pipeline.Builder.builder().withAnalyzerService(analyzerService) //
+        final Pipeline pipeline = Pipeline.Builder.builder() //
+                .withAnalyzerService(analyzerService) //
                 .withActionRegistry(actionRegistry) //
                 .withPreparation(preparation) //
                 .withActions(actionParser.parse(configuration.getActions())) //
                 .withInitialMetadata(rowMetadata, configuration.volume() == SMALL) //
                 .withMonitor(configuration.getMonitor()) //
                 .withFilter(configuration.getFilter()) //
+                .withLimit(configuration.getLimit()) //
                 .withFilterOut(configuration.getOutFilter()) //
                 .withOutput(() -> new WriterNode(writer, metadataWriter, metadataKey, fallBackRowMetadata)) //
                 .withStatisticsAdapter(adapter) //

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/CacheKeyGenerator.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/CacheKeyGenerator.java
@@ -37,7 +37,7 @@ public class CacheKeyGenerator {
      * Build a cache key to identify the transformation result content
      */
     public TransformationCacheKey generateContentKey(final String datasetId, final String preparationId, final String stepId,
-            final String format, final SourceType sourceType, String filter) {
+            final String format, final SourceType sourceType, final String filter) {
         return this.generateContentKey(datasetId, preparationId, stepId, format, sourceType, Collections.emptyMap(), filter);
     }
 
@@ -61,7 +61,7 @@ public class CacheKeyGenerator {
             final String format, //
             final SourceType sourceType, //
             final Map<String, String> parameters, //
-            String filter) {
+            final String filter) {
 
         final String actualParameters = parameters == null ? StringUtils.EMPTY : parameters.entrySet().stream() //
                 .sorted(Comparator.comparing(Map.Entry::getKey)) //

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/CacheKeyGenerator.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/CacheKeyGenerator.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.talend.dataprep.api.export.ExportParameters;
+import org.talend.dataprep.api.export.ExportParameters.SourceType;
 import org.talend.dataprep.security.Security;
 
 /**
@@ -37,26 +37,52 @@ public class CacheKeyGenerator {
      * Build a cache key to identify the transformation result content
      */
     public TransformationCacheKey generateContentKey(final String datasetId, final String preparationId, final String stepId,
-            final String format, final ExportParameters.SourceType sourceType) {
-        return this.generateContentKey(datasetId, preparationId, stepId, format, sourceType, Collections.emptyMap());
+            final String format, final SourceType sourceType, String filter) {
+        return this.generateContentKey(datasetId, preparationId, stepId, format, sourceType, Collections.emptyMap(), filter);
     }
 
     /**
+     *
      * Build a cache key with additional parameters
      * When source type is HEAD, the user id is not included in cache key, as the HEAD sample is common for all users
+     *
+     * @param datasetId the dataset id.
+     * @param preparationId the preparation id.
+     * @param stepId the step id.
+     * @param format the format (csv, excel...)
+     * @param sourceType where the data comes from.
+     * @param parameters the parameters.
+     * @param filter the applied filters.
+     * @return the transformation cache key to use.
      */
-    public TransformationCacheKey generateContentKey(final String datasetId, final String preparationId, final String stepId,
-            final String format, final ExportParameters.SourceType sourceType, final Map<String, String> parameters) {
+    public TransformationCacheKey generateContentKey(final String datasetId, //
+            final String preparationId, //
+            final String stepId, //
+            final String format, //
+            final SourceType sourceType, //
+            final Map<String, String> parameters, //
+            String filter) {
+
         final String actualParameters = parameters == null ? StringUtils.EMPTY : parameters.entrySet().stream() //
                 .sorted(Comparator.comparing(Map.Entry::getKey)) //
                 .map(Map.Entry::getValue) //
                 .reduce((s1, s2) -> s1 + s2) //
                 .orElse(StringUtils.EMPTY);
-        final ExportParameters.SourceType actualSourceType = sourceType == null ? HEAD : sourceType;
+        final SourceType actualSourceType = sourceType == null ? HEAD : sourceType;
         final String actualUserId = actualSourceType == HEAD ? null : security.getUserId();
 
-        return new TransformationCacheKey(preparationId, datasetId, format, stepId, actualParameters, actualSourceType,
-                actualUserId);
+        final String actualFilter = filter == null ? "" : filter;
+
+        return new TransformationCacheKey( //
+                preparationId, //
+                datasetId, //
+                format, //
+                stepId, //
+                actualParameters, //
+                actualSourceType, //
+                actualUserId, //
+                actualFilter //
+        );
     }
 
     /**
@@ -64,8 +90,8 @@ public class CacheKeyGenerator {
      * When source type is HEAD, the user id is not included in cache key, as the HEAD sample is common for all users
      */
     public TransformationMetadataCacheKey generateMetadataKey(final String preparationId, final String stepId,
-            final ExportParameters.SourceType sourceType) {
-        final ExportParameters.SourceType actualSourceType = sourceType == null ? HEAD : sourceType;
+            final SourceType sourceType) {
+        final SourceType actualSourceType = sourceType == null ? HEAD : sourceType;
         final String actualUserId = actualSourceType == HEAD ? null : security.getUserId();
 
         return new TransformationMetadataCacheKey(preparationId, stepId, actualSourceType, actualUserId);
@@ -91,7 +117,7 @@ public class CacheKeyGenerator {
 
         private String stepId;
 
-        private ExportParameters.SourceType sourceType;
+        private SourceType sourceType;
 
         private CacheKeyGenerator cacheKeyGenerator;
 
@@ -109,7 +135,7 @@ public class CacheKeyGenerator {
             return this;
         }
 
-        public MetadataCacheKeyBuilder sourceType(final ExportParameters.SourceType sourceType) {
+        public MetadataCacheKeyBuilder sourceType(final SourceType sourceType) {
             this.sourceType = sourceType;
             return this;
         }
@@ -131,7 +157,9 @@ public class CacheKeyGenerator {
 
         private String stepId;
 
-        private ExportParameters.SourceType sourceType;
+        private SourceType sourceType;
+
+        private String filter;
 
         private CacheKeyGenerator cacheKeyGenerator;
 
@@ -149,7 +177,7 @@ public class CacheKeyGenerator {
             return this;
         }
 
-        public ContentCacheKeyBuilder sourceType(final ExportParameters.SourceType sourceType) {
+        public ContentCacheKeyBuilder sourceType(final SourceType sourceType) {
             this.sourceType = sourceType;
             return this;
         }
@@ -169,8 +197,13 @@ public class CacheKeyGenerator {
             return this;
         }
 
+        public ContentCacheKeyBuilder filter(final String filter) {
+            this.filter = filter;
+            return this;
+        }
+
         public TransformationCacheKey build() {
-            return cacheKeyGenerator.generateContentKey(datasetId, preparationId, stepId, format, sourceType, parameters);
+            return cacheKeyGenerator.generateContentKey(datasetId, preparationId, stepId, format, sourceType, parameters, filter);
         }
     }
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationCacheKey.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/cache/TransformationCacheKey.java
@@ -49,6 +49,9 @@ public class TransformationCacheKey implements ContentCacheKey {
     /** The transformation format. */
     private String format;
 
+    /** Transformation filter. */
+    private String filter;
+
     /**
      * Create a cache key for transformation result content
      * @param preparationId The preparation id.
@@ -66,10 +69,12 @@ public class TransformationCacheKey implements ContentCacheKey {
             final String stepId,
             final String parameters,
             final ExportParameters.SourceType sourceType,
-            final String userId) {
+            final String userId, final String filter) {
+
         if (StringUtils.equals("head", stepId)) {
             throw new IllegalArgumentException("'head' is not allowed as step id for cache key");
         }
+
         this.preparationId = preparationId;
         this.datasetId = datasetId;
         this.format = format;
@@ -77,6 +82,7 @@ public class TransformationCacheKey implements ContentCacheKey {
         this.parameters = parameters;
         this.sourceType = sourceType;
         this.userId = userId;
+        this.filter = filter;
     }
 
     /**
@@ -92,6 +98,7 @@ public class TransformationCacheKey implements ContentCacheKey {
                 + ", parameters='" + parameters + '\''
                 + ", sourceType='" + sourceType + '\''
                 + ", userId='" + userId + '\''
+                + ", filter='" + filter + '\''
                 + '}';
     }
 
@@ -103,7 +110,7 @@ public class TransformationCacheKey implements ContentCacheKey {
     @Override
     public String getKey() {
         return PREFIX + '_' + preparationId + "_" + datasetId + "_"
-                + DigestUtils.sha1Hex(stepId + format + Objects.hash(parameters) + sourceType + userId);
+                + DigestUtils.sha1Hex(stepId + format + Objects.hash(parameters) + sourceType + userId + filter);
     }
 
     @Override

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/event/PreparationCacheListener.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/event/PreparationCacheListener.java
@@ -39,6 +39,7 @@ public class PreparationCacheListener {
                 null, //
                 null, //
                 null, //
+                null, //
                 null);
         contentCache.evictMatch(transformationCacheKey);
     }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -412,7 +412,8 @@ public class TransformationService extends BaseTransformationService {
                 previewParameters.getPreparationId(), //
                 Step.ROOT_STEP.id(), //
                 JSON, //
-                previewParameters.getSourceType() //
+                previewParameters.getSourceType(), //
+                "" // no filters for preview
         );
 
         try (final InputStream metadata = contentCache.get(metadataKey); //
@@ -487,7 +488,8 @@ public class TransformationService extends BaseTransformationService {
                     previewParameters.getPreparationId(), //
                     Step.ROOT_STEP.id(), //
                     JSON, //
-                    previewParameters.getSourceType() //
+                    previewParameters.getSourceType(), //
+                    "" // no filter for preview parameters
             );
 
             return contentCache.has(metadataKey) && contentCache.has(contentKey);

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/ApplyPreparationExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/ApplyPreparationExportStrategy.java
@@ -84,7 +84,8 @@ public class ApplyPreparationExportStrategy extends BaseSampleExportStrategy {
         boolean technicianIdentityReleased = false;
         securityProxy.asTechnicalUser();
         // get the dataset content (in an auto-closable block to make sure it is properly closed)
-        final DataSetGet dataSetGet = applicationContext.getBean(DataSetGet.class, dataSetId, true, true);
+        final boolean fullContent = parameters.getFrom() == ExportParameters.SourceType.FILTER;
+        final DataSetGet dataSetGet = applicationContext.getBean(DataSetGet.class, dataSetId, fullContent, true);
 
         try (final InputStream datasetContent = dataSetGet.execute();
                 final JsonParser parser = mapper.getFactory().createParser(datasetContent)) {
@@ -102,8 +103,15 @@ public class ApplyPreparationExportStrategy extends BaseSampleExportStrategy {
             final String actions = getActions(preparationId, version);
 
             // create tee to broadcast to cache + service output
-            final TransformationCacheKey key = cacheKeyGenerator.generateContentKey(dataSetId, preparationId, version, formatName,
-                    parameters.getFrom(), parameters.getArguments());
+            final TransformationCacheKey key = cacheKeyGenerator.generateContentKey( //
+                    dataSetId, //
+                    preparationId, //
+                    version, //
+                    formatName, //
+                    parameters.getFrom(), //
+                    parameters.getArguments(), //
+                    parameters.getFilter() //
+            );
             LOGGER.debug("Cache key: " + key.getKey());
             LOGGER.debug("Cache key details: " + key.toString());
             try (final TeeOutputStream tee = new TeeOutputStream(outputStream,

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/BaseSampleExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/BaseSampleExportStrategy.java
@@ -13,7 +13,17 @@
 
 package org.talend.dataprep.transformation.service.export;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.talend.dataprep.transformation.service.BaseExportStrategy;
 
+/**
+ * Base class for all SampleExport strategies.
+ *
+ * By default the sample is 10k lines.
+ */
 public abstract class BaseSampleExportStrategy extends BaseExportStrategy implements SampleExportStrategy {
+
+    @Value("${dataset.records.limit:10000}")
+    protected long limit;
+
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/CachedExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/CachedExportStrategy.java
@@ -77,8 +77,10 @@ public class CachedExportStrategy extends BaseSampleExportStrategy {
                 parameters.getPreparationId(), //
                 getCleanStepId(preparation, parameters.getStepId()), //
                 parameters.getExportType(), //
-                parameters.getFrom(),
-                parameters.getArguments());
+                parameters.getFrom(), //
+                parameters.getArguments(), //
+                parameters.getFilter() //
+        );
     }
 
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/DataSetExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/DataSetExportStrategy.java
@@ -68,6 +68,7 @@ public class DataSetExportStrategy extends BaseSampleExportStrategy {
                             .format(format.getName()) //
                             .volume(Configuration.Volume.SMALL) //
                             .output(outputStream) //
+                            .limit(limit) //
                             .build();
                     factory.get(configuration).buildExecutable(dataSet, configuration).execute();
                 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
@@ -133,6 +133,7 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
                         .stepId(version) //
                         .volume(Configuration.Volume.SMALL) //
                         .output(tee) //
+                        .limit(limit) //
                         .build();
                 factory.get(configuration).buildExecutable(dataSet, configuration).execute();
                 tee.flush();

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
@@ -110,13 +110,14 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
             LOGGER.debug("Running optimized strategy for preparation {} @ step #{}", preparationId, version);
 
             // create tee to broadcast to cache + service output
-            final TransformationCacheKey key = cacheKeyGenerator.generateContentKey(
-                    dataSetId,
-                    preparationId,
-                    version,
-                    parameters.getExportType(),
-                    parameters.getFrom(),
-                    parameters.getArguments()
+            final TransformationCacheKey key = cacheKeyGenerator.generateContentKey( //
+                    dataSetId, //
+                    preparationId, //
+                    version, //
+                    parameters.getExportType(), //
+                    parameters.getFrom(), //
+                    parameters.getArguments(), //
+                    parameters.getFilter() //
             );
             LOGGER.debug("Cache key: " + key.getKey());
             LOGGER.debug("Cache key details: " + key.toString());
@@ -199,6 +200,8 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
 
         private String previousVersion;
 
+        private String filter;
+
         private OptimizedPreparationInput(ExportParameters parameters) {
             this.stepId = parameters.getStepId();
             this.preparationId = parameters.getPreparationId();
@@ -214,6 +217,7 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
                 this.dataSetId = parameters.getDatasetId();
             }
             this.formatName = parameters.getExportType();
+            this.filter = parameters.getFilter();
         }
 
         private String getDataSetId() {
@@ -226,6 +230,10 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
 
         private DataSetMetadata getMetadata() {
             return metadata;
+        }
+
+        private String getFilter() {
+            return filter;
         }
 
         private TransformationCacheKey getTransformationCacheKey() {
@@ -273,12 +281,13 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
             try (InputStream input = contentCache.get(transformationMetadataCacheKey)) {
                 metadata = mapper.readerFor(DataSetMetadata.class).readValue(input);
             }
-            transformationCacheKey = cacheKeyGenerator.generateContentKey(
-                    dataSetId,
-                    preparationId,
-                    previousVersion,
-                    formatName,
-                    sourceType
+            transformationCacheKey = cacheKeyGenerator.generateContentKey( //
+                    dataSetId, //
+                    preparationId, //
+                    previousVersion, //
+                    formatName, //
+                    sourceType, //
+                    filter //
             );
             LOGGER.debug("Previous content cache key: " + transformationCacheKey.getKey());
             LOGGER.debug("Previous content cache key details: " + transformationCacheKey.toString());

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategy.java
@@ -105,13 +105,14 @@ public class PreparationExportStrategy extends BaseSampleExportStrategy {
                 // get the actions to apply (no preparation ==> dataset export ==> no actions)
                 final String actions = getActions(preparationId, version);
 
-                final TransformationCacheKey key = cacheKeyGenerator.generateContentKey(
-                        dataSetId,
-                        preparationId,
-                        version,
-                        formatName,
-                        parameters.getFrom(),
-                        parameters.getArguments()
+                final TransformationCacheKey key = cacheKeyGenerator.generateContentKey( //
+                        dataSetId, //
+                        preparationId, //
+                        version, //
+                        formatName, //
+                        parameters.getFrom(), //
+                        parameters.getArguments(), //
+                        parameters.getFilter() //
                 );
                 LOGGER.debug("Cache key: " + key.getKey());
                 LOGGER.debug("Cache key details: " + key.toString());

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategy.java
@@ -129,6 +129,7 @@ public class PreparationExportStrategy extends BaseSampleExportStrategy {
                             .stepId(version) //
                             .volume(Configuration.Volume.SMALL) //
                             .output(tee) //
+                            .limit(limit) //
                             .build();
                     factory.get(configuration).buildExecutable(dataSet, configuration).execute();
                     tee.flush();

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/cache/TransformationCacheKeyTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/cache/TransformationCacheKeyTest.java
@@ -13,7 +13,9 @@
 package org.talend.dataprep.transformation.cache;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 
@@ -49,21 +51,22 @@ public class TransformationCacheKeyTest {
     @Test(expected = IllegalArgumentException.class)
     public void headNotAllowed() throws Exception {
         // when
-        new TransformationCacheKey(
-                "prep1",
-                "123456789",
-                "JSON",
+        new TransformationCacheKey( //
+                "prep1", //
+                "123456789", //
+                "JSON", //
                 "head", // this is not allowed
-                "params",
-                FILTER,
-                "user 1"
+                "params", //
+                FILTER, //
+                "user 1", //
+                "" // no filter
         );
     }
 
     @Test
     public void getKey_should_generate_serialized_key() throws Exception {
         // given
-        final ContentCacheKey key = new TransformationCacheKey("prep1", "dataset1", "JSON", "step1", "param1", HEAD, "user1");
+        final ContentCacheKey key = new TransformationCacheKey("prep1", "dataset1", "JSON", "step1", "param1", HEAD, "user1", "");
 
         // when
         final String keyStr = key.getKey();
@@ -75,10 +78,12 @@ public class TransformationCacheKeyTest {
     @Test
     public void getMatcher_should_return_matcher_for_partial_key() throws Exception {
         // given
-        final ContentCacheKey prepKey = new TransformationCacheKey("prep1", null, null, null, null, null, null);
-        final ContentCacheKey dataSetKey = new TransformationCacheKey(null, "dataset1", null, null, null, null, null);
-        final ContentCacheKey matchingKey = new TransformationCacheKey("prep1", "dataset1", "JSON", "step1", "param1", HEAD, "user1");
-        final ContentCacheKey nonMatchingKey = new TransformationCacheKey("prep2", "dataset2", "XLS", "step2", "param2", FILTER, "user2");
+        final ContentCacheKey prepKey = new TransformationCacheKey("prep1", null, null, null, null, null, null, "");
+        final ContentCacheKey dataSetKey = new TransformationCacheKey(null, "dataset1", null, null, null, null, null, "");
+        final ContentCacheKey matchingKey = new TransformationCacheKey("prep1", "dataset1", "JSON", "step1", "param1", HEAD,
+                "user1", "");
+        final ContentCacheKey nonMatchingKey = new TransformationCacheKey("prep2", "dataset2", "XLS", "step2", "param2", FILTER,
+                "user2", "");
 
         // when / then
         assertThat(prepKey.getMatcher().test(matchingKey.getKey()), is(true));
@@ -88,14 +93,15 @@ public class TransformationCacheKeyTest {
     }
 
     private TransformationCacheKey createTestDefaultKey() {
-        return new TransformationCacheKey(
-                "prep1",
-                "123456789",
-                "JSON",
-                "v1",
-                "params",
-                FILTER,
-                "user 1"
+        return new TransformationCacheKey( //
+                "prep1", //
+                "123456789", //
+                "JSON", //
+                "v1", //
+                "params", //
+                FILTER, //
+                "user 1", //
+                "" // no filter
         );
     }
 }

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformationServiceTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformationServiceTest.java
@@ -17,7 +17,10 @@ import static com.jayway.restassured.RestAssured.when;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 import static org.talend.dataprep.cache.ContentCache.TimeToLive.PERMANENT;
@@ -45,10 +48,10 @@ import org.talend.dataprep.cache.ContentCacheKey;
 import org.talend.dataprep.preparation.store.PreparationRepository;
 import org.talend.dataprep.transformation.cache.CacheKeyGenerator;
 import org.talend.dataprep.transformation.cache.TransformationCacheKey;
+import org.talend.dataquality.semantic.broadcast.TdqCategories;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.jayway.restassured.response.Response;
-import org.talend.dataquality.semantic.broadcast.TdqCategories;
 
 /**
  * Integration tests on actions.
@@ -191,12 +194,13 @@ public class TransformationServiceTest extends TransformationServiceBaseTest {
         final Preparation preparation = getPreparation(prepId);
         final String headId = preparation.getHeadId();
 
-        final TransformationCacheKey key = cacheKeyGenerator.generateContentKey(
-                dsId,
-                preparation.getId(),
-                headId,
-                JSON,
-                HEAD
+        final TransformationCacheKey key = cacheKeyGenerator.generateContentKey( //
+                dsId, //
+                preparation.getId(), //
+                headId, //
+                JSON, //
+                HEAD, //
+                "" // no filter
         );
         assertFalse(contentCache.has(key));
 
@@ -299,12 +303,13 @@ public class TransformationServiceTest extends TransformationServiceBaseTest {
         // System.out.println("\n\n\net voila le résultat de la transformation : " + result + "\n\n\n");
 
         // (make sure the result was not cached)
-        final TransformationCacheKey key = cacheKeyGenerator.generateContentKey(
-                dataSetId,
-                preparationId,
-                preparationRepository.get(preparationId, Preparation.class).getHeadId(),
-                JSON,
-                HEAD
+        final TransformationCacheKey key = cacheKeyGenerator.generateContentKey( //
+                dataSetId, //
+                preparationId, //
+                preparationRepository.get(preparationId, Preparation.class).getHeadId(), //
+                JSON, //
+                HEAD, //
+                "" // no filter
         );
 
         // Thread.sleep(500L);

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/export/CachedExportStrategyTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/export/CachedExportStrategyTest.java
@@ -14,6 +14,7 @@ package org.talend.dataprep.transformation.service.export;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -52,8 +53,7 @@ public class CachedExportStrategyTest extends ServiceBaseTest {
         preparation.setHeadId("0");
         preparationRepository.add(preparation);
 
-        final TransformationCacheKey cacheKey = cacheKeyGenerator.generateContentKey("1234", "1234", "0", "text",
-                ExportParameters.SourceType.HEAD);
+        final TransformationCacheKey cacheKey = cacheKeyGenerator.generateContentKey("1234", "1234", "0", "text", HEAD, "");
         try (OutputStream text = cache.put(cacheKey, ContentCache.TimeToLive.DEFAULT)) {
             text.write("{}".getBytes());
         } catch (IOException e) {
@@ -70,7 +70,7 @@ public class CachedExportStrategyTest extends ServiceBaseTest {
         parameters.setPreparationId("1234");
         parameters.setStepId("0");
         parameters.setExportType("text");
-        parameters.setFrom(ExportParameters.SourceType.HEAD);
+        parameters.setFrom(HEAD);
 
         // Then
         assertTrue(cachedExportStrategy.accept(parameters));
@@ -84,7 +84,7 @@ public class CachedExportStrategyTest extends ServiceBaseTest {
         parameters.setPreparationId("2345"); // Preparation differs from key.
         parameters.setStepId("0");
         parameters.setExportType("text");
-        parameters.setFrom(ExportParameters.SourceType.HEAD);
+        parameters.setFrom(HEAD);
 
         // Then
         assertFalse(cachedExportStrategy.accept(parameters));

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategyTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategyTest.java
@@ -146,12 +146,13 @@ public class OptimizedExportStrategyTest extends TransformationServiceBaseTest {
                 content.flush();
             }
 
-            final TransformationCacheKey key = cacheKeyGenerator.generateContentKey(
-                    datasetId,
-                    preparation,
-                    step.id(),
-                    format,
-                    HEAD
+            final TransformationCacheKey key = cacheKeyGenerator.generateContentKey( //
+                    datasetId, //
+                    preparation, //
+                    step.id(), //
+                    format, //
+                    HEAD, //
+                    "" //
             );
             try (OutputStream content = contentCache.put(key, ContentCache.TimeToLive.DEFAULT)) {
                 content.write("{}".getBytes());
@@ -185,12 +186,13 @@ public class OptimizedExportStrategyTest extends TransformationServiceBaseTest {
                 content.flush();
             }
 
-            final TransformationCacheKey key = cacheKeyGenerator.generateContentKey(
-                    datasetId,
-                    preparation,
-                    step.id(),
-                    format,
-                    HEAD
+            final TransformationCacheKey key = cacheKeyGenerator.generateContentKey( //
+                    datasetId, //
+                    preparation, //
+                    step.id(), //
+                    format, //
+                    HEAD, //
+                    "" // no filter
             );
             try (OutputStream content = contentCache.put(key, ContentCache.TimeToLive.DEFAULT)) {
                 content.write("{\"records\": [{\"0000\": \"a\"}]}".getBytes());


### PR DESCRIPTION
 * improve TDP-4330 used to so that the get dataset command gets all the dataset content in case of a sampling
 * remove ExportParameters.filterOut that was never used
 * add filter in ContentCacheKey

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4443

**Please check if the PR fulfills these requirements**
- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [X] The new code does not introduce new technical issues (sonar / eslint)
- [X] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [X] No, and no need to (backend changes only)
