### PR TITLE
feat(TDP-3936): remove StandardizeInvalid scope

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/AbstractActionMetadata.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/AbstractActionMetadata.java
@@ -12,7 +12,8 @@
 
 package org.talend.dataprep.transformation.actions.common;
 
-import java.util.ArrayList;
+import static java.util.Collections.emptyList;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -122,7 +123,7 @@ public abstract class AbstractActionMetadata implements InternalActionDefinition
      */
     @Override
     public List<String> getActionScope() {
-        return new ArrayList<>();
+        return emptyList();
     }
 
     /**

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalid.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalid.java
@@ -16,7 +16,6 @@ package org.talend.dataprep.transformation.actions.dataquality;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static org.talend.dataprep.parameters.SelectParameter.selectParameter;
-import static org.talend.dataprep.transformation.actions.category.ActionScope.HIDDEN_IN_ACTION_LIST;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.CANCELED;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.OK;
 
@@ -64,8 +63,6 @@ public class StandardizeInvalid extends AbstractActionMetadata implements Column
      * The selected column if it uses semantic category
      */
     private static final String COLUMN_IS_SEMANTIC_KEY = "is_semantic_category";
-
-    private static final List<String> ACTION_SCOPE = singletonList(HIDDEN_IN_ACTION_LIST.getDisplayName());
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StandardizeInvalid.class);
 

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalid.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalid.java
@@ -134,11 +134,6 @@ public class StandardizeInvalid extends AbstractActionMetadata implements Column
     }
 
     @Override
-    public List<String> getActionScope() {
-        return ACTION_SCOPE;
-    }
-
-    @Override
     public boolean acceptField(ColumnMetadata column) {
         return isDictionaryType(column);
     }

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalid.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalid.java
@@ -16,6 +16,7 @@ package org.talend.dataprep.transformation.actions.dataquality;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static org.talend.dataprep.parameters.SelectParameter.selectParameter;
+import static org.talend.dataprep.transformation.actions.category.ActionScope.INVALID;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.CANCELED;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.OK;
 
@@ -71,6 +72,11 @@ public class StandardizeInvalid extends AbstractActionMetadata implements Column
     @Override
     public String getName() {
         return ACTION_NAME;
+    }
+
+    @Override
+    public List<String> getActionScope() {
+        return Collections.singletonList(INVALID.getDisplayName());
     }
 
     @Override

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/delete/AbstractFilteringAction.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/delete/AbstractFilteringAction.java
@@ -12,10 +12,14 @@
 
 package org.talend.dataprep.transformation.actions.delete;
 
+import static java.util.Collections.singletonList;
 import static org.talend.dataprep.transformation.actions.category.ActionCategory.FILTERED;
 import static org.talend.dataprep.transformation.actions.category.ActionScope.COLUMN_FILTERED;
 
-import java.util.*;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import org.talend.dataprep.api.dataset.ColumnMetadata;
 import org.talend.dataprep.transformation.actions.common.AbstractActionMetadata;
@@ -45,6 +49,6 @@ public abstract class AbstractFilteringAction extends AbstractActionMetadata imp
 
     @Override
     public List<String> getActionScope() {
-        return Collections.singletonList(COLUMN_FILTERED.getDisplayName());
+        return singletonList(COLUMN_FILTERED.getDisplayName());
     }
 }

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalidTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalidTest.java
@@ -12,9 +12,11 @@
 // ============================================================================
 package org.talend.dataprep.transformation.actions.dataquality;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
+import static org.talend.dataprep.transformation.actions.category.ActionScope.INVALID;
 
 import java.util.*;
 
@@ -42,7 +44,7 @@ import org.talend.dataquality.semantic.classifier.SemanticCategoryEnum;
 public class StandardizeInvalidTest extends AbstractMetadataBaseTest<StandardizeInvalid> {
 
     private final String MATCH_THRESHOLD_PARAMETER = "match_threshold";
-
+    
     private final String fixedName = "David Bowie";
 
     private final String columnId0 = "0000";
@@ -188,8 +190,8 @@ public class StandardizeInvalidTest extends AbstractMetadataBaseTest<Standardize
     }
 
     @Test
