### PR TITLE
chore: add missing start class property in pom

### DIFF
--- a/dataprep-api/pom.xml
+++ b/dataprep-api/pom.xml
@@ -26,6 +26,7 @@
     <name>dataprep-api</name>
     <properties>
         <stack.param.name>DataPrepApiFQIN</stack.param.name>
+        <start-class>org.talend.dataprep.api.Application</start-class>
     </properties>
     <dependencies>
         <dependency>

--- a/dataprep-dataset/pom.xml
+++ b/dataprep-dataset/pom.xml
@@ -27,6 +27,7 @@
     </parent>
     <properties>
         <stack.param.name>DataPrepDatasetFQIN</stack.param.name>
+        <start-class>org.talend.dataprep.dataset.Application</start-class>
     </properties>
 
     <build>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
When trying to run TDP in command line (`mvn` or `java -jar`), it fails with a NoClassDefFound `fill.this.value.in.service.module`.
 
**What is the chosen solution to this problem?**
It reads the pom to get the start class, there were 2 missing properties

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
