### PR TITLE
fix(TDP-4568): add watcher for Resource

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/io/CloseableResourceWatch.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/io/CloseableResourceWatch.java
@@ -247,6 +247,17 @@ public class CloseableResourceWatch implements Condition {
         public Closeable getCloseable() {
             return this;
         }
+
+        /**
+         * Ensure that the delegate is closed before being GCed.
+         *
+         * @see FileInputStream#finalize()
+         * @see Object#finalize()
+         */
+        @Override
+        protected void finalize() throws Throwable {
+            delegate.close();
+        }
     }
 
     private class OutputStreamHandler extends OutputStream implements CloseableHandler {
@@ -315,6 +326,17 @@ public class CloseableResourceWatch implements Condition {
         @Override
         public String toString() {
             return format();
+        }
+
+        /**
+         * Ensure that the delegate is closed before being GCed.
+         *
+         * @see FileInputStream#finalize()
+         * @see Object#finalize()
+         */
+        @Override
+        protected void finalize() throws Throwable {
+            delegate.close();
         }
     }
 

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/io/CloseableResourceWatch.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/io/CloseableResourceWatch.java
@@ -249,16 +249,6 @@ public class CloseableResourceWatch implements Condition {
             return this;
         }
 
-        /**
-         * Ensure that the delegate is closed before being GCed.
-         *
-         * @see FileInputStream#finalize()
-         * @see Object#finalize()
-         */
-        @Override
-        protected void finalize() throws Throwable {
-            delegate.close();
-        }
     }
 
     private class OutputStreamHandler extends OutputStream implements CloseableHandler {
@@ -329,16 +319,6 @@ public class CloseableResourceWatch implements Condition {
             return format();
         }
 
-        /**
-         * Ensure that the delegate is closed before being GCed.
-         *
-         * @see FileInputStream#finalize()
-         * @see Object#finalize()
-         */
-        @Override
-        protected void finalize() throws Throwable {
-            delegate.close();
-        }
     }
 
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/io/CloseableResourceWatch.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/io/CloseableResourceWatch.java
@@ -37,6 +37,7 @@ import org.talend.daikon.content.DeletableResource;
  * <ul>
  *     <li>{@link InputStream}</li>
  *     <li>{@link OutputStream}</li>
+ *     <li>streams created by {@link DeletableResource}</li>
  * </ul>
  * To activate this watcher, logging framework must enable "org.talend.dataprep.io" in debug level.
  */

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/io/CloseableInputStreamComponent.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/io/CloseableInputStreamComponent.java
@@ -12,13 +12,16 @@
 
 package org.talend.dataprep.io;
 
-import java.io.*;
-import java.net.URI;
-import java.net.URL;
+import static org.mockito.Mockito.when;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.io.output.NullOutputStream;
-import org.springframework.core.io.Resource;
+import org.mockito.Mockito;
 import org.springframework.stereotype.Component;
 import org.talend.daikon.content.DeletableResource;
 
@@ -47,92 +50,11 @@ public class CloseableInputStreamComponent {
         };
     }
 
-    public DeletableResource getDeletableResource() {
-        return new DeletableResource() {
-
-            private NullOutputStream nullOutputStream = new NullOutputStream();
-
-            private NullInputStream nullInputStream = new NullInputStream(0);
-
-            @Override
-            public void delete() throws IOException {
-
-            }
-
-            @Override
-            public void move(String s) throws IOException {
-
-            }
-
-            @Override
-            public boolean isWritable() {
-                return false;
-            }
-
-            @Override
-            public OutputStream getOutputStream() throws IOException {
-                return nullOutputStream;
-            }
-
-            @Override
-            public boolean exists() {
-                return false;
-            }
-
-            @Override
-            public boolean isReadable() {
-                return false;
-            }
-
-            @Override
-            public boolean isOpen() {
-                return false;
-            }
-
-            @Override
-            public URL getURL() throws IOException {
-                return null;
-            }
-
-            @Override
-            public URI getURI() throws IOException {
-                return null;
-            }
-
-            @Override
-            public File getFile() throws IOException {
-                return null;
-            }
-
-            @Override
-            public long contentLength() throws IOException {
-                return 0;
-            }
-
-            @Override
-            public long lastModified() throws IOException {
-                return 0;
-            }
-
-            @Override
-            public Resource createRelative(String relativePath) throws IOException {
-                return null;
-            }
-
-            @Override
-            public String getFilename() {
-                return null;
-            }
-
-            @Override
-            public String getDescription() {
-                return null;
-            }
-
-            @Override
-            public InputStream getInputStream() throws IOException {
-                return nullInputStream;
-            }
-        };
+    public DeletableResource getDeletableResource() throws IOException {
+        final DeletableResource deletableResource = Mockito.mock(DeletableResource.class);
+        when(deletableResource.getInputStream()).thenReturn(getInput());
+        when(deletableResource.getOutputStream()).thenReturn(getOutput());
+        return deletableResource;
     }
+
 }

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/io/CloseableInputStreamComponent.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/io/CloseableInputStreamComponent.java
@@ -12,14 +12,15 @@
 
 package org.talend.dataprep.io;
 
+import java.io.*;
+import java.net.URI;
+import java.net.URL;
+
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.io.output.NullOutputStream;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import org.talend.daikon.content.DeletableResource;
 
 @Component
 public class CloseableInputStreamComponent {
@@ -43,6 +44,95 @@ public class CloseableInputStreamComponent {
     public Closeable getUnknownCloseable() {
         return () -> {
             // Nothing to do
+        };
+    }
+
+    public DeletableResource getDeletableResource() {
+        return new DeletableResource() {
+
+            private NullOutputStream nullOutputStream = new NullOutputStream();
+
+            private NullInputStream nullInputStream = new NullInputStream(0);
+
+            @Override
+            public void delete() throws IOException {
+
+            }
+
+            @Override
+            public void move(String s) throws IOException {
+
+            }
+
+            @Override
+            public boolean isWritable() {
+                return false;
+            }
+
+            @Override
+            public OutputStream getOutputStream() throws IOException {
+                return nullOutputStream;
+            }
+
+            @Override
+            public boolean exists() {
+                return false;
+            }
+
+            @Override
+            public boolean isReadable() {
+                return false;
+            }
+
+            @Override
+            public boolean isOpen() {
+                return false;
+            }
+
+            @Override
+            public URL getURL() throws IOException {
+                return null;
+            }
+
+            @Override
+            public URI getURI() throws IOException {
+                return null;
+            }
+
+            @Override
+            public File getFile() throws IOException {
+                return null;
+            }
+
+            @Override
+            public long contentLength() throws IOException {
+                return 0;
+            }
+
+            @Override
+            public long lastModified() throws IOException {
+                return 0;
+            }
+
+            @Override
+            public Resource createRelative(String relativePath) throws IOException {
+                return null;
+            }
+
+            @Override
+            public String getFilename() {
+                return null;
+            }
+
+            @Override
+            public String getDescription() {
+                return null;
+            }
+
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return nullInputStream;
+            }
         };
     }
 }

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/io/CloseableResourceWatchTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/io/CloseableResourceWatchTest.java
@@ -15,6 +15,7 @@ package org.talend.dataprep.io;
 import static org.junit.Assert.*;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.function.Supplier;
 
 import org.junit.Test;
@@ -54,6 +55,28 @@ public class CloseableResourceWatchTest extends ServiceBaseTest {
     @Test
     public void shouldNotWrapUnknown() throws Exception {
         assertCloseable(() -> component.getUnknownCloseable(), false);
+    }
+
+    @Test
+    public void shouldWrapResourceInput() throws Exception {
+        assertCloseable(() -> {
+            try {
+                return component.getDeletableResource().getInputStream();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }, true);
+    }
+
+    @Test
+    public void shouldWrapResourceOutput() throws Exception {
+        assertCloseable(() -> {
+            try {
+                return component.getDeletableResource().getOutputStream();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }, true);
     }
 
     public void assertCloseable(Supplier<Closeable> closeableSupplier, boolean shouldWrap) throws Exception {


### PR DESCRIPTION
When using org.talend.daikon.content.DeletableResource that are used to
read/write in cache and store uploaded dataset the streams will be
monitored just the same as other streams.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4568

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted
