### PR TITLE
feat(TDP-5366): Display the Dictionary service consumer & producer ve…

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/VersionServiceAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/VersionServiceAPI.java
@@ -14,51 +14,36 @@ package org.talend.dataprep.api.service;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.PredicateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.talend.dataprep.api.service.command.info.VersionCommand;
-import org.talend.dataprep.api.service.info.VersionService;
-import org.talend.dataprep.exception.TDPException;
-import org.talend.dataprep.exception.error.CommonErrorCodes;
+import org.talend.dataprep.api.service.version.VersionsSupplier;
 import org.talend.dataprep.info.BuildDetails;
 import org.talend.dataprep.info.Version;
 import org.talend.dataprep.metrics.Timed;
 import org.talend.dataprep.security.PublicAPI;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.hystrix.HystrixCommand;
 
 import io.swagger.annotations.ApiOperation;
 
 @RestController
 public class VersionServiceAPI extends APIService {
 
-    @Autowired
-    private VersionService versionService;
-
-    @Autowired
-    private ObjectMapper mapper;
-
-    @Value("${transformation.service.url}")
-    protected String transformationServiceUrl;
-
-    @Value("${dataset.service.url}")
-    protected String datasetServiceUrl;
-
-    @Value("${preparation.service.url}")
-    protected String preparationServiceUrl;
-
     @Value("${dataprep.display.version}")
-    protected String applicationVersion;
+    private String applicationVersion;
+
+    @Autowired
+    private List<VersionsSupplier> versionsSuppliers;
 
     /**
-     * Returns all the versions of the different services (api, dataset, preparation and transformation) and the global application version.
+     * Returns all the versions of the different services (api, dataset, preparation and transformation) and the global
+     * application version.
      *
      * @return an array of service versions
      */
@@ -68,33 +53,13 @@ public class VersionServiceAPI extends APIService {
     @Timed
     @PublicAPI
     public BuildDetails allVersions() {
-        final Version[] versions = new Version[4];
+        List<Version> versions = new ArrayList<>();
 
-        final Version apiVersion = versionService.version();
-        apiVersion.setServiceName("API");
-        versions[0] = apiVersion;
-        versions[1] = callVersionService(datasetServiceUrl, "DATASET");
-        versions[2] = callVersionService(preparationServiceUrl, "PREPARATION");
-        versions[3] = callVersionService(transformationServiceUrl, "TRANSFORMATION");
-
-        return new BuildDetails(applicationVersion, versions);
-    }
-
-    /**
-     * Call the version service on the given service: dataset, preparation or transformation.
-     *
-     * @param serviceName the name of the service
-     * @return the version of the called service
-     */
-    private Version callVersionService(String serviceUrl, String serviceName) {
-        HystrixCommand<InputStream> versionCommand = getCommand(VersionCommand.class, serviceUrl);
-        try (InputStream content = versionCommand.execute()) {
-            final Version version = mapper.readerFor(Version.class).readValue(content);
-            version.setServiceName(serviceName);
-            return version;
-        } catch (IOException e) {
-            throw new TDPException(CommonErrorCodes.UNABLE_TO_GET_SERVICE_VERSION, e);
+        for (VersionsSupplier versionsSupplier : versionsSuppliers) {
+            versions.addAll(versionsSupplier.getVersions());
         }
-    }
+        CollectionUtils.filter(versions, PredicateUtils.notNullPredicate());
 
+        return new BuildDetails(applicationVersion, versions.toArray(new Version[versions.size()]));
+    }
 }

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/info/VersionCommand.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/info/VersionCommand.java
@@ -35,11 +35,11 @@ public class VersionCommand extends GenericCommand<InputStream> {
 
     public static final HystrixCommandGroupKey VERSION_GROUP = HystrixCommandGroupKey.Factory.asKey("version");
 
-    private VersionCommand(String serviceUrl) {
+    private VersionCommand(String serviceUrl, String entryPoint) {
         super(VERSION_GROUP);
 
         execute(() -> {
-            String url = serviceUrl + "/version";
+            String url = serviceUrl + entryPoint;
             return new HttpGet(url);
         });
         onError(e -> new TDPException(CommonErrorCodes.UNABLE_TO_GET_SERVICE_VERSION, e,

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/version/AbstractVersionSupplier.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/version/AbstractVersionSupplier.java
@@ -1,0 +1,59 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.api.service.version;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.talend.dataprep.api.service.command.info.VersionCommand;
+import org.talend.dataprep.exception.TDPException;
+import org.talend.dataprep.info.Version;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.hystrix.HystrixCommand;
+
+public abstract class AbstractVersionSupplier implements VersionsSupplier {
+
+    protected static final String VERSION_ENTRY_POINT = "/version";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractVersionSupplier.class);
+
+    @Autowired
+    protected ObjectMapper mapper;
+
+    @Autowired
+    protected ApplicationContext context;
+
+    /**
+     * Call the version service on the given service: dataset, preparation or transformation.
+     *
+     * @param serviceName the name of the service
+     * @return the version of the called service
+     */
+    Version callVersionService(String serviceUrl, String serviceName, String entryPoint) {
+        HystrixCommand<InputStream> versionCommand = context.getBean(VersionCommand.class, serviceUrl, entryPoint);
+        try (InputStream content = versionCommand.execute()) {
+            final Version version = mapper.readerFor(Version.class).readValue(content);
+            version.setServiceName(serviceName);
+            return version;
+        } catch (IOException | TDPException e) {
+            LOGGER.warn("Unable to get the version of the service {}", serviceName, e);
+            return null;
+        }
+    }
+}

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/version/OSVersionSupplier.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/version/OSVersionSupplier.java
@@ -1,0 +1,56 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.api.service.version;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.talend.dataprep.api.service.info.VersionService;
+import org.talend.dataprep.info.Version;
+
+@Component
+@Order(value = 1)
+public class OSVersionSupplier extends AbstractVersionSupplier {
+
+    @Value("${transformation.service.url}")
+    protected String transformationServiceUrl;
+
+    @Value("${dataset.service.url}")
+    protected String datasetServiceUrl;
+
+    @Value("${preparation.service.url}")
+    protected String preparationServiceUrl;
+
+    @Autowired
+    private VersionService versionService;
+
+    @Override
+    public List<Version> getVersions() {
+        final List<Version> versions = new ArrayList<>(4);
+
+        final Version apiVersion = versionService.version();
+        apiVersion.setServiceName("API");
+        versions.add(apiVersion);
+        versions.add(callVersionService(datasetServiceUrl, "Dataset", VERSION_ENTRY_POINT));
+        versions.add(callVersionService(preparationServiceUrl, "Preparation", VERSION_ENTRY_POINT));
+        versions.add(callVersionService(transformationServiceUrl, "Transformation", VERSION_ENTRY_POINT));
+
+        return versions;
+    }
+
+}

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/version/VersionsSupplier.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/version/VersionsSupplier.java
@@ -1,0 +1,27 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.api.service.version;
+
+import java.util.List;
+
+import org.talend.dataprep.info.Version;
+
+/**
+ * Supplier of services or component versions, like TDP API, or TDQ Semantic Types Consumer.
+ */
+public interface VersionsSupplier {
+
+    List<Version> getVersions();
+
+}

--- a/dataprep-backend-service/src/main/resources/org/talend/dataprep/configuration/default.properties
+++ b/dataprep-backend-service/src/main/resources/org/talend/dataprep/configuration/default.properties
@@ -34,8 +34,7 @@ support.url=https://www.talend.com/services/technical-support/
 # Community link
 community.url=https://community.talend.com/t5/Data-Quality-and-Preparation/bd-p/prepare_govern
 ################################
-
-dataprep.display.version=2.5.0 BETA
+dataprep.display.version=2.6.0 BETA
 
 ############## UI ##############
 #dataprep.ui.theme.enabled=false


### PR DESCRIPTION
…rsions in the TDP About dialog

* Add Semantic Types Consumer, Semantic Types Producer, Gateway, Fullrun (and for cloud Async Store)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5366

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
