### PR TITLE
fix(TDP-3936): make standardize value only available in suggestion

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalid.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalid.java
@@ -13,8 +13,9 @@
 
 package org.talend.dataprep.transformation.actions.dataquality;
 
+import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
-import static org.talend.dataprep.transformation.actions.category.ActionScope.INVALID;
+import static org.talend.dataprep.transformation.actions.category.ActionScope.HIDDEN_IN_ACTION_LIST;
 
 import java.util.*;
 
@@ -25,7 +26,6 @@ import org.talend.dataprep.api.action.Action;
 import org.talend.dataprep.api.dataset.ColumnMetadata;
 import org.talend.dataprep.api.dataset.RowMetadata;
 import org.talend.dataprep.api.dataset.row.DataSetRow;
-import org.talend.dataprep.i18n.ActionsBundle;
 import org.talend.dataprep.parameters.Parameter;
 import org.talend.dataprep.parameters.SelectParameter;
 import org.talend.dataprep.transformation.actions.category.ActionCategory;
@@ -62,7 +62,7 @@ public class StandardizeInvalid extends AbstractActionMetadata implements Column
      */
     private static final String COLUMN_IS_SEMANTIC_KEY = "is_semantic_category";
 
-    private static final List<String> ACTION_SCOPE = Collections.singletonList(INVALID.getDisplayName());
+    private static final List<String> ACTION_SCOPE = singletonList(HIDDEN_IN_ACTION_LIST.getDisplayName());
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StandardizeInvalid.class);
 

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalidTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalidTest.java
@@ -12,6 +12,13 @@
 // ============================================================================
 package org.talend.dataprep.transformation.actions.dataquality;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
+import static org.talend.dataprep.transformation.actions.category.ActionScope.HIDDEN_IN_ACTION_LIST;
+
+import java.util.*;
+
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,13 +35,6 @@ import org.talend.dataprep.transformation.actions.common.ImplicitParameters;
 import org.talend.dataprep.transformation.api.action.ActionTestWorkbench;
 import org.talend.dataquality.semantic.classifier.SemanticCategoryEnum;
 
-import java.util.*;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
-import static org.talend.dataprep.transformation.actions.category.ActionScope.INVALID;
-
 /**
  * Test class for StandardizeInvalid action
  *
@@ -44,7 +44,7 @@ public class StandardizeInvalidTest extends AbstractMetadataBaseTest {
 
     private final String MATCH_THRESHOLD_PARAMETER = "match_threshold";
 
-    private final List<String> ACTION_SCOPE = Collections.singletonList(INVALID.getDisplayName());
+    private final List<String> ACTION_SCOPE = Collections.singletonList(HIDDEN_IN_ACTION_LIST.getDisplayName());
 
     private final String fixedName = "David Bowie";
 


### PR DESCRIPTION
* action is no longer displayed in "invalid menu"
* action is not present in the list for not dictionary columns

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3936

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
