### PR TITLE
fix(TDP-4988): InvalidPathException in PreparationServiceTest

### DIFF
--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/service/PreparationServiceTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/service/PreparationServiceTest.java
@@ -80,13 +80,13 @@ public class PreparationServiceTest extends BasePreparationTest {
         // then : : should list preparation with special character in preparation (see
         // https://jira.talendforge.org/browse/TDP-4779)
         assertThat(preparationService
-                .listAll(null, null, "foo/Cr((eate E?mail A!dd\"ressrrrbb[zzzz (copie*-é'(-è_çà)+&.csv", null, null)
+                .listAll(null, null, "foo/Cr((eate Email A!ddressrrrbb[zzzz (copie-é'(-è_çà)+&.csv", null, null)
                 .collect(Collectors.toList()).size(), is(1));
 
         // then : : should list preparation with special character in folder and preparation (see
         // https://jira.talendforge.org/browse/TDP-4779)
         assertThat(preparationService.listAll(null, null,
-                "Folder Cr((eate E?mail A!dd\"ressrrrbb[zzzz (copie*-é'(-è_çà)+&.csv/Cr((eate E?mail A!dd\"ressrrrbb[zzzz (copie*-é'(-è_çà)+&.csv",
+                "Folder Cr((eate Email A!ddressrrrbb[zzzz (copie-é'(-è_çà)+&.csv/Cr((eate Email A!ddressrrrbb[zzzz (copie-é'(-è_çà)+&.csv",
                 null, null).collect(Collectors.toList()).size(), is(1));
     }
 
@@ -94,8 +94,8 @@ public class PreparationServiceTest extends BasePreparationTest {
         createFolder(home.getId(), "foo");
         final Folder foo = getFolder(home.getId(), "foo");
 
-        createFolder(home.getId(), "Folder Cr((eate E?mail A!dd\"ressrrrbb[zzzz (copie*-é'(-è_çà)+&.csv");
-        final Folder specialChar = getFolder(home.getId(), "Folder Cr((eate E?mail A!dd\"ressrrrbb[zzzz (copie*-é'(-è_çà)+&.csv");
+        createFolder(home.getId(), "Folder Cr((eate Email A!ddressrrrbb[zzzz (copie-é'(-è_çà)+&.csv");
+        final Folder specialChar = getFolder(home.getId(), "Folder Cr((eate Email A!ddressrrrbb[zzzz (copie-é'(-è_çà)+&.csv");
 
         Preparation preparation = new Preparation();
         preparation.setName("prep_name_foo");
@@ -106,10 +106,10 @@ public class PreparationServiceTest extends BasePreparationTest {
         preparation.setName("prep_name_home");
         clientTest.createPreparation(preparation, home.getId());
 
-        preparation.setName("Cr((eate E?mail A!dd\"ressrrrbb[zzzz (copie*-é'(-è_çà)+&.csv");
+        preparation.setName("Cr((eate Email A!ddressrrrbb[zzzz (copie-é'(-è_çà)+&.csv");
         clientTest.createPreparation(preparation, foo.getId());
 
-        preparation.setName("Cr((eate E?mail A!dd\"ressrrrbb[zzzz (copie*-é'(-è_çà)+&.csv");
+        preparation.setName("Cr((eate Email A!ddressrrrbb[zzzz (copie-é'(-è_çà)+&.csv");
         clientTest.createPreparation(preparation, specialChar.getId());
     }
 }


### PR DESCRIPTION
remove usage of ? " and * characters in paths because saw as invalid when launched on windows

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4988

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
