### PR TITLE
chore: switch to an up-to-date browser

### DIFF
--- a/dataprep-webapp/karma.conf.js
+++ b/dataprep-webapp/karma.conf.js
@@ -52,7 +52,18 @@ module.exports = function (config) {
 
 		// start these browsers
 		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-		browsers: ['ChromeHeadless'],
+		browsers: ['ChromeHeadless_without_sandbox'],
+
+		// you can define custom flags
+        customLaunchers: {
+          ChromeHeadless_without_sandbox: {
+            base: 'ChromeHeadless',
+            flags: [
+              '--no-sandbox',
+              '--disable-setuid-sandbox'
+            ],
+          },
+        },
 
 		coverageReporter: {
 			type: 'html',

--- a/dataprep-webapp/karma.conf.js
+++ b/dataprep-webapp/karma.conf.js
@@ -1,5 +1,7 @@
 'use strict';
 
+process.env.CHROME_BIN = require('puppeteer').executablePath()
+
 const argv = require('yargs').argv;
 const webpack = require('webpack');
 const SASS_DATA = require('./config/sass.conf');
@@ -63,7 +65,7 @@ module.exports = function (config) {
 		proxies: {
 			'/assets/': '/src/assets/',
 		},
-		
+
 		browserNoActivityTimeout: 120000,
 	});
 };

