### PR TITLE
fix(cookie): Cookies are returned by REST Services

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
@@ -224,6 +224,12 @@ public class GenericCommand<T> extends HystrixCommand<T> {
 
         status = HttpStatus.valueOf(response.getStatusLine().getStatusCode());
 
+        Header cookies = response.getFirstHeader("Set-Cookie");
+        if (cookies != null) {
+            LOGGER.warn("request {} {}: Cookie detected in responseHeaders (check security.oauth2.resource.uri settings)",
+                    request.getMethod(), request.getURI());
+        }
+
         // do we have a behavior for this status code (even an error) ?
         // if yes use it
         BiFunction<HttpRequestBase, HttpResponse, T> function = behavior.get(status);

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/HttpClient.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/HttpClient.java
@@ -20,6 +20,7 @@ import org.apache.http.HeaderElementIterator;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolException;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.ConnectionKeepAliveStrategy;
@@ -52,6 +53,7 @@ import org.springframework.stereotype.Component;
 public class HttpClient {
 
     /** This class' logger. */
+
     private static final Logger LOGGER = LoggerFactory.getLogger(HttpClient.class);
 
     /** Maximum connection pool size. */
@@ -119,6 +121,7 @@ public class HttpClient {
         return RequestConfig.custom() //
                 .setContentCompressionEnabled(true)
                 .setConnectionRequestTimeout(connectionRequestTimeout)
+                .setCookieSpec(CookieSpecs.IGNORE_COOKIES)
                 .build();
     }
 


### PR DESCRIPTION
Cookies are returned by some REST Services.

Problem comes that :
 - some REST Services are not registered in
security.oauth2.resource.uri.
   The filterChain from OIDC Gateway handles the REST Service
   request and returns a cookie.
 - the httpClient used by /api keeps any cookies returned
   by the called REST Service and returns them on the next call.

The fix:
 - adds some REST Services in security.oauth2.resource.uri
 - instructs httpClient not to use cookies.
 - logs on WARN level any call made by GenericCommand
   when there's a SetCookie response header.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-XXXX

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