-    public void should_action_Scope() {
-        assertTrue(action.getActionScope().isEmpty());
+    public void testActionScope() throws Exception {
+        assertThat(action.getActionScope(), hasItem("invalid"));
     }
 
     private DataSetRow createRow(Map<String, String> inputValues, String invalidColumnId, String domain) {

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalidTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalidTest.java
@@ -197,8 +197,7 @@ public class StandardizeInvalidTest extends AbstractMetadataBaseTest<Standardize
 
     @Test
     public void should_action_Scope() {
-        assertTrue(action.getActionScope().size() == 1);
-        assertTrue(action.getActionScope().equals(ACTION_SCOPE));
+        assertTrue(action.getActionScope().isEmpty());
     }
 
     private DataSetRow createRow(Map<String, String> inputValues, String invalidColumnId, String domain) {

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalidTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/dataquality/StandardizeInvalidTest.java
@@ -15,7 +15,6 @@ package org.talend.dataprep.transformation.actions.dataquality;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
-import static org.talend.dataprep.transformation.actions.category.ActionScope.HIDDEN_IN_ACTION_LIST;
 
 import java.util.*;
 
@@ -43,8 +42,6 @@ import org.talend.dataquality.semantic.classifier.SemanticCategoryEnum;
 public class StandardizeInvalidTest extends AbstractMetadataBaseTest<StandardizeInvalid> {
 
     private final String MATCH_THRESHOLD_PARAMETER = "match_threshold";
-
-    private final List<String> ACTION_SCOPE = Collections.singletonList(HIDDEN_IN_ACTION_LIST.getDisplayName());
 
     private final String fixedName = "David Bowie";
 
@@ -125,14 +122,13 @@ public class StandardizeInvalidTest extends AbstractMetadataBaseTest<Standardize
 
         final DataSetRow row = createRow(values, columnId1, "");
 
-        final Map<String, String> expectedValues = values;
-        expectedValues.put("__tdpInvalid", columnId1);
+        values.put("__tdpInvalid", columnId1);
 
         // when
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
-        assertEquals(expectedValues, row.values());
+        assertEquals(values, row.values());
     }
 
     @Test
@@ -145,13 +141,11 @@ public class StandardizeInvalidTest extends AbstractMetadataBaseTest<Standardize
         // set semantic domain
         final DataSetRow row = createRow(values, null, "COUNTRY");
 
-        final Map<String, String> expectedValues = values;
-
         // when
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
-        assertEquals(expectedValues, row.values());
+        assertEquals(values, row.values());
 
     }
 
@@ -165,14 +159,13 @@ public class StandardizeInvalidTest extends AbstractMetadataBaseTest<Standardize
 
         final DataSetRow row = createRow(values, columnId1, "FR_COMMUNE");
 
-        final Map<String, String> expectedValues = values;
-        expectedValues.put("__tdpInvalid", columnId1);
+        values.put("__tdpInvalid", columnId1);
 
         // when
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
-        assertEquals(expectedValues, row.values());
+        assertEquals(values, row.values());
     }
 
     @Test
@@ -185,14 +178,13 @@ public class StandardizeInvalidTest extends AbstractMetadataBaseTest<Standardize
         // set semantic domain
         final DataSetRow row = createRow(values, columnId1, "COUNTRY");
 
-        final Map<String, String> expectedValues = values;
-        expectedValues.put("__tdpInvalid", columnId1);
+        values.put("__tdpInvalid", columnId1);
 
         // when
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
-        assertEquals(expectedValues, row.values());
+        assertEquals(values, row.values());
     }
 
     @Test


### PR DESCRIPTION
removing all scope from StandardizeInvalid make it available in action
list to be used even if the column is not detected as dict based on the
sample and still in suggestions for sample dict-detected columns

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-3936

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted
