### PR TITLE
fix(TDP-2663): Hook default locale set higher in startup sequence.

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/parameters/Parameterizable.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/parameters/Parameterizable.java
@@ -2,16 +2,12 @@ package org.talend.dataprep.parameters;
 
 import java.util.List;
 
-public class Parameterizable {
+public abstract class Parameterizable {
 
     /** Does this format type need more parameters? (ui will open a new form in this case). */
     private final boolean needParameters;
 
-    /** List of extra parameters needed for this format (i.e separator for csv files etc...). */
-    private final List<Parameter> parameters;
-
-    public Parameterizable(final List<Parameter> parameters, final boolean needParameters) {
-        this.parameters = parameters;
+    public Parameterizable(final boolean needParameters) {
         this.needParameters = needParameters;
     }
 
@@ -25,7 +21,6 @@ public class Parameterizable {
     /**
      * @return the list of needed parameters.
      */
-    public List<Parameter> getParameters() {
-        return parameters;
-    }
+    public abstract List<Parameter> getParameters();
+
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Localization.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Localization.java
@@ -50,7 +50,7 @@ public class Localization {
             if (registry instanceof BeanFactory) {
                 final Environment environment = ((BeanFactory) registry).getBean(Environment.class);
 
-                final String defaultLocale = environment.getProperty("dataprep.default.locale", "en-US");
+                final String defaultLocale = environment.getProperty("dataprep.locale", "en-US");
                 Locale locale = new Locale.Builder().setLanguageTag(defaultLocale).build();
                 if (LocaleUtils.isAvailableLocale(locale)) {
                     LOGGER.debug("Setting default JVM locale to configured {}", locale);

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Localization.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Localization.java
@@ -17,13 +17,16 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.Locale;
 
-import javax.annotation.PostConstruct;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotationMetadata;
 
 /**
  * This class is used to set default JVM locale at the initialization.
@@ -31,29 +34,41 @@ import org.springframework.context.annotation.Configuration;
  * EE Spring context Locale
  */
 @Configuration
+@Import(Localization.LocaleRegistrar.class)
 public class Localization {
 
-    private static final Logger LOGGER = getLogger(Localization.class);
+    /**
+     * A {@link ImportBeanDefinitionRegistrar} allows code to be executed <b>before</b> any bean creation, which is the
+     * main point of this class (in case some classes are locale-dependent in their constructors.
+     */
+    public static class LocaleRegistrar implements ImportBeanDefinitionRegistrar {
 
-    @Value("${dataprep.default.locale:en-US}")
-    private String defaultLocale;
+        private static final Logger LOGGER = getLogger(Localization.class);
 
-    @PostConstruct
-    public void localizationDefaultConfiguration() {
-        Locale locale;
-        if (StringUtils.isEmpty(defaultLocale)) {
-            LOGGER.debug("No configuration for JVM default locale. Defaulting to US english.");
-            locale = Locale.US;
-        } else {
-            locale = new Locale.Builder().setLanguageTag(defaultLocale).build();
-            if (LocaleUtils.isAvailableLocale(locale)) {
-                LOGGER.debug("Setting default JVM locale to configured {}", locale);
+        @Override
+        public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
+                                            BeanDefinitionRegistry registry) {
+            if (registry instanceof BeanFactory) {
+                final Environment environment = ((BeanFactory) registry).getBean(Environment.class);
+                Locale locale;
+                final String defaultLocale = environment.getProperty("dataprep.default.locale", "en-US");
+                if (StringUtils.isEmpty(defaultLocale)) {
+                    LOGGER.debug("No configuration for JVM default locale. Defaulting to US english.");
+                    locale = Locale.US;
+                } else {
+                    locale = new Locale.Builder().setLanguageTag(defaultLocale).build();
+                    if (LocaleUtils.isAvailableLocale(locale)) {
+                        LOGGER.debug("Setting default JVM locale to configured {}", locale);
+                    } else {
+                        LOGGER.debug("Configured JVM Locale {} is not available. Defaulting to {}", locale, Locale.US);
+                        locale = Locale.US;
+                    }
+                }
+                Locale.setDefault(locale);
+                LOGGER.info("JVM Default locale set to: '{}'", locale);
             } else {
-                LOGGER.debug("Configured JVM Locale {} is not available. Defaulting to {}", locale, Locale.US);
-                locale = Locale.US;
+                LOGGER.warn("Unable to set default locale (unexpected bean registry of type '{}')", registry.getClass().getName());
             }
         }
-        Locale.setDefault(locale);
-        LOGGER.info("JVM Default locale set to: '{}'", locale);
     }
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Localization.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Localization.java
@@ -17,7 +17,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.Locale;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.BeanFactory;
@@ -50,24 +49,20 @@ public class Localization {
                                             BeanDefinitionRegistry registry) {
             if (registry instanceof BeanFactory) {
                 final Environment environment = ((BeanFactory) registry).getBean(Environment.class);
-                Locale locale;
+
                 final String defaultLocale = environment.getProperty("dataprep.default.locale", "en-US");
-                if (StringUtils.isEmpty(defaultLocale)) {
-                    LOGGER.debug("No configuration for JVM default locale. Defaulting to US english.");
-                    locale = Locale.US;
+                Locale locale = new Locale.Builder().setLanguageTag(defaultLocale).build();
+                if (LocaleUtils.isAvailableLocale(locale)) {
+                    LOGGER.debug("Setting default JVM locale to configured {}", locale);
                 } else {
-                    locale = new Locale.Builder().setLanguageTag(defaultLocale).build();
-                    if (LocaleUtils.isAvailableLocale(locale)) {
-                        LOGGER.debug("Setting default JVM locale to configured {}", locale);
-                    } else {
-                        LOGGER.debug("Configured JVM Locale {} is not available. Defaulting to {}", locale, Locale.US);
-                        locale = Locale.US;
-                    }
+                    LOGGER.debug("Configured JVM Locale {} is not available. Defaulting to {}", locale, Locale.US);
+                    locale = Locale.US;
                 }
                 Locale.setDefault(locale);
                 LOGGER.info("JVM Default locale set to: '{}'", locale);
             } else {
-                LOGGER.warn("Unable to set default locale (unexpected bean registry of type '{}')", registry.getClass().getName());
+                LOGGER.warn("Unable to set default locale (unexpected bean registry of type '{}')",
+                        registry.getClass().getName());
             }
         }
     }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/format/export/ExportFormat.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/format/export/ExportFormat.java
@@ -15,13 +15,11 @@ package org.talend.dataprep.format.export;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toMap;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.talend.dataprep.api.dataset.DataSetMetadata;
 import org.talend.dataprep.i18n.DataprepBundle;
-import org.talend.dataprep.parameters.Parameter;
 import org.talend.dataprep.parameters.Parameterizable;
 
 /**
@@ -58,11 +56,9 @@ public abstract class ExportFormat extends Parameterizable {
      * @param extension the file extension.
      * @param needParameters if the type needs parameters.
      * @param defaultExport if it's the default format.
-     * @param parameters the list of parameters.
      */
-    public ExportFormat(final String name, final String mimeType, final String extension, final boolean needParameters,
-            final boolean defaultExport, final List<Parameter> parameters) {
-        super(parameters, needParameters);
+    public ExportFormat(final String name, final String mimeType, final String extension, final boolean needParameters, final boolean defaultExport) {
+        super(needParameters);
         this.name = name;
         this.mimeType = mimeType;
         this.extension = extension;

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/format/CSVFormat.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/format/CSVFormat.java
@@ -13,7 +13,6 @@
 package org.talend.dataprep.transformation.format;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.emptyList;
 import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 
 import java.nio.charset.Charset;
@@ -60,9 +59,7 @@ public class CSVFormat extends ExportFormat {
      * Default constructor.
      */
     public CSVFormat() {
-        //@formatter:off
-        super(ParametersCSV.CSV_NAME_FORMAT, "text/csv", ".csv", true, false, emptyList());
-        //@formatter:on
+        super(ParametersCSV.CSV_NAME_FORMAT, "text/csv", ".csv", true, false);
     }
 
     @Override

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/format/JsonFormat.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/format/JsonFormat.java
@@ -13,10 +13,12 @@
 package org.talend.dataprep.transformation.format;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.dataset.DataSetMetadata;
 import org.talend.dataprep.format.export.ExportFormat;
+import org.talend.dataprep.parameters.Parameter;
 
 /**
  * Json format type.
@@ -31,7 +33,7 @@ public class JsonFormat extends ExportFormat {
      * Default constructor.
      */
     public JsonFormat() {
-        super(JSON, "application/json", ".json", false, false, Collections.emptyList());
+        super(JSON, "application/json", ".json", false, false);
     }
 
     @Override
@@ -47,5 +49,10 @@ public class JsonFormat extends ExportFormat {
     @Override
     public boolean supportSampling() {
         return true;
+    }
+
+    @Override
+    public List<Parameter> getParameters() {
+        return Collections.emptyList();
     }
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/format/XlsFormat.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/format/XlsFormat.java
@@ -15,6 +15,7 @@ package org.talend.dataprep.transformation.format;
 import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
@@ -33,15 +34,18 @@ public class XlsFormat extends ExportFormat {
     public static final String XLSX = "XLSX";
 
     public XlsFormat() {
-        super(XLSX, "application/vnd.ms-excel", ".xlsx", true, true,
-                Collections.singletonList(
-                        Parameter.parameter(getLocale()) //
-                                .setName("fileName") //
-                                .setType(ParameterType.STRING) //
-                                .setDefaultValue(StringUtils.EMPTY) //
-                                .setCanBeBlank(false) //
-                                .build(null) //
-                ) //
+        super(XLSX, "application/vnd.ms-excel", ".xlsx", true, true);
+    }
+
+    @Override
+    public List<Parameter> getParameters() {
+        return Collections.singletonList(
+                Parameter.parameter(getLocale()) //
+                        .setName("fileName") //
+                        .setType(ParameterType.STRING) //
+                        .setDefaultValue(StringUtils.EMPTY) //
+                        .setCanBeBlank(false) //
+                        .build(null) //
         );
     }
 

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/format/XlsFormat.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/format/XlsFormat.java
@@ -32,16 +32,18 @@ public class XlsFormat extends ExportFormat {
     /** XLS format type name. */
     public static final String XLSX = "XLSX";
 
-    /**
-     * Default constructor.
-     */
-    //@formatter:off
     public XlsFormat() {
         super(XLSX, "application/vnd.ms-excel", ".xlsx", true, true,
                 Collections.singletonList(
-                        Parameter.parameter(getLocale()).setName("fileName").setType(ParameterType.STRING).setDefaultValue(StringUtils.EMPTY).setCanBeBlank(false).build(null)));
+                        Parameter.parameter(getLocale()) //
+                                .setName("fileName") //
+                                .setType(ParameterType.STRING) //
+                                .setDefaultValue(StringUtils.EMPTY) //
+                                .setCanBeBlank(false) //
+                                .build(null) //
+                ) //
+        );
     }
-    //@formatter:on
 
     @Override
     public int getOrder() {


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-2663

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)

* Hook default locale setup during bean scan so it gets set *before* bean initialization.
