### PR TITLE
fix(TDP-5225): Handle cases when preparation action id changes during migration

### DIFF
--- a/dataprep-upgrade-common/src/main/java/org/talend/dataprep/upgrade/common/ActionNewColumnToggleCommon.java
+++ b/dataprep-upgrade-common/src/main/java/org/talend/dataprep/upgrade/common/ActionNewColumnToggleCommon.java
@@ -20,6 +20,7 @@ import static org.talend.tql.api.TqlBuilder.eq;
 import org.slf4j.Logger;
 import org.talend.dataprep.api.preparation.Action;
 import org.talend.dataprep.api.preparation.PreparationActions;
+import org.talend.dataprep.api.preparation.Step;
 import org.talend.dataprep.preparation.store.PersistentStep;
 import org.talend.dataprep.preparation.store.PreparationRepository;
 
@@ -33,6 +34,7 @@ public class ActionNewColumnToggleCommon {
     public static void upgradeActions(PreparationRepository preparationRepository) {
         preparationRepository
                 .list(PreparationActions.class) //
+                .filter(pa -> !PreparationActions.ROOT_ACTIONS.id().equals(pa.id())) //
                 .peek(action -> {
                     final String beforeUpdateId = action.id();
                     action.getActions().forEach(ActionNewColumnToggleCommon::updateAction);
@@ -43,6 +45,7 @@ public class ActionNewColumnToggleCommon {
                         LOGGER.debug("Migration changed action id from '{}' to '{}', updating steps", beforeUpdateId,
                                 afterUpdateId);
                         preparationRepository.list(PersistentStep.class, eq("contentId", beforeUpdateId)) //
+                                .filter(s -> !Step.ROOT_STEP.id().equals(s.id())) //
                                 .peek(s -> s.setContent(afterUpdateId)) //
                                 .forEach(preparationRepository::add);
                     }

--- a/dataprep-upgrade-common/src/main/java/org/talend/dataprep/upgrade/common/ActionNewColumnToggleCommon.java
+++ b/dataprep-upgrade-common/src/main/java/org/talend/dataprep/upgrade/common/ActionNewColumnToggleCommon.java
@@ -35,7 +35,7 @@ public class ActionNewColumnToggleCommon {
         preparationRepository
                 .list(PreparationActions.class) //
                 .filter(pa -> !PreparationActions.ROOT_ACTIONS.id().equals(pa.id()) && pa.getActions() != null
-                        && pa.getActions().isEmpty()) //
+                        && !pa.getActions().isEmpty()) //
                 .peek(action -> {
                     final String beforeUpdateId = action.id();
                     action.getActions().forEach(ActionNewColumnToggleCommon::updateAction);

--- a/dataprep-upgrade-common/src/main/java/org/talend/dataprep/upgrade/common/ActionNewColumnToggleCommon.java
+++ b/dataprep-upgrade-common/src/main/java/org/talend/dataprep/upgrade/common/ActionNewColumnToggleCommon.java
@@ -34,7 +34,8 @@ public class ActionNewColumnToggleCommon {
     public static void upgradeActions(PreparationRepository preparationRepository) {
         preparationRepository
                 .list(PreparationActions.class) //
-                .filter(pa -> !PreparationActions.ROOT_ACTIONS.id().equals(pa.id())) //
+                .filter(pa -> !PreparationActions.ROOT_ACTIONS.id().equals(pa.id()) && pa.getActions() != null
+                        && pa.getActions().isEmpty()) //
                 .peek(action -> {
                     final String beforeUpdateId = action.id();
                     action.getActions().forEach(ActionNewColumnToggleCommon::updateAction);
@@ -68,34 +69,18 @@ public class ActionNewColumnToggleCommon {
             switch (action.getName()) {
             case "padding":
             case "absolute":
-            case "type_change":
             case "change_date_pattern":
-            case "domain_change":
             case "lowercase":
             case "propercase":
             case "uppercase":
-            case "clear_matching":
-            case "clear_invalid":
             case "date_calendar_converter":
             case "distance_converter":
             case "duration_converter":
-            case "delete_column":
             case "delete":
-            case "delete_on_value":
-            case "delete_empty":
-            case "delete_invalid":
             case "delete_lines":
-            case "fill_with_value":
-            case "fill_empty_from_above":
-            case "fillemptywithdefault":
-            case "fillinvalidwithdefault":
-            case "textclustering":
             case "change_number_format":
             case "format_phone_number":
             case "generate_a_sequence":
-            case "keep_only":
-            case "make_line_header":
-            case "mask_data_by_domain":
             case "modify_date":
             case "negate":
             case "remove_non_alpha_num_chars":
@@ -104,47 +89,31 @@ public class ActionNewColumnToggleCommon {
             case "round_down":
             case "cut":
             case "trim":
-            case "rename_column":
-            case "reorder":
             case "replace_cell_value":
             case "ceil":
             case "round_down_real":
             case "floor":
             case "round":
             case "normalize":
-            case "swap_column":
                 oldBehaviour = FALSE;
                 break;
             case "numeric_ops":
             case "logarithm_numbers":
-            case "compute_length":
             case "compute_time_since":
             case "timestamp_to_date":
             case "compare_dates":
             case "compare_numbers":
             case "concat":
-            case "contains":
             case "temperatures_converter":
             case "cos_numbers":
-            case "create_new_column":
-            case "copy":
             case "exponential_numbers":
-            case "extract_date_tokens":
-            case "extractemaildomain":
-            case "extract_number":
             case "substring":
-            case "extract_string_tokens":
-            case "extract_url_tokens":
-            case "lookup":
-            case "fuzzy_matching":
-            case "matches_pattern":
             case "max_numbers":
             case "min_numbers":
             case "natural_logarithm_numbers":
             case "negate_numbers":
             case "pow_numbers":
             case "sin_numbers":
-            case "split":
             case "square_root_numbers":
             case "tan_numbers":
                 oldBehaviour = TRUE;


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5225

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)

* Don't modify root step's actions.
* Add unit test to reproduce issue.