### PR TITLE
fix(TDP-2902) Dataset API allows dataset with empty name

### DIFF
--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/DataSetService.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/DataSetService.java
@@ -582,6 +582,9 @@ public class DataSetService extends BaseDataSetService {
         }
 
         DataSetMetadata currentDataSetMetadata = dataSetMetadataRepository.get(dataSetId);
+        if (currentDataSetMetadata == null && name == null) {
+            throw new TDPException(INVALID_DATASET_NAME, ExceptionContext.build().put("name", name));
+        }
 
         // just like the creation, let's make sure invalid size forbids dataset creation
         if (size < 0) {

--- a/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/DataSetServiceTest.java
+++ b/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/DataSetServiceTest.java
@@ -12,9 +12,7 @@
 
 package org.talend.dataprep.dataset.service;
 
-import static com.jayway.restassured.RestAssured.expect;
-import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.RestAssured.when;
+import static com.jayway.restassured.RestAssured.*;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static com.jayway.restassured.path.json.JsonPath.from;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -23,22 +21,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.http.HttpStatus.OK;
 import static org.talend.dataprep.test.SameJSONFile.sameJSONAsFile;
@@ -48,13 +33,7 @@ import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
@@ -883,6 +862,28 @@ public class DataSetServiceTest extends DataSetBaseTest {
                 .put("/datasets/{id}", "3d72677c-e2c9-4a34-8c58-959a56ec8643") //
                 .then() //
                 .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    public void update_or_create_unknown_dataset_without_name() throws Exception {
+        assertThat(dataSetMetadataRepository.get("3d72677c-e2c9-4a34-8c58-959a56ec8643"), nullValue());
+        given().contentType(JSON) //
+                .body(IOUtils.toString(this.getClass().getResourceAsStream(METADATA_JSON), UTF_8)) //
+                .when() //
+                .put("/datasets/{id}/raw", "3d72677c-e2c9-4a34-8c58-959a56ec8643") //
+                .then() //
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    public void update_or_create_unknown_dataset_with_name() throws Exception {
+        assertThat(dataSetMetadataRepository.get("3d72677c-e2c9-4a34-8c58-959a56ec8643"), nullValue());
+        given().contentType(JSON) //
+                .body(IOUtils.toString(this.getClass().getResourceAsStream(METADATA_JSON), UTF_8)) //
+                .when() //
+                .put("/datasets/{id}/raw?name=califormia", "3d72677c-e2c9-4a34-8c58-959a56ec8643") //
+                .then() //
+                .statusCode(HttpStatus.OK.value());
     }
 
     @Test


### PR DESCRIPTION
* Fix the updateRawDataSet when we want to create a new dataSet, but without name
* Add unit tests

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2902

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
