### PR TITLE
fix(TDP-4471): filter autocompletion is missing for last deleted filter

### DIFF
--- a/dataprep-webapp/package.json
+++ b/dataprep-webapp/package.json
@@ -33,7 +33,7 @@
     "X-SlickGrid": "git+https://github.com/ddomingues/X-SlickGrid#2e7784a39c2625c3800ebfeb62e4b239e2eafacf",
     "angular": "1.5.9",
     "angular-animate": "1.5.9",
-    "angular-mass-autocomplete": "^0.6.0",
+    "angular-mass-autocomplete": "^0.8.0",
     "angular-sanitize": "1.5.9",
     "angular-translate": "^2.10.0",
     "angular-translate-loader-static-files": "^2.10.0",

--- a/dataprep-webapp/src/app/services/dataset/rest/dataset-rest-service.js
+++ b/dataprep-webapp/src/app/services/dataset/rest/dataset-rest-service.js
@@ -133,7 +133,7 @@ export default function DatasetRestService($rootScope, $upload, $http, RestURLs)
      * @returns {Promise} The GET call promise
      */
 	function getDatasets(sortType, sortOrder, deferredAbort) {
-		let url = `${RestURLs.datasetUrl}/summary`
+		let url = `${RestURLs.datasetUrl}/summary`;
 		if (sortType) {
 			url += `?sort=${sortType}`;
 		}

--- a/dataprep-webapp/yarn.lock
+++ b/dataprep-webapp/yarn.lock
@@ -145,9 +145,9 @@ angular-animate@1.5.9, angular-animate@^1.5.3:
   version "1.5.9"
   resolved "https://registry.yarnpkg.com/angular-animate/-/angular-animate-1.5.9.tgz#c958d524f9333a48abdaefb32947c7e611f54453"
 
-angular-mass-autocomplete@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/angular-mass-autocomplete/-/angular-mass-autocomplete-0.6.0.tgz#90e7a22a21f2f697b9ed7f2a1cc8cdf629984594"
+angular-mass-autocomplete@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/angular-mass-autocomplete/-/angular-mass-autocomplete-0.8.0.tgz#6acb7bd3acb205b2078c0306e52043acbcd30351"
 
 angular-mocks@1.5.9:
   version "1.5.9"


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4471

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
