### PR TITLE
chore: update versions in data-prep

### DIFF
--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -26,10 +26,10 @@
     "stats": "webpack --config config/webpack.config.dev.js --profile -j > stats.json"
   },
   "dependencies": {
-    "@talend/bootstrap-theme": "0.131.0",
-    "@talend/icons": "0.131.0",
-    "@talend/react-components": "0.131.0",
-    "@talend/react-forms": "0.131.0",
+    "@talend/bootstrap-theme": "0.132.0",
+    "@talend/icons": "0.132.0",
+    "@talend/react-components": "0.132.0",
+    "@talend/react-forms": "0.132.0",
     "X-SlickGrid": "git+https://github.com/ddomingues/X-SlickGrid#2e7784a39c2625c3800ebfeb62e4b239e2eafacf",
     "angular": "1.5.9",
     "angular-animate": "1.5.9",
@@ -57,11 +57,11 @@
     "ng-file-upload": "2.2.2",
     "ng-sortable": "1.3.6",
     "ngreact": "^0.5.0",
-    "react": "^15.6.1",
+    "react": "^15.6.2",
     "react-autowhatever": "7.0.0",
     "react-bootstrap": "0.31.0",
     "react-css-transition": "^0.7.4",
-    "react-dom": "^15.6.1",
+    "react-dom": "^15.6.2",
     "react-i18next": "^5.2.0",
     "sunchoke": "git+https://github.com/Talend/sunchoke.git#2.0.0",
     "uuid": "3.0.1"

--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -26,10 +26,10 @@
     "stats": "webpack --config config/webpack.config.dev.js --profile -j > stats.json"
   },
   "dependencies": {
-    "@talend/bootstrap-theme": "0.130.0",
-    "@talend/icons": "0.130.0",
-    "@talend/react-components": "0.130.0",
-    "@talend/react-forms": "0.130.0",
+    "@talend/bootstrap-theme": "0.131.0",
+    "@talend/icons": "0.131.0",
+    "@talend/react-components": "0.131.0",
+    "@talend/react-forms": "0.131.0",
     "X-SlickGrid": "git+https://github.com/ddomingues/X-SlickGrid#2e7784a39c2625c3800ebfeb62e4b239e2eafacf",
     "angular": "1.5.9",
     "angular-animate": "1.5.9",

--- a/dataprep-webapp/yarn.lock
+++ b/dataprep-webapp/yarn.lock
@@ -2,28 +2,28 @@
 # yarn lockfile v1
 
 
-"@talend/bootstrap-theme@0.131.0":
-  version "0.131.0"
-  resolved "https://registry.yarnpkg.com/@talend/bootstrap-theme/-/bootstrap-theme-0.131.0.tgz#bdd44781c2823bd3214911ebbf29905310ad6aaf"
+"@talend/bootstrap-theme@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@talend/bootstrap-theme/-/bootstrap-theme-0.132.0.tgz#a0e83e84e049980d393138fad150b37f076f0c3a"
   dependencies:
     bootstrap-sass "3.3.7"
 
-"@talend/icons@0.131.0":
-  version "0.131.0"
-  resolved "https://registry.yarnpkg.com/@talend/icons/-/icons-0.131.0.tgz#b52d7690aea308ac12fe73f40ed8af7616dfe419"
+"@talend/icons@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@talend/icons/-/icons-0.132.0.tgz#506577410c46f6b2d312b53cf34de6af7bf61b1e"
 
-"@talend/react-components@0.131.0":
-  version "0.131.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-components/-/react-components-0.131.0.tgz#59d812fbcf6788342941d0c00fea3062960175e7"
+"@talend/react-components@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-components/-/react-components-0.132.0.tgz#0ec1cce1de626dbfb32b2b59c1c23b995449fee8"
   dependencies:
     lodash "4.17.4"
     react-autowhatever "7.0.0"
     react-debounce-input "2.4.2"
     react-virtualized "9.10.1"
 
-"@talend/react-forms@0.131.0":
-  version "0.131.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-forms/-/react-forms-0.131.0.tgz#7ae411a3372fa8a9d31dee03dc46754b29145da0"
+"@talend/react-forms@0.132.0":
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-forms/-/react-forms-0.132.0.tgz#2c68df3d9e26c580654ba08ac0cbbcae6314f04b"
   dependencies:
     classnames "2.2.5"
     keycode "2.1.9"
@@ -6128,7 +6128,7 @@ react-debounce-input@2.4.2:
   dependencies:
     lodash.debounce "^3 || ^4"
 
-react-dom@^15.6.1:
+react-dom@^15.6.1, react-dom@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
@@ -6196,7 +6196,7 @@ react-virtualized@9.10.1:
     loose-envify "^1.3.0"
     prop-types "^15.5.4"
 
-react@^15.6.1:
+react@^15.6.1, react@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:

--- a/dataprep-webapp/yarn.lock
+++ b/dataprep-webapp/yarn.lock
@@ -2,28 +2,28 @@
 # yarn lockfile v1
 
 
-"@talend/bootstrap-theme@0.130.0":
-  version "0.130.0"
-  resolved "https://registry.yarnpkg.com/@talend/bootstrap-theme/-/bootstrap-theme-0.130.0.tgz#a7221b0347f5380fdaa8efd7d806ba163e1d3f26"
+"@talend/bootstrap-theme@0.131.0":
+  version "0.131.0"
+  resolved "https://registry.yarnpkg.com/@talend/bootstrap-theme/-/bootstrap-theme-0.131.0.tgz#bdd44781c2823bd3214911ebbf29905310ad6aaf"
   dependencies:
     bootstrap-sass "3.3.7"
 
-"@talend/icons@0.130.0":
-  version "0.130.0"
-  resolved "https://registry.yarnpkg.com/@talend/icons/-/icons-0.130.0.tgz#548e5f86064c3b93e32e44ed161eac37ffe79a49"
+"@talend/icons@0.131.0":
+  version "0.131.0"
+  resolved "https://registry.yarnpkg.com/@talend/icons/-/icons-0.131.0.tgz#b52d7690aea308ac12fe73f40ed8af7616dfe419"
 
-"@talend/react-components@0.130.0":
-  version "0.130.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-components/-/react-components-0.130.0.tgz#e425191579de3bd12eedd6d319b382b46f44340c"
+"@talend/react-components@0.131.0":
+  version "0.131.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-components/-/react-components-0.131.0.tgz#59d812fbcf6788342941d0c00fea3062960175e7"
   dependencies:
     lodash "4.17.4"
     react-autowhatever "7.0.0"
     react-debounce-input "2.4.2"
     react-virtualized "9.10.1"
 
-"@talend/react-forms@0.130.0":
-  version "0.130.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-forms/-/react-forms-0.130.0.tgz#5f19d2f4dc8fbbcfd120df4d8415c22412bdf104"
+"@talend/react-forms@0.131.0":
+  version "0.131.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-forms/-/react-forms-0.131.0.tgz#7ae411a3372fa8a9d31dee03dc46754b29145da0"
   dependencies:
     classnames "2.2.5"
     keycode "2.1.9"


### PR DESCRIPTION
***What is the problem this PR is trying to solve?**<br><br>Framework/libs/tools are out of date, compared to Talend/ui [version.js](https://github.com/Talend/ui/blob/master/version.js).<br><br>This is an automatic PR, which goal is to align all Framework/libs/tools versions accross all apps.<br><br>**What is the chosen solution to this problem?**<br><br>Run version.js on the webapp.<br><br>Please check Talend/ui [breaking changes log](https://github.com/Talend/ui/blob/master/BREAKING_CHANGES_LOG.md)<br><br>**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR