### PR TITLE
chore: handle remote error from non dataprep services

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
+import org.talend.daikon.exception.ExceptionContext;
 import org.talend.daikon.exception.error.ErrorCode;
 import org.talend.daikon.exception.json.JsonErrorCode;
 import org.talend.dataprep.api.preparation.Action;
@@ -417,7 +418,13 @@ public class GenericCommand<T> extends HystrixCommand<T> {
                     LOGGER.trace("Error received {}", content);
                 }
                 TdpExceptionDto exceptionDto = objectMapper.readValue(content, TdpExceptionDto.class);
-                TDPException cause = conversionService.convert(exceptionDto, TDPException.class);
+                TDPException cause;
+                try {
+                    cause = conversionService.convert(exceptionDto, TDPException.class);
+                } catch (RuntimeException e) {
+                    cause = new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, null, content,
+                            "Remote service returned an unhandled error and response could not be deserialized.", ExceptionContext.build());
+                }
                 ErrorCode code = cause.getCode();
                 if (code instanceof ErrorCodeDto) {
                     ((ErrorCodeDto) code).setHttpStatus(statusCode);


### PR DESCRIPTION
when there is no handling defined for a remote service error, dataprep
tries to deserialize it as TDPException. When it cannot we have a strange
stacktrace that mask the real error message.
This read the error content as-is to create the error message
