### PR TITLE
feat TDP-4270 dynamically select prep in di

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/DataSetAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/DataSetAPI.java
@@ -47,6 +47,7 @@ import org.talend.dataprep.dataset.service.UserDataSetMetadata;
 import org.talend.dataprep.http.HttpResponseContext;
 import org.talend.dataprep.metrics.Timed;
 import org.talend.dataprep.security.PublicAPI;
+import org.talend.dataprep.util.SortAndOrderHelper;
 import org.talend.dataprep.util.SortAndOrderHelper.Order;
 import org.talend.dataprep.util.SortAndOrderHelper.Sort;
 
@@ -343,7 +344,7 @@ public class DataSetAPI extends APIService {
                     .collectList() //
                     .cache(); // Keep it in cache for later reuse
             // get list of preparations
-            GenericCommand<InputStream> preparationList = getCommand(PreparationList.class, PreparationList.Format.LONG, sort, order);
+            GenericCommand<InputStream> preparationList = getCommand(PreparationList.class, SortAndOrderHelper.Format.LONG, sort, order);
             return Flux.from(toPublisher(Preparation.class, mapper, preparationList)) //
                     .filter(p -> compatibleList.flatMapIterable(l -> l) //
                             .map(DataSetMetadata::getId) //

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
@@ -80,13 +80,14 @@ public class PreparationAPI extends APIService {
             @RequestParam(value = "format", defaultValue = "summary") Format format,
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
             @ApiParam(name = "folder_path", value = "Filter preparations by its folder path.") @RequestParam(required = false, name = "folder_path") String folderPath,
+            @ApiParam(name = "path", value = "Filter preparations by full path. Should always return one preparation") @RequestParam(required = false, name = "path") String path,
             @ApiParam(value = "Sort key, defaults to 'modification'.") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc), defaults to 'desc'.") @RequestParam(defaultValue = "desc") Order order) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Listing preparations (pool: {} )...", getConnectionStats());
         }
 
-        GenericCommand<InputStream> command = getCommand(PreparationList.class, format, name, folderPath, sort, order);
+        GenericCommand<InputStream> command = getCommand(PreparationList.class, format, name, folderPath, path, sort, order);
         return CommandHelper.toStreaming(command);
     }
 

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
@@ -79,14 +79,14 @@ public class PreparationAPI extends APIService {
             @ApiParam(name = "format", value = "Format of the returned document (can be 'long', 'short' or 'summary'). Defaults to 'summary'.")
             @RequestParam(value = "format", defaultValue = "summary") Format format,
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
-            @ApiParam(name = "path", value = "Filter preparations by path.") @RequestParam(required = false) String path,
+            @ApiParam(name = "folder_path", value = "Filter preparations by its folder path.") @RequestParam(required = false, name = "folder_path") String folderPath,
             @ApiParam(value = "Sort key, defaults to 'modification'.") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc), defaults to 'desc'.") @RequestParam(defaultValue = "desc") Order order) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Listing preparations (pool: {} )...", getConnectionStats());
         }
 
-        GenericCommand<InputStream> command = getCommand(PreparationList.class, format, name, path, sort, order);
+        GenericCommand<InputStream> command = getCommand(PreparationList.class, format, name, folderPath, sort, order);
         return CommandHelper.toStreaming(command);
     }
 

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
@@ -58,6 +58,7 @@ import org.talend.dataprep.exception.error.APIErrorCodes;
 import org.talend.dataprep.metrics.Timed;
 import org.talend.dataprep.security.PublicAPI;
 import org.talend.dataprep.transformation.actions.datablending.Lookup;
+import org.talend.dataprep.util.SortAndOrderHelper.Format;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.netflix.hystrix.HystrixCommand;
@@ -76,16 +77,16 @@ public class PreparationAPI extends APIService {
     @Timed
     public ResponseEntity<StreamingResponseBody> listPreparations(
             @ApiParam(name = "format", value = "Format of the returned document (can be 'long', 'short' or 'summary'). Defaults to 'summary'.")
-            @RequestParam(value = "format", defaultValue = "summary") String format,
+            @RequestParam(value = "format", defaultValue = "summary") Format format,
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
+            @ApiParam(name = "path", value = "Filter preparations by path.") @RequestParam(required = false) String path,
             @ApiParam(value = "Sort key, defaults to 'modification'.") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc), defaults to 'desc'.") @RequestParam(defaultValue = "desc") Order order) {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Listing preparations (pool: {} )...", getConnectionStats());
         }
 
-        PreparationList.Format listFormat = PreparationList.Format.valueOf(format.toUpperCase());
-        GenericCommand<InputStream> command = getCommand(PreparationList.class, listFormat, name, sort, order);
+        GenericCommand<InputStream> command = getCommand(PreparationList.class, format, name, path, sort, order);
         return CommandHelper.toStreaming(command);
     }
 

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreparationList.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreparationList.java
@@ -29,40 +29,40 @@ import org.talend.dataprep.command.GenericCommand;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.APIErrorCodes;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
+import org.talend.dataprep.util.SortAndOrderHelper;
 import org.talend.dataprep.util.SortAndOrderHelper.Order;
 
 @Component
 @Scope("request")
 public class PreparationList extends GenericCommand<InputStream> {
 
-    private PreparationList(Format format, String name, Sort sort, Order order) {
+    private PreparationList(SortAndOrderHelper.Format format, String name, String path, Sort sort, Order order) {
         super(GenericCommand.PREPARATION_GROUP);
-        execute(() -> onExecute(name, sort, order, format));
+        execute(() -> onExecute(format, name, path, sort, order));
         onError(e -> new TDPException(APIErrorCodes.UNABLE_TO_RETRIEVE_PREPARATION_LIST, e));
         on(HttpStatus.NO_CONTENT, HttpStatus.ACCEPTED).then(emptyStream());
         on(HttpStatus.OK).then(pipeStream());
     }
 
-    private PreparationList(Format format, Sort sort, Order order) {
-        this(format, null, sort, order);
+    private PreparationList(SortAndOrderHelper.Format format, Sort sort, Order order) {
+        this(format, null, null, sort, order);
     }
 
-    private PreparationList(Format format) {
-        this(format, null, Sort.NAME, Order.ASC);
-    }
-
-    private HttpRequestBase onExecute(String name, Sort sort, Order order, Format format) {
+    private HttpRequestBase onExecute(SortAndOrderHelper.Format format, String name, String path, Sort sort, Order order) {
         try {
             URIBuilder uriBuilder;
-            if (Format.SHORT.equals(format)) {
+            if (SortAndOrderHelper.Format.SHORT.equals(format)) {
                 uriBuilder = new URIBuilder(preparationServiceUrl + "/preparations"); //$NON-NLS-1$
-            } else if (Format.SUMMARY.equals(format)) {
+            } else if (SortAndOrderHelper.Format.SUMMARY.equals(format)) {
                 uriBuilder = new URIBuilder(preparationServiceUrl + "/preparations/summaries"); //$NON-NLS-1$
             } else {
                 uriBuilder = new URIBuilder(preparationServiceUrl + "/preparations/details"); //$NON-NLS-1$
             }
             if (name != null) {
                 uriBuilder.addParameter("name", name);
+            }
+            if (path != null) {
+                uriBuilder.addParameter("path", path);
             }
             uriBuilder.addParameter("sort", sort.camelName());
             uriBuilder.addParameter("order", order.camelName());
@@ -72,9 +72,4 @@ public class PreparationList extends GenericCommand<InputStream> {
         }
     }
 
-    public enum Format {
-        SHORT,
-        SUMMARY,
-        LONG
-    }
 }

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreparationList.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreparationList.java
@@ -36,19 +36,19 @@ import org.talend.dataprep.util.SortAndOrderHelper.Order;
 @Scope("request")
 public class PreparationList extends GenericCommand<InputStream> {
 
-    private PreparationList(SortAndOrderHelper.Format format, String name, String folderPath, Sort sort, Order order) {
+    private PreparationList(SortAndOrderHelper.Format format, String name, String folderPath, String path, Sort sort, Order order) {
         super(GenericCommand.PREPARATION_GROUP);
-        execute(() -> onExecute(format, name, folderPath, sort, order));
+        execute(() -> onExecute(format, name, folderPath, path, sort, order));
         onError(e -> new TDPException(APIErrorCodes.UNABLE_TO_RETRIEVE_PREPARATION_LIST, e));
         on(HttpStatus.NO_CONTENT, HttpStatus.ACCEPTED).then(emptyStream());
         on(HttpStatus.OK).then(pipeStream());
     }
 
     private PreparationList(SortAndOrderHelper.Format format, Sort sort, Order order) {
-        this(format, null, null, sort, order);
+        this(format, null, null, null, sort, order);
     }
 
-    private HttpRequestBase onExecute(SortAndOrderHelper.Format format, String name, String folderPath, Sort sort, Order order) {
+    private HttpRequestBase onExecute(SortAndOrderHelper.Format format, String name, String folderPath, String path, Sort sort, Order order) {
         try {
             URIBuilder uriBuilder;
             if (SortAndOrderHelper.Format.SHORT.equals(format)) {
@@ -63,6 +63,9 @@ public class PreparationList extends GenericCommand<InputStream> {
             }
             if (folderPath != null) {
                 uriBuilder.addParameter("folder_path", folderPath);
+            }
+            if (path != null) {
+                uriBuilder.addParameter("path", path);
             }
             uriBuilder.addParameter("sort", sort.camelName());
             uriBuilder.addParameter("order", order.camelName());

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreparationList.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreparationList.java
@@ -36,9 +36,9 @@ import org.talend.dataprep.util.SortAndOrderHelper.Order;
 @Scope("request")
 public class PreparationList extends GenericCommand<InputStream> {
 
-    private PreparationList(SortAndOrderHelper.Format format, String name, String path, Sort sort, Order order) {
+    private PreparationList(SortAndOrderHelper.Format format, String name, String folderPath, Sort sort, Order order) {
         super(GenericCommand.PREPARATION_GROUP);
-        execute(() -> onExecute(format, name, path, sort, order));
+        execute(() -> onExecute(format, name, folderPath, sort, order));
         onError(e -> new TDPException(APIErrorCodes.UNABLE_TO_RETRIEVE_PREPARATION_LIST, e));
         on(HttpStatus.NO_CONTENT, HttpStatus.ACCEPTED).then(emptyStream());
         on(HttpStatus.OK).then(pipeStream());
@@ -48,7 +48,7 @@ public class PreparationList extends GenericCommand<InputStream> {
         this(format, null, null, sort, order);
     }
 
-    private HttpRequestBase onExecute(SortAndOrderHelper.Format format, String name, String path, Sort sort, Order order) {
+    private HttpRequestBase onExecute(SortAndOrderHelper.Format format, String name, String folderPath, Sort sort, Order order) {
         try {
             URIBuilder uriBuilder;
             if (SortAndOrderHelper.Format.SHORT.equals(format)) {
@@ -61,8 +61,8 @@ public class PreparationList extends GenericCommand<InputStream> {
             if (name != null) {
                 uriBuilder.addParameter("name", name);
             }
-            if (path != null) {
-                uriBuilder.addParameter("path", path);
+            if (folderPath != null) {
+                uriBuilder.addParameter("folder_path", folderPath);
             }
             uriBuilder.addParameter("sort", sort.camelName());
             uriBuilder.addParameter("order", order.camelName());

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -12,21 +12,13 @@
 
 package org.talend.dataprep.api.service;
 
-import static com.jayway.restassured.RestAssured.expect;
-import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.RestAssured.when;
+import static com.jayway.restassured.RestAssured.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.OK;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
@@ -43,13 +35,7 @@ import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -137,7 +123,7 @@ public class PreparationAPITest extends ApiServiceTestBase {
     }
 
     @Test
-    public void testPreparationsList_withFilter() throws Exception {
+    public void testPreparationsList_withFilterOnName() throws Exception {
         // given
         String tagadaId = testClient.createDataset("dataset/dataset.csv", "tagada");
         String preparationId = testClient.createPreparationFromDataset(tagadaId, "testPreparation", home.getId());
@@ -148,6 +134,25 @@ public class PreparationAPITest extends ApiServiceTestBase {
         // then
         final List<String> values = shortFormat.getList("");
         assertThat(values.get(0), is(preparationId));
+    }
+
+    @Test
+    public void testPreparationsList_withFilterOnPath() throws Exception {
+        // given
+        String tagadaId = testClient.createDataset("dataset/dataset.csv", "tagada");
+        String preparationId = testClient.createPreparationFromDataset(tagadaId, "testPreparation", home.getId());
+
+        // when : short format
+        final JsonPath shouldNotBeEmpty = when().get("/api/preparations/?format=short&path={path}", "/").jsonPath();
+
+        // then
+        assertThat(shouldNotBeEmpty.<String>getList("").get(0), is(preparationId));
+
+        // when
+        final JsonPath shouldBeEmpty = when().get("/api/preparations/?format=short&path={path}", "/toto").jsonPath();
+
+        // then
+        assertThat(shouldBeEmpty.<String>getList(""), is(empty()));
     }
 
     @Test

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -143,13 +143,13 @@ public class PreparationAPITest extends ApiServiceTestBase {
         String preparationId = testClient.createPreparationFromDataset(tagadaId, "testPreparation", home.getId());
 
         // when : short format
-        final JsonPath shouldNotBeEmpty = when().get("/api/preparations/?format=short&path={path}", "/").jsonPath();
+        final JsonPath shouldNotBeEmpty = when().get("/api/preparations/?format=short&folder_path={folder_path}", "/").jsonPath();
 
         // then
         assertThat(shouldNotBeEmpty.<String>getList("").get(0), is(preparationId));
 
         // when
-        final JsonPath shouldBeEmpty = when().get("/api/preparations/?format=short&path={path}", "/toto").jsonPath();
+        final JsonPath shouldBeEmpty = when().get("/api/preparations/?format=short&folder_path={folder_path}", "/toto").jsonPath();
 
         // then
         assertThat(shouldBeEmpty.<String>getList(""), is(empty()));

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -158,19 +158,41 @@ public class PreparationAPITest extends ApiServiceTestBase {
     }
 
     @Test
-    public void testPreparationsList_withFilterOnPath() throws Exception {
+    public void testPreparationsList_withFilterOnFolderPath() throws Exception {
         // given
         String tagadaId = testClient.createDataset("dataset/dataset.csv", "tagada");
-        String preparationId = testClient.createPreparationFromDataset(tagadaId, "testPreparation", home.getId());
+        String preparationName = "tagadaPreparation";
+        String preparationId = testClient.createPreparationFromDataset(tagadaId, preparationName, home.getId());
 
         // when : short format
-        final JsonPath shouldNotBeEmpty = when().get("/api/preparations/?format=short&folder_path={folder_path}", "/").jsonPath();
+        final Response shouldNotBeEmpty = when().get("/api/preparations/?format=short&folder_path={folder_path}", "/");
+
+        // then
+        List<String> result = mapper.readerFor(String.class).<String>readValues(shouldNotBeEmpty.asInputStream()).readAll();
+        assertThat(result.get(0), is(preparationId));
+
+        // when
+        final JsonPath shouldBeEmpty = when().get("/api/preparations/?format=short&folder_path={folder_path}", "/toto").jsonPath();
+
+        // then
+        assertThat(shouldBeEmpty.<String>getList(""), is(empty()));
+    }
+
+    @Test
+    public void testPreparationsList_withFilterOnFullPath() throws Exception {
+        // given
+        String tagadaId = testClient.createDataset("dataset/dataset.csv", "tagada");
+        String preparationName = "tagadaPreparation";
+        String preparationId = testClient.createPreparationFromDataset(tagadaId, preparationName, home.getId());
+
+        // when : short format
+        final JsonPath shouldNotBeEmpty = when().get("/api/preparations/?format=short&path={path}", "/" + preparationName).jsonPath();
 
         // then
         assertThat(shouldNotBeEmpty.<String>getList("").get(0), is(preparationId));
 
         // when
-        final JsonPath shouldBeEmpty = when().get("/api/preparations/?format=short&folder_path={folder_path}", "/toto").jsonPath();
+        final JsonPath shouldBeEmpty = when().get("/api/preparations/?format=short&path={path}", "/toto/" + preparationName).jsonPath();
 
         // then
         assertThat(shouldBeEmpty.<String>getList(""), is(empty()));

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/SortAndOrderSerializationAdvice.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/SortAndOrderSerializationAdvice.java
@@ -25,6 +25,7 @@ public class SortAndOrderSerializationAdvice {
         // URLs are cleaner in lowercase.
         binder.registerCustomEditor(SortAndOrderHelper.Sort.class, SortAndOrderHelper.getSortPropertyEditor());
         binder.registerCustomEditor(SortAndOrderHelper.Order.class, SortAndOrderHelper.getOrderPropertyEditor());
+        binder.registerCustomEditor(SortAndOrderHelper.Format.class, SortAndOrderHelper.getFormatPropertyEditor());
     }
 
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/ErrorCodeDto.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/ErrorCodeDto.java
@@ -13,6 +13,7 @@ import static java.util.Collections.emptyList;
 
 import java.util.Collection;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.talend.daikon.exception.error.ErrorCode;
 
 public class ErrorCodeDto implements ErrorCode {
@@ -75,5 +76,15 @@ public class ErrorCodeDto implements ErrorCode {
     public ErrorCodeDto setExpectedContextEntries(Collection<String> expectedContextEntries) {
         this.expectedContextEntries = expectedContextEntries;
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("product", product)
+                .append("group", group)
+                .append("code", code)
+                .append("httpStatus", httpStatus)
+                .append("expectedContextEntries", expectedContextEntries)
+                .toString();
     }
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/FolderRepository.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/FolderRepository.java
@@ -12,8 +12,11 @@
 
 package org.talend.dataprep.folder.store;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.talend.dataprep.api.folder.Folder;
@@ -203,4 +206,16 @@ public interface FolderRepository {
 
         return hierarchy;
     }
+
+    /**
+     * Builds a Map with preparations IDs as key and their folder path as values.
+     */
+    default Map<String, String> getPreparationsFolderPaths() {
+        return searchFolders("", false) //
+                .flatMap( //
+                        f -> entries(f.getId(), FolderContentType.PREPARATION).map(e -> new SimpleEntry<>(f.getPath(), e.getContentId())) //
+                ) //
+                .collect(Collectors.toMap(SimpleEntry::getValue, SimpleEntry::getKey));
+    }
+
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/FolderRepository.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/FolderRepository.java
@@ -210,10 +210,10 @@ public interface FolderRepository {
     /**
      * Builds a Map with preparations IDs as key and their folder path as values.
      */
-    default Map<String, String> getPreparationsFolderPaths() {
+    default Map<String, Folder> getPreparationsFolderPaths() {
         return searchFolders("", false) //
                 .flatMap( //
-                        f -> entries(f.getId(), FolderContentType.PREPARATION).map(e -> new SimpleEntry<>(f.getPath(), e.getContentId())) //
+                        f -> entries(f.getId(), FolderContentType.PREPARATION).map(e -> new SimpleEntry<>(f, e.getContentId())) //
                 ) //
                 .collect(Collectors.toMap(SimpleEntry::getValue, SimpleEntry::getKey));
     }

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
@@ -75,11 +75,11 @@ public class PreparationController {
     @Timed
     public Stream<String> list(
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
-            @ApiParam(name = "path", value = "Filter preparations by path.") @RequestParam(required = false) String path,
+            @ApiParam(name = "folder_path", value = "Filter preparations by folder path.") @RequestParam(required = false, name = "folder_path") String folderPath,
             @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
         LOGGER.debug("Get list of preparations (summary).");
-        return preparationService.listAll(name, path, sort, order).map(Preparation::id);
+        return preparationService.listAll(name, folderPath, sort, order).map(Preparation::id);
     }
 
     /**
@@ -94,10 +94,10 @@ public class PreparationController {
     @Timed
     public Stream<UserPreparation> listAll(
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
-            @ApiParam(name = "path", value = "Filter preparations by path.") @RequestParam(required = false) String path,
+            @ApiParam(name = "folder_path", value = "Filter preparations by folder path.") @RequestParam(required = false, name = "folder_path") String folderPath,
             @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
-        return preparationService.listAll(name, path, sort, order);
+        return preparationService.listAll(name, folderPath, sort, order);
     }
 
     /**
@@ -110,11 +110,11 @@ public class PreparationController {
     @Timed
     public Stream<PreparationSummary> listSummary(
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
-            @ApiParam(name = "path", value = "Filter preparations by path.") @RequestParam(required = false) String path,
+            @ApiParam(name = "folder_path", value = "Filter preparations by folder path.") @RequestParam(required = false, name = "folder_path") String folderPath,
             @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
         LOGGER.debug("Get list of preparations (summary).");
-        return preparationService.listSummary(name, path, sort, order);
+        return preparationService.listSummary(name, folderPath, sort, order);
     }
 
     /**

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
@@ -12,6 +12,7 @@
 
 package org.talend.dataprep.preparation.service;
 
+import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
@@ -22,6 +23,7 @@ import java.util.stream.Stream;
 
 import javax.validation.Valid;
 
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -40,6 +42,8 @@ import io.swagger.annotations.ApiParam;
 @RestController
 @Api(value = "preparations", basePath = "/preparations", description = "Operations on preparations")
 public class PreparationController {
+
+    private static final Logger LOGGER = getLogger(PreparationController.class);
 
     @Autowired
     private PreparationService preparationService;
@@ -71,9 +75,11 @@ public class PreparationController {
     @Timed
     public Stream<String> list(
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
+            @ApiParam(name = "path", value = "Filter preparations by path.") @RequestParam(required = false) String path,
             @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
-        return preparationService.list(name, sort, order);
+        LOGGER.debug("Get list of preparations (summary).");
+        return preparationService.listAll(name, path, sort, order).map(Preparation::id);
     }
 
     /**
@@ -88,9 +94,10 @@ public class PreparationController {
     @Timed
     public Stream<UserPreparation> listAll(
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
+            @ApiParam(name = "path", value = "Filter preparations by path.") @RequestParam(required = false) String path,
             @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
-        return preparationService.listAll(name, sort, order);
+        return preparationService.listAll(name, path, sort, order);
     }
 
     /**
@@ -102,8 +109,12 @@ public class PreparationController {
     @ApiOperation(value = "List all preparations", notes = "Returns the list of preparations summaries the current user is allowed to see. Creation date is always displayed in UTC time zone.")
     @Timed
     public Stream<PreparationSummary> listSummary(
-            @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name) {
-        return preparationService.listSummary(name);
+            @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
+            @ApiParam(name = "path", value = "Filter preparations by path.") @RequestParam(required = false) String path,
+            @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
+            @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
+        LOGGER.debug("Get list of preparations (summary).");
+        return preparationService.listSummary(name, path, sort, order);
     }
 
     /**

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
@@ -76,10 +76,11 @@ public class PreparationController {
     public Stream<String> list(
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
             @ApiParam(name = "folder_path", value = "Filter preparations by folder path.") @RequestParam(required = false, name = "folder_path") String folderPath,
+            @ApiParam(name = "path", value = "Filter preparations by full path (<folder path>/<preparation name>).") @RequestParam(required = false, name = "path") String path,
             @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
         LOGGER.debug("Get list of preparations (summary).");
-        return preparationService.listAll(name, folderPath, sort, order).map(Preparation::id);
+        return preparationService.listAll(name, folderPath, path, sort, order).map(Preparation::id);
     }
 
     /**
@@ -95,9 +96,10 @@ public class PreparationController {
     public Stream<UserPreparation> listAll(
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
             @ApiParam(name = "folder_path", value = "Filter preparations by folder path.") @RequestParam(required = false, name = "folder_path") String folderPath,
+            @ApiParam(name = "path", value = "Filter preparations by full path (<folder path>/<preparation name>).") @RequestParam(required = false, name = "path") String path,
             @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
-        return preparationService.listAll(name, folderPath, sort, order);
+        return preparationService.listAll(name, folderPath, path, sort, order);
     }
 
     /**
@@ -111,10 +113,11 @@ public class PreparationController {
     public Stream<PreparationSummary> listSummary(
             @ApiParam(name = "name", value = "Filter preparations by name.") @RequestParam(required = false) String name,
             @ApiParam(name = "folder_path", value = "Filter preparations by folder path.") @RequestParam(required = false, name = "folder_path") String folderPath,
+            @ApiParam(name = "path", value = "Filter preparations by full path (<folder path>/<preparation name>).") @RequestParam(required = false, name = "path") String path,
             @ApiParam(value = "Sort key (by name or date).") @RequestParam(defaultValue = "lastModificationDate") Sort sort,
             @ApiParam(value = "Order for sort key (desc or asc).") @RequestParam(defaultValue = "desc") Order order) {
         LOGGER.debug("Get list of preparations (summary).");
-        return preparationService.listSummary(name, folderPath, sort, order);
+        return preparationService.listSummary(name, folderPath, path, sort, order);
     }
 
     /**

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationSearchCriterion.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationSearchCriterion.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ * https://github.com/Talend/data-prep/blob/master/LICENSE
+ *
+ * You should have received a copy of the agreement
+ * along with this program; if not, write to Talend SA
+ * 9 rue Pages 92150 Suresnes, France
+ */
+
+package org.talend.dataprep.preparation.service;
+
+/**
+ * Group any criteria available to filter preparations.
+ */
+public class PreparationSearchCriterion {
+
+    private String dataSetId;
+    private String folderId;
+    private String name;
+    private boolean nameExactMatch;
+    private String folderPath;
+
+    public static PreparationSearchCriterion filterPreparation() {
+        return new PreparationSearchCriterion();
+    }
+
+    public String getDataSetId() {
+        return dataSetId;
+    }
+
+    public PreparationSearchCriterion byDataSetId(String dataSetId) {
+        this.dataSetId = dataSetId;
+        return this;
+    }
+
+    public String getFolderId() {
+        return folderId;
+    }
+
+    public PreparationSearchCriterion byFolderId(String folderId) {
+        this.folderId = folderId;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PreparationSearchCriterion byName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public boolean isNameExactMatch() {
+        return nameExactMatch;
+    }
+
+    public PreparationSearchCriterion withNameExactMatch(boolean nameExactMatch) {
+        this.nameExactMatch = nameExactMatch;
+        return this;
+    }
+
+    public String getFolderPath() {
+        return folderPath;
+    }
+
+    public PreparationSearchCriterion byFolderPath(String folderPath) {
+        this.folderPath = folderPath;
+        return this;
+    }
+}


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4270

- add preparation filter by path to be able to retrieve a specific preparation using name and path filter
- add testing for folder embedded in preparation when retrieving one preparation

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted
