### PR TITLE
chore: Fix TQL dependency version

### DIFF
--- a/dataprep-backend-service/pom.xml
+++ b/dataprep-backend-service/pom.xml
@@ -122,8 +122,8 @@
             <artifactId>dataquality-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.talend.daikon</groupId>
-            <artifactId>daikon-tql-core</artifactId>
+            <groupId>org.talend.datastewardship</groupId>
+            <artifactId>tql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.talend.dataprep</groupId>

--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
     <name>dataprep-backend</name>
     <properties>
-        <dataprep.core.version>2.2.1-SNAPSHOT</dataprep.core.version>
+        <dataprep.core.version>2.2.0</dataprep.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.7.22</slf4j.version>
         <java.version>1.8</java.version>
@@ -45,7 +45,7 @@
         <project.organization>Talend</project.organization>
         <!-- This version should match the one pulled by tika-parsers -> geoapi -->
         <javax.measure.jsr-275.version>0.9.3</javax.measure.jsr-275.version>
-        <tql.version>0.19.0-SNAPSHOT</tql.version>
+        <tql.version>6.3.1</tql.version>
         <commons-compress.version>1.14</commons-compress.version>
         <!-- avro version must match the one in the studio -->
         <avro.version>1.7.7</avro.version>
@@ -496,8 +496,8 @@
                 <version>${commons-compress.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.talend.daikon</groupId>
-                <artifactId>daikon-tql-core</artifactId>
+                <groupId>org.talend.datastewardship</groupId>
+                <artifactId>tql</artifactId>
                 <version>${tql.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
* Revert TQL change from 6.3.1 -> 0.18.3 (change in version number during TDS to Daikon).

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4600

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
