### PR TITLE
fix(TDP-5057): wrong preview of "calculate time until" step after trim step

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreviewAbstract.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/preparation/PreviewAbstract.java
@@ -13,8 +13,6 @@
 
 package org.talend.dataprep.api.service.command.preparation;
 
-import static org.talend.dataprep.command.Defaults.pipeStream;
-
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
@@ -34,6 +32,8 @@ import org.talend.dataprep.exception.error.TransformationErrorCodes;
 import org.talend.dataprep.transformation.preview.api.PreviewParameters;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+
+import static org.talend.dataprep.command.Defaults.pipeStream;
 
 /**
  * Base class for preview commands.
@@ -75,7 +75,7 @@ public abstract class PreviewAbstract extends GenericCommand<InputStream> {
 
         final String paramsAsJson;
         try {
-            paramsAsJson = objectMapper.writer().writeValueAsString(parameters);
+            paramsAsJson = objectMapper.writeValueAsString(parameters);
         } catch (JsonProcessingException e) {
             throw new TDPException(TransformationErrorCodes.UNABLE_TO_PERFORM_PREVIEW, e);
         }

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -1016,7 +1016,7 @@ public class PreparationAPITest extends ApiServiceTestBase {
 
         // create a preview of calculate time until action
         PreviewAddParameters previewAddParameters = new PreviewAddParameters();
-        previewAddParameters.setDatasetId(datasetId);
+//        previewAddParameters.setDatasetId(datasetId);
         previewAddParameters.setPreparationId(preparationId);
         previewAddParameters.setTdpIds(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
 

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -12,13 +12,71 @@
 
 package org.talend.dataprep.api.service;
 
-import static com.jayway.restassured.RestAssured.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.talend.dataprep.StandalonePreparation;
+import org.talend.dataprep.api.dataset.ColumnMetadata;
+import org.talend.dataprep.api.dataset.DataSetMetadata;
+import org.talend.dataprep.api.dataset.RowMetadata;
+import org.talend.dataprep.api.dataset.statistics.PatternFrequency;
+import org.talend.dataprep.api.folder.Folder;
+import org.talend.dataprep.api.folder.FolderEntry;
+import org.talend.dataprep.api.preparation.Action;
+import org.talend.dataprep.api.preparation.AppendStep;
+import org.talend.dataprep.api.preparation.MixedContentMap;
+import org.talend.dataprep.api.preparation.Preparation;
+import org.talend.dataprep.api.preparation.PreparationSummary;
+import org.talend.dataprep.api.preparation.Step;
+import org.talend.dataprep.api.service.api.EnrichedPreparation;
+import org.talend.dataprep.api.service.api.PreviewAddParameters;
+import org.talend.dataprep.cache.ContentCache;
+import org.talend.dataprep.cache.ContentCacheKey;
+import org.talend.dataprep.preparation.service.UserPreparation;
+import org.talend.dataprep.security.Security;
+import org.talend.dataprep.transformation.actions.date.ComputeTimeSince;
+import org.talend.dataprep.transformation.actions.text.Trim;
+import org.talend.dataprep.transformation.cache.CacheKeyGenerator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.restassured.http.ContentType;
+import com.jayway.restassured.path.json.JsonPath;
+import com.jayway.restassured.response.Response;
+
+import static com.jayway.restassured.RestAssured.expect;
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.RestAssured.when;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.OK;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
@@ -31,40 +89,6 @@ import static org.talend.dataprep.cache.ContentCache.TimeToLive.PERMANENT;
 import static org.talend.dataprep.test.SameJSONFile.sameJSONAsFile;
 import static org.talend.dataprep.transformation.format.JsonFormat.JSON;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.talend.dataprep.StandalonePreparation;
-import org.talend.dataprep.api.dataset.ColumnMetadata;
-import org.talend.dataprep.api.dataset.DataSetMetadata;
-import org.talend.dataprep.api.dataset.RowMetadata;
-import org.talend.dataprep.api.folder.Folder;
-import org.talend.dataprep.api.folder.FolderEntry;
-import org.talend.dataprep.api.preparation.AppendStep;
-import org.talend.dataprep.api.preparation.Preparation;
-import org.talend.dataprep.api.preparation.PreparationSummary;
-import org.talend.dataprep.api.preparation.Step;
-import org.talend.dataprep.api.service.api.EnrichedPreparation;
-import org.talend.dataprep.cache.ContentCache;
-import org.talend.dataprep.cache.ContentCacheKey;
-import org.talend.dataprep.preparation.service.UserPreparation;
-import org.talend.dataprep.security.Security;
-import org.talend.dataprep.transformation.cache.CacheKeyGenerator;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Response;
 
 public class PreparationAPITest extends ApiServiceTestBase {
 
@@ -956,6 +980,70 @@ public class PreparationAPITest extends ApiServiceTestBase {
 
         // then
         assertThat(preview, sameJSONAsFile(expectedPreviewStream));
+    }
+
+    /**
+     * Verify a calculate time until preview after a trim step on a preparation
+     * see <a href="https://jira.talendforge.org/browse/TDP-5057">TDP-5057</a>
+     */
+    @Test
+    public void testPreparationPreviewOnPreparationWithTrimAction_TDP_5057() throws IOException {
+        //Create a dataset from csv
+        final String datasetId = testClient.createDataset("preview/best_sad_songs_of_all_time.csv", "testPreview");
+        // Create a preparation
+        String preparationId = testClient.createPreparationFromDataset(datasetId, "testPrep", home.getId());
+
+        // apply trim action on the 8nd column to make this column date valid
+        Map<String, String> trimParameters = new HashMap<>();
+        trimParameters.put("create_new_column", "false");
+        trimParameters.put("padding_character", "whitespace");
+        trimParameters.put("scope", "column");
+        trimParameters.put("column_id", "0008");
+        trimParameters.put("column_name", "Added At");
+        trimParameters.put("row_id", "null");
+
+        testClient.applyAction(preparationId, Trim.TRIM_ACTION_NAME, trimParameters);
+
+        // check column is date valid after trim action
+        RowMetadata preparationContent = testClient.getPreparationContent(preparationId);
+
+        List<PatternFrequency> patternFrequencies =
+                preparationContent.getColumns().get(8).getStatistics().getPatternFrequencies();
+
+        assertTrue(patternFrequencies.stream() //
+                .map(PatternFrequency::getPattern) //
+                .anyMatch("yyyy-MM-dd"::equals));
+
+        // create a preview of calculate time until action
+        PreviewAddParameters previewAddParameters = new PreviewAddParameters();
+        previewAddParameters.setDatasetId(datasetId);
+        previewAddParameters.setPreparationId(preparationId);
+        previewAddParameters.setTdpIds(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
+
+        Action calculateTimeUntilAction = new Action();
+        calculateTimeUntilAction.setName(ComputeTimeSince.TIME_SINCE_ACTION_NAME);
+        MixedContentMap actionParameters = new MixedContentMap();
+        actionParameters.put("create_new_column", "true");
+        actionParameters.put("time_unit", "HOURS");
+        actionParameters.put("since_when", "now_server_side");
+        actionParameters.put("scope", "column");
+        actionParameters.put("column_id", "0008");
+        actionParameters.put("column_name", "Added At");
+        calculateTimeUntilAction.setParameters(actionParameters);
+        previewAddParameters.setActions(Collections.singletonList(calculateTimeUntilAction));
+
+        JsonPath jsonPath = given().contentType(ContentType.JSON) //
+                .body(previewAddParameters) //
+                .expect().statusCode(200).log() .ifError() //
+                .when() //
+                .post("/api/preparations/preview/add") //
+                .jsonPath();
+
+        // check non empty value for the new column
+        assertEquals("new preview column should contains values according to calculate time until action", //
+                0, //
+                jsonPath.getList("records.0009").stream().map(String::valueOf).filter(StringUtils::isBlank).count());
+
     }
 
     @Test

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -1016,7 +1016,7 @@ public class PreparationAPITest extends ApiServiceTestBase {
 
         // create a preview of calculate time until action
         PreviewAddParameters previewAddParameters = new PreviewAddParameters();
-//        previewAddParameters.setDatasetId(datasetId);
+        previewAddParameters.setDatasetId(datasetId);
         previewAddParameters.setPreparationId(preparationId);
         previewAddParameters.setTdpIds(Arrays.asList(1, 2, 3, 4, 5, 6, 7));
 

--- a/dataprep-api/src/test/resources/org/talend/dataprep/api/service/preview/best_sad_songs_of_all_time.csv
+++ b/dataprep-api/src/test/resources/org/talend/dataprep/api/service/preview/best_sad_songs_of_all_time.csv
@@ -1,0 +1,8 @@
+Spotify URI,Track Name,Artist Name,Album Name,Disc Number,Track Number,Track Duration (ms),Added By,Added At
+spotify:track:3RxPlpIxQd2MHmq7BHvk0q,Maps,Yeah Yeah Yeahs,Fever To Tell (UK Version),1,9,219753,spotify:user:vinzir,2016-03-01 
+spotify:track:0eGsygTp906u18L0Oimnem,Mr. Brightside,The Killers,Hot Fuss,1,2,222075,spotify:user:vinzir,2016-03-07 
+spotify:track:3M2LLIKDLRpLRUwgFZnGLg,Like Eating Glass,Bloc Party,Silent Alarm,1,1,261986,spotify:user:vinzir,2016-05-26 
+spotify:track:5UWwZ5lm5PKu6eKsHAGxOk,Everlong,Foo Fighters,The Colour And The Shape,1,11,250546,spotify:user:vinzir,2016-06-22 
+spotify:track:7vhhU4SsMDV8uSQlCxf1Lk,Say It Ain't So,Weezer,Weezer,1,7,258826,spotify:user:vinzir,2016-10-19 
+spotify:track:52Bg6oaos7twR7IUtEpqcE,Between The Bars,Elliott Smith,Either/Or,1,4,141280,spotify:user:vinzir,2016-12-09 
+spotify:track:1qDrWA6lyx8cLECdZE7TV7,Somebody That I Used To Know,"Gotye, Kimbra",Making Mirrors,1,3,244884,spotify:user:vinzir,2017-01-12 

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
@@ -12,9 +12,6 @@
 
 package org.talend.dataprep.command;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.http.HttpHeaders.AUTHORIZATION;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -54,6 +51,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 /**
  * Base Hystrix command request for all DataPrep commands.
@@ -375,7 +375,9 @@ public class GenericCommand<T> extends HystrixCommand<T> {
      * @return the serialized actions
      */
     protected String serializeActions(final Collection<Action> stepActions) throws JsonProcessingException {
-        return "{\"actions\": " + objectMapper.writeValueAsString(stepActions) + "}";
+        return objectMapper.writer() //
+                .withRootName("actions") //
+                .writeValueAsString(stepActions);
     }
 
     // A intermediate builder for behavior definition.

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineDiffTransformer.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineDiffTransformer.java
@@ -133,8 +133,6 @@ class PipelineDiffTransformer implements Transformer {
                 .withActions(actionParser.parse(actions)) //
                 .withInitialMetadata(rowMetadata, false) //
                 .withOutput(BasicNode::new) //
-                .withGlobalStatistics(true) //
-                .allowMetadataChange(true) //
                 .withStatisticsAdapter(adapter) //
                 .build();
     }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineDiffTransformer.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineDiffTransformer.java
@@ -131,10 +131,10 @@ class PipelineDiffTransformer implements Transformer {
                 .withAnalyzerService(analyzerService) //
                 .withActionRegistry(actionRegistry) //
                 .withActions(actionParser.parse(actions)) //
-                .withInitialMetadata(rowMetadata, true) //
+                .withInitialMetadata(rowMetadata, false) //
                 .withOutput(BasicNode::new) //
-                .withGlobalStatistics(false) //
-                .allowMetadataChange(false) //
+                .withGlobalStatistics(true) //
+                .allowMetadataChange(true) //
                 .withStatisticsAdapter(adapter) //
                 .build();
     }


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5057

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
