### PR TITLE
chore: remove ops version from OS code

### DIFF
--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/VersionServiceAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/VersionServiceAPITest.java
@@ -13,50 +13,99 @@
 
 package org.talend.dataprep.api.service;
 
+import com.google.common.base.MoreObjects;
+
 import org.junit.Assert;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 import org.talend.dataprep.info.BuildDetails;
+import org.talend.dataprep.info.ManifestInfo;
+import org.talend.dataprep.info.ManifestInfoProvider;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
+import static com.jayway.restassured.RestAssured.expect;
+import static com.jayway.restassured.RestAssured.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
+@Import(VersionServiceAPITest.VersionTestConfiguration.class)
 public class VersionServiceAPITest extends ApiServiceTestBase {
 
-    @Autowired
-    ObjectMapper objectMapper = new ObjectMapper();
-
     @Test
-    public void shouldReturnOKWhenVersionAsked() throws Exception {
-        Response response = RestAssured.given() //
-                .when() //
-                .get("/api/version");
-
-        Assert.assertEquals(200, response.getStatusCode());
-
-        BuildDetails buildDetails = objectMapper.readValue(response.asString(), BuildDetails.class);
+    public void shouldReturnOKWhenVersionAsked() {
+        BuildDetails buildDetails =
+                expect().statusCode(200).when().get("/api/version").as(BuildDetails.class);
 
         Assert.assertEquals(4, buildDetails.getServices().length);
         Assert.assertEquals("GLOBAL_VERSION", buildDetails.getDisplayVersion());
     }
 
     @Test
-    public void shouldReceiveSameVersionsWhenAskedTwice() throws Exception {
-        //
-        Response response = RestAssured.given() //
-                .when() //
-                .get("/api/version");
-
-        Response response2 = RestAssured.given() //
-                .when() //
-                .get("/api/version");
-
-        BuildDetails buildDetails = objectMapper.readValue(response.asString(), BuildDetails.class);
-
-        BuildDetails buildDetails2 = objectMapper.readValue(response.asString(), BuildDetails.class);
+    public void shouldReceiveSameVersionsWhenAskedTwice() {
+        BuildDetails buildDetails = when().get("/api/version").as(BuildDetails.class);
+        BuildDetails buildDetails2 = when().get("/api/version").as(BuildDetails.class);
 
         Assert.assertArrayEquals(buildDetails.getServices(), buildDetails2.getServices());
         Assert.assertEquals(buildDetails.getDisplayVersion(), buildDetails2.getDisplayVersion());
+    }
+
+    @Test
+    public void shouldReceiveVersionsInCorrectOrder() {
+        BuildDetails buildDetails = when().get("/api/version").as(BuildDetails.class);
+
+        assertThat(buildDetails.getServices()).isNotEmpty();
+        assertThat(buildDetails.getServices()).allMatch(v -> v.getVersionId().endsWith("-v2-id-v3-id"));
+        assertThat(buildDetails.getServices()).allMatch(v -> v.getBuildId().endsWith("-v2-buildId-v3-buildId"));
+    }
+
+    @Configuration
+    public static class VersionTestConfiguration {
+
+        @Bean
+        @Order(3)
+        public ManifestInfoProvider version3ManifestProvider() {
+            return new ManifestInfoProvider() {
+                @Override
+                public String getName() {
+                    return "Version3";
+                }
+
+                @Override
+                public ManifestInfo getManifestInfo() {
+                    return new ManifestInfo("v3-id", "v3-buildId");
+                }
+
+                @Override
+                public String toString() {
+                    return MoreObjects.toStringHelper(this)
+                            .add("name", getName())
+                            .toString();
+                }
+            };
+        }
+
+        @Bean
+        @Order(2)
+        public ManifestInfoProvider version2ManifestProvider() {
+            return new ManifestInfoProvider() {
+                @Override
+                public String getName() {
+                    return "Version2";
+                }
+
+                @Override
+                public ManifestInfo getManifestInfo() {
+                    return new ManifestInfo("v2-id", "v2-buildId");
+                }
+
+                @Override
+                public String toString() {
+                    return MoreObjects.toStringHelper(this)
+                            .add("name", getName())
+                            .toString();
+                }
+            };
+        }
     }
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Versions.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Versions.java
@@ -14,6 +14,7 @@ package org.talend.dataprep.configuration;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.talend.dataprep.info.ClassPathManifestInfoProvider;
 import org.talend.dataprep.info.ManifestInfo;
 import org.talend.dataprep.info.ManifestInfoProvider;
@@ -25,12 +26,9 @@ import org.talend.dataprep.info.ManifestInfoProvider;
 public class Versions {
 
     @Bean
-    public ManifestInfoProvider baseProvider() {
+    @Order(1)
+    public ManifestInfoProvider manifestInfoProvider() {
         return new ClassPathManifestInfoProvider("/dataprep-git.properties", "OS");
     }
 
-    @Bean
-    public ManifestInfoProvider opsProvider() {
-        return new ClassPathManifestInfoProvider("/dataprep-ops-git.properties", "OPS");
-    }
 }

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/api/service/info/VersionServiceTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/api/service/info/VersionServiceTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.talend.dataprep.info.ManifestInfo;
 import org.talend.dataprep.info.ManifestInfoProvider;
 import org.talend.dataprep.info.Version;
@@ -38,7 +39,7 @@ public class VersionServiceTest {
         final ManifestInfoProvider provider2 = mock(ManifestInfoProvider.class);
         when(provider1.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
         when(provider2.getManifestInfo()).thenReturn(new ManifestInfo("v1", "5678"));
-        versionService.setManifestInfoProviders(asList(provider1, provider2));
+        ReflectionTestUtils.setField(versionService, "manifestInfoProviders", asList(provider1, provider2));
 
         // when
         final Version version = versionService.version();
@@ -55,7 +56,7 @@ public class VersionServiceTest {
         final ManifestInfoProvider provider2 = mock(ManifestInfoProvider.class);
         when(provider1.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
         when(provider2.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
-        versionService.setManifestInfoProviders(asList(provider1, provider2));
+        ReflectionTestUtils.setField(versionService, "manifestInfoProviders", asList(provider1, provider2));
 
         // when
         final Version version = versionService.version();
@@ -72,7 +73,7 @@ public class VersionServiceTest {
         final ManifestInfoProvider provider2 = mock(ManifestInfoProvider.class);
         when(provider1.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
         when(provider2.getManifestInfo()).thenReturn(new ManifestInfo("v2", "1234"));
-        versionService.setManifestInfoProviders(asList(provider1, provider2));
+        ReflectionTestUtils.setField(versionService, "manifestInfoProviders", asList(provider1, provider2));
 
         // when
         final Version version = versionService.version();
@@ -89,7 +90,7 @@ public class VersionServiceTest {
         final ManifestInfoProvider provider2 = mock(ManifestInfoProvider.class);
         when(provider1.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
         when(provider2.getManifestInfo()).thenReturn(new ManifestInfo("N/A", "1234"));
-        versionService.setManifestInfoProviders(asList(provider1, provider2));
+        ReflectionTestUtils.setField(versionService, "manifestInfoProviders", asList(provider1, provider2));
 
         // when
         final Version version = versionService.version();
@@ -97,50 +98,6 @@ public class VersionServiceTest {
         // then
         assertEquals("v1", version.getVersionId());
         assertEquals("1234-1234", version.getBuildId());
-    }
-
-    @Test
-    public void shouldOrderBuildIds() throws Exception {
-        // given
-        final ManifestInfoProvider os = mock(ManifestInfoProvider.class);
-        final ManifestInfoProvider ee = mock(ManifestInfoProvider.class);
-        final ManifestInfoProvider ops = mock(ManifestInfoProvider.class);
-        when(os.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
-        when(os.getName()).thenReturn("os");
-        when(ee.getManifestInfo()).thenReturn(new ManifestInfo("v1", "5678"));
-        when(ee.getName()).thenReturn("ee");
-        when(ops.getManifestInfo()).thenReturn(new ManifestInfo("v1", "91011"));
-        when(ops.getName()).thenReturn("ops");
-        versionService.setManifestInfoProviders(asList(ee, ops, os));
-
-        // when
-        final Version version = versionService.version();
-
-        // then
-        assertEquals("v1", version.getVersionId());
-        assertEquals("1234-5678-91011", version.getBuildId());
-    }
-
-    @Test
-    public void shouldOrderBuildVersions() throws Exception {
-        // given
-        final ManifestInfoProvider os = mock(ManifestInfoProvider.class);
-        final ManifestInfoProvider ee = mock(ManifestInfoProvider.class);
-        final ManifestInfoProvider ops = mock(ManifestInfoProvider.class);
-        when(os.getManifestInfo()).thenReturn(new ManifestInfo("v1", "1234"));
-        when(os.getName()).thenReturn("os");
-        when(ee.getManifestInfo()).thenReturn(new ManifestInfo("v2", "5678"));
-        when(ee.getName()).thenReturn("ee");
-        when(ops.getManifestInfo()).thenReturn(new ManifestInfo("v1", "91011"));
-        when(ops.getName()).thenReturn("ops");
-        versionService.setManifestInfoProviders(asList(ee, ops, os));
-
-        // when
-        final Version version = versionService.version();
-
-        // then
-        assertEquals("v1-v2-v1", version.getVersionId());
-        assertEquals("1234-5678-91011", version.getBuildId());
     }
 
 }


### PR DESCRIPTION
- use @Order annotation to order version List
- remove setter used only for testing
- move version order test in API integration test