--- a/dataprep-webapp/karma.conf.js
+++ b/dataprep-webapp/karma.conf.js
@@ -50,7 +50,7 @@ module.exports = function (config) {
 
 		// start these browsers
 		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-		browsers: ['PhantomJS'],
+		browsers: ['ChromeHeadless'],
 
 		coverageReporter: {
 			type: 'html',

--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -101,6 +101,7 @@
     "jasmine": "2.5.2",
     "jasmine-core": "2.5.2",
     "karma": "^1.4.1",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.1.0",
     "karma-junit-reporter": "^1.2.0",

--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -115,6 +115,7 @@
     "null-loader": "^0.1.1",
     "phantomjs-prebuilt": "^2.1.7",
     "postcss-loader": "2.0.8",
+    "puppeteer": "^0.13.0",
     "react-ace": "5.2.0",
     "react-addons-css-transition-group": "15.5.2",
     "resolve-url-loader": "^1.6.1",

--- a/dataprep-webapp/src/app/components/dataset/parameters/dataset-parameters-directive.spec.js
+++ b/dataprep-webapp/src/app/components/dataset/parameters/dataset-parameters-directive.spec.js
@@ -12,8 +12,6 @@
   ============================================================================*/
 
 describe('Dataset parameters directive', () => {
-	'use strict';
-
 	let scope;
 	let createElement;
 	let element;
@@ -28,7 +26,7 @@ describe('Dataset parameters directive', () => {
 		OTHER: 'Other',
 	};
 
-	beforeEach(angular.mock.module('pascalprecht.translate', $translateProvider => {
+	beforeEach(angular.mock.module('pascalprecht.translate', ($translateProvider) => {
 		$translateProvider.translations('en', translations);
 		$translateProvider.preferredLanguage('en');
 	}));
@@ -72,15 +70,15 @@ describe('Dataset parameters directive', () => {
 
 	describe('render', () => {
 		it('should render title', () => {
-			//when
+			// when
 			createElement();
 
-			//then
+			// then
 			expect(element.find('.dataset-parameters-title').eq(0).text()).toBe(translations.DATASET_PARAMETERS);
 		});
 
 		it('should render dataset name', () => {
-			//given
+			// given
 			scope.dataset = {
 				id: '12ce6c32-bf80-41c8-92e5-66d70f22ec1f',
 				name: 'US States',
@@ -88,16 +86,16 @@ describe('Dataset parameters directive', () => {
 			};
 			scope.displayNbLines = true;
 
-			//when
+			// when
 			createElement();
 
-			//then
+			// then
 			expect(element.find('.dataset-name-group').eq(0).text().trim().replace(/[\s]+/g, ' '))
 				.toBe(`${translations.NAME} ${scope.dataset.name}`);
 		});
 
 		it('should render nb lines', () => {
-			//given
+			// given
 			scope.dataset = {
 				id: '12ce6c32-bf80-41c8-92e5-66d70f22ec1f',
 				name: 'US States',
@@ -105,16 +103,16 @@ describe('Dataset parameters directive', () => {
 			};
 			scope.displayNbLines = true;
 
-			//when
+			// when
 			createElement();
 
-			//then
+			// then
 			expect(element.find('.line-number-group').eq(0).text().trim().replace(/[\s]+/g, ' '))
 				.toBe(`${translations.SIZE} ${translations.FILE_DETAILS_LINES.replace('{{records}}', scope.dataset.records)}`);
 		});
 
 		it('should render cut lines number when dataset is truncated', () => {
-			//given
+			// given
 			scope.dataset = {
 				id: '12ce6c32-bf80-41c8-92e5-66d70f22ec1f',
 				name: 'US States',
@@ -123,16 +121,16 @@ describe('Dataset parameters directive', () => {
 			};
 			scope.displayNbLines = true;
 
-			//when
+			// when
 			createElement();
 
-			//then
+			// then
 			expect(element.find('.line-number-group').eq(0).text().trim().replace(/[\s]+/g, ' '))
 				.toBe(`${translations.SIZE} ${translations.FILE_DETAILS_LIMIT.replace('{{records}}', scope.dataset.limit)}`);
 		});
 
 		it('should not render dataset nb lines', () => {
-			//given
+			// given
 			scope.dataset = {
 				id: '12ce6c32-bf80-41c8-92e5-66d70f22ec1f',
 				name: 'US States',
@@ -141,18 +139,18 @@ describe('Dataset parameters directive', () => {
 			};
 			scope.displayNbLines = false;
 
-			//when
+			// when
 			createElement();
 
-			//then
+			// then
 			expect(element.find('#line-number').length).toBe(0);
 		});
 
 		it('should render encodings', () => {
-			//when
+			// when
 			createElement();
 
-			//then
+			// then
 			const encodingContainer = element.find('.encodings-group').eq(0);
 			expect(encodingContainer.find('label').eq(0).text().trim()).toBe(translations.DATASET_PARAMETERS_ENCODING);
 
@@ -168,36 +166,36 @@ describe('Dataset parameters directive', () => {
 
 		describe('separator', () => {
 			it('should NOT render separators on NON csv', () => {
-				//given
+				// given
 				scope.dataset = { type: 'other' };
 
-				//when
+				// when
 				createElement();
 
-				//then
+				// then
 				expect(element.find('.separator-group').length).toBe(0);
 			});
 
 			it('should NOT render text enclosure and escape character on NON csv', () => {
-				//given
+				// given
 				scope.dataset = { type: 'other' };
 
-				//when
+				// when
 				createElement();
 
-				//then
+				// then
 				expect(element.find('.text-enclosure-group').length).toBe(0);
 				expect(element.find('.escape-character-group').length).toBe(0);
 			});
 
 			it('should render separators on csv dataset', () => {
-				//given
+				// given
 				scope.dataset = { type: 'text/csv' };
 
-				//when
+				// when
 				createElement();
 
-				//then
+				// then
 				const separatorContainer = element.find('.separator-group').eq(0);
 				expect(separatorContainer.find('label').eq(0).text().trim()).toBe(translations.DATASET_PARAMETERS_SEPARATOR);
 
@@ -216,40 +214,40 @@ describe('Dataset parameters directive', () => {
 			});
 
 			it('should render custom separator input only when separator is not in the configuration list', () => {
-				//given
+				// given
 				scope.dataset = { type: 'text/csv' };
 				createElement();
 
 				const separatorContainer = element.find('.separator-group').eq(0);
 				expect(separatorContainer.find('select').length).toBe(1);
 
-				//when
+				// when
 				scope.parameters.separator = '|';
 				scope.$digest();
 
-				//then
+				// then
 				expect(separatorContainer.find('input').length).toBe(1);
 			});
 
 			it('should render separators on csv dataset', () => {
-				//given
+				// given
 				scope.dataset = { type: 'text/csv' };
 
-				//when
+				// when
 				createElement();
 
-				//then
+				// then
 				expect(element.find('.separator-group').length).toBe(1);
 			});
 
 			it('should render text enclosure and escape character on csv dataset', () => {
-				//given
+				// given
 				scope.dataset = { type: 'text/csv' };
 
-				//when
+				// when
 				createElement();
 
-				//then
+				// then
 				expect(element.find('.text-enclosure-group').length).toBe(1);
 				expect(element.find('.escape-character-group').length).toBe(1);
 			});
@@ -257,47 +255,26 @@ describe('Dataset parameters directive', () => {
 
 		describe('button', () => {
 			it('should enable button when processing is falsy', () => {
-				//given
+				// given
 				scope.processing = false;
 
-				//when
+				// when
 				createElement();
 
-				//then
+				// then
 				expect(element.find('button').attr('disabled')).toBeFalsy();
 			});
 
 			it('should disable button when processing is truthy', () => {
-				//given
+				// given
 				scope.processing = true;
 
-				//when
+				// when
 				createElement();
 
-				//then
+				// then
 				expect(element.find('button').attr('disabled')).toBeTruthy();
 			});
-		});
-	});
-
-	describe('validation', () => {
-		it('should call validation callback on form submit', () => {
-			//given
-			scope.dataset = { id: '54a146cf854b54', type: 'text/csv' };
-			scope.parameters.separator = '|';
-			scope.parameters.encoding = 'UTF-16';
-			createElement();
-
-			expect(scope.validate).not.toHaveBeenCalled();
-
-			//when
-			element.find('button').click();
-
-			//then
-			expect(scope.validate).toHaveBeenCalledWith(
-				{ id: '54a146cf854b54', type: 'text/csv' },
-				{ separator: '|', encoding: 'UTF-16' }
-			);
 		});
 	});
 });

--- a/dataprep-webapp/yarn.lock
+++ b/dataprep-webapp/yarn.lock
@@ -3290,6 +3290,12 @@ front-matter@2.1.0:
   dependencies:
     js-yaml "^3.4.6"
 
+fs-access@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
+  dependencies:
+    null-check "^1.0.0"
+
 fs-extra@^1.0.0, fs-extra@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
@@ -4106,6 +4112,10 @@ isexe@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz#36f3e22e60750920f5e7241a476a8c6a42275ad0"
 
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -4326,6 +4336,13 @@ jsx-ast-utils@^1.0.0:
 jsx-ast-utils@^1.3.4:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
+
+karma-chrome-launcher@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
+  dependencies:
+    fs-access "^1.0.0"
+    which "^1.2.1"
 
 karma-coverage@^1.1.1:
   version "1.1.1"
@@ -5228,6 +5245,10 @@ nth-check@~1.0.1:
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
   dependencies:
     boolbase "~1.0.0"
+
+null-check@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/null-check/-/null-check-1.0.0.tgz#977dffd7176012b9ec30d2a39db5cf72a0439edd"
 
 null-loader@^0.1.1:
   version "0.1.1"
@@ -7819,6 +7840,12 @@ which@1, which@^1.0.9, which@^1.1.1, which@^1.2.9, which@~1.2.10:
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:
     isexe "^1.1.1"
+
+which@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.0"

--- a/dataprep-webapp/yarn.lock
+++ b/dataprep-webapp/yarn.lock
@@ -95,6 +95,12 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
+agent-base@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.1.2.tgz#80fa6cde440f4dcf9af2617cf246099b5d99f0c8"
+  dependencies:
+    es6-promisify "^5.0.0"
+
 ajv-keywords@^1.0.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.0.tgz#c11e6859eafff83e0dafc416929472eca946aa2c"
@@ -363,6 +369,10 @@ async-each@^1.0.0:
 async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
+
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
 async@1.x, async@^1.4.0, async@^1.5.2:
   version "1.5.2"
@@ -1869,7 +1879,7 @@ concat-stream@1.5.0:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@^1.5.2:
+concat-stream@1.6.0, concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -2247,17 +2257,17 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
+debug@2.6.9, debug@^2.6.6, debug@^2.6.8:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
-
-debug@^2.6.6, debug@^2.6.8:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  dependencies:
-    ms "2.0.0"
 
 debug@^3.1.0:
   version "3.1.0"
@@ -2627,9 +2637,19 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
+es6-promise@^4.0.3:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.2.tgz#f722d7769af88bd33bc13ec6605e1f92966b82d9"
+
 es6-promise@~4.0.3:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.0.5.tgz#7882f30adde5b240ccfa7f7d78c548330951ae42"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
 
 es6-set@^0.1.4, es6-set@~0.1.3:
   version "0.1.4"
@@ -3034,6 +3054,15 @@ extract-text-webpack-plugin@3.0.2:
     loader-utils "^1.1.0"
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
+
+extract-zip@^1.6.5:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
+  dependencies:
+    concat-stream "1.6.0"
+    debug "2.6.9"
+    mkdirp "0.5.0"
+    yauzl "2.4.1"
 
 extract-zip@~1.5.0:
   version "1.5.0"
@@ -3746,6 +3775,13 @@ http-signature@~1.1.0:
 https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
+
+https-proxy-agent@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
 
 i18next@^9.0.0:
   version "9.1.0"
@@ -5972,6 +6008,10 @@ progress@^1.1.8, progress@~1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -6016,6 +6056,10 @@ proxy-addr@~1.1.2:
     forwarded "~0.1.0"
     ipaddr.js "1.1.1"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -6056,6 +6100,19 @@ punycode@1.3.2:
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+puppeteer@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-0.13.0.tgz#2e6956205f2c640964c2107f620ae1eef8bde8fd"
+  dependencies:
+    debug "^2.6.8"
+    extract-zip "^1.6.5"
+    https-proxy-agent "^2.1.0"
+    mime "^1.3.4"
+    progress "^2.0.0"
+    proxy-from-env "^1.0.0"
+    rimraf "^2.6.1"
+    ws "^3.0.0"
 
 q@^1.1.2:
   version "1.4.1"
@@ -7543,6 +7600,10 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+
 uncontrollable@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
@@ -7913,6 +7974,14 @@ ws@1.1.1:
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+ws@^3.0.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
 
 wtf-8@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Use `ChromeHeadless` instead of `PhantomJS`

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
