### PR TITLE
feat(TDP-3601): add the locale resolver

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/help/DocumentationLinksManager.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/help/DocumentationLinksManager.java
@@ -1,6 +1,7 @@
 package org.talend.dataprep.help;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -8,9 +9,6 @@ public class DocumentationLinksManager {
 
     @Value("${help.facets.version:}")
     private String versionFacet;
-
-    @Value("${help.facets.language:}")
-    private String languageFacet;
 
     @Value("${help.search.url:https://www.talendforge.org/find/api/THC.php}")
     private String searchUrl;
@@ -26,7 +24,7 @@ public class DocumentationLinksManager {
     }
 
     public String getLanguageFacet() {
-        return languageFacet;
+        return LocaleContextHolder.getLocale().toString();
     }
 
     public String getSearchUrl() {

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/i18n/DataprepLocaleContextResolver.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/i18n/DataprepLocaleContextResolver.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at https://github.com/Talend/data-prep/blob/master/LICENSE
+ *
+ * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+ * 92150 Suresnes, France
+ */
+
+package org.talend.dataprep.i18n;
+
+import static java.util.Locale.US;
+import static org.slf4j.LoggerFactory.getLogger;
+import static org.springframework.web.servlet.DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.LocaleUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.i18n.LocaleContext;
+import org.springframework.context.i18n.SimpleLocaleContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.i18n.AbstractLocaleContextResolver;
+
+// This component must have the LOCALE_RESOLVER_BEAN_NAME as it is searched by this name in DispatcherServlet.initLocaleResolver:524
+@Component(LOCALE_RESOLVER_BEAN_NAME)
+public class DataprepLocaleContextResolver extends AbstractLocaleContextResolver {
+
+    private static final Logger LOGGER = getLogger(DataprepLocaleContextResolver.class);
+
+    private final Locale applicationLocale;
+
+    public DataprepLocaleContextResolver(@Value("${dataprep.locale:${help.facets.language:}}") String configuredLocale) {
+        setDefaultLocale(US);
+        this.applicationLocale = resolveApplicationLocale(configuredLocale);
+    }
+
+    @Override
+    public LocaleContext resolveLocaleContext(HttpServletRequest request) {
+        return new SimpleLocaleContext(applicationLocale);
+    }
+
+    @Override
+    public void setLocaleContext(HttpServletRequest request, HttpServletResponse response, LocaleContext localeContext) {
+        throw new UnsupportedOperationException();
+    }
+
+    private Locale resolveApplicationLocale(String configuredLocale) {
+        Locale locale;
+        if (StringUtils.isNotBlank(configuredLocale)) {
+            try {
+                locale = LocaleUtils.toLocale(configuredLocale);
+                LOGGER.info("Setting application locale to configured {}", locale);
+            } catch (IllegalArgumentException e) {
+                // Illegal locale
+                locale = getDefaultLocale();
+                LOGGER.warn(
+                        "Error parsing configured application locale: {}. Defaulting to {}. Locale must be in the form \"en_US\" or \"fr_CA\"",
+                        configuredLocale, getDefaultLocale());
+            }
+        } else {
+            locale = getDefaultLocale();
+            LOGGER.info("Setting application locale to default value {}", getDefaultLocale());
+        }
+        return locale;
+    }
+}

--- a/dataprep-backend-service/src/test/java/org/talend/ServiceBaseTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/ServiceBaseTest.java
@@ -13,6 +13,7 @@
 package org.talend;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.talend.ServiceBaseTest.TEST_LOCALE;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,8 +36,10 @@ import com.jayway.restassured.RestAssured;
 @RunWith(SpringRunner.class)
 @Import(LocalContentServiceConfiguration.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = { "dataset.asynchronous.analysis=false",
-        "content-service.store=local", "live.dataset.location=tac"})
+        "content-service.store=local", "live.dataset.location=tac", "dataprep.locale:" + TEST_LOCALE})
 public abstract class ServiceBaseTest {
+
+    public static final String TEST_LOCALE = "vi_VN";
 
     @Configuration
     @ComponentScan(basePackages = {"org.talend.daikon.content", "org.talend.dataprep"})

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/i18n/DataprepLocaleContextResolverIntegrationTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/i18n/DataprepLocaleContextResolverIntegrationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ * https://github.com/Talend/data-prep/blob/master/LICENSE
+ *
+ * You should have received a copy of the agreement
+ * along with this program; if not, write to Talend SA
+ * 9 rue Pages 92150 Suresnes, France
+ */
+
+package org.talend.dataprep.i18n;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.talend.ServiceBaseTest;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Response;
+
+
+public class DataprepLocaleContextResolverIntegrationTest extends ServiceBaseTest {
+
+    @Test
+    public void shouldReturnOKWhenVersionAsked() throws Exception {
+        Response response = RestAssured.get("/get_my_test_locale");
+
+        assertEquals(200, response.getStatusCode());
+        assertEquals(TEST_LOCALE, response.asString());
+    }
+
+    @Controller
+    public static class TestController {
+
+        @RequestMapping("get_my_test_locale")
+        @ResponseBody
+        public String getLocale() {
+            return LocaleContextHolder.getLocale().toString();
+        }
+
+    }
+}

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/i18n/DataprepLocaleContextResolverTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/i18n/DataprepLocaleContextResolverTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ * https://github.com/Talend/data-prep/blob/master/LICENSE
+ *
+ * You should have received a copy of the agreement
+ * along with this program; if not, write to Talend SA
+ * 9 rue Pages 92150 Suresnes, France
+ */
+
+package org.talend.dataprep.i18n;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.i18n.LocaleContext;
+import org.springframework.context.i18n.SimpleLocaleContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataprepLocaleContextResolverTest {
+
+    private static final String TEST_LOCALE = "vi_VN";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Test
+    public void resolveLocaleContext_wellFormattedLocaleIsTaken() throws Exception {
+        DataprepLocaleContextResolver resolver = new DataprepLocaleContextResolver(TEST_LOCALE);
+
+        LocaleContext localeContext = resolver.resolveLocaleContext(request);
+        assertNotNull(localeContext);
+        assertEquals(TEST_LOCALE, localeContext.getLocale().toString());
+    }
+
+    @Test
+    public void resolveLocaleContext_notFormattedLocaleDefault() throws Exception {
+        DataprepLocaleContextResolver resolver = new DataprepLocaleContextResolver("abcd");
+
+        LocaleContext localeContext = resolver.resolveLocaleContext(request);
+        assertNotNull(localeContext);
+        assertEquals(Locale.US, localeContext.getLocale());
+    }
+
+    @Test
+    public void resolveLocaleContext_noLocaleThenDefault() throws Exception {
+        DataprepLocaleContextResolver resolver = new DataprepLocaleContextResolver(null);
+
+        LocaleContext localeContext = resolver.resolveLocaleContext(request);
+        assertNotNull(localeContext);
+        assertEquals(Locale.US, localeContext.getLocale());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void setLocaleContext() throws Exception {
+        new DataprepLocaleContextResolver("en_US").setLocaleContext(request, response, new SimpleLocaleContext(Locale.FRANCE));
+    }
+
+}


### PR DESCRIPTION
* Spring MVC locale resolver is able to add for every request the
  locale defined in configuration and appropriate fallbacks
* TDP-4498: use conf locale in DocumentationLinksManager
* change locale configuration property name

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-TDP-3601

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted
