### PR TITLE
feature(TDP-5323): Create Multi-Tenant (Integration tests on DQ dict …

### DIFF
--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/step/DatasetStep.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/step/DatasetStep.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.dataprep.qa.config.DataPrepStep;
@@ -108,21 +107,29 @@ public class DatasetStep extends DataPrepStep {
             throws IOException, InterruptedException {
         String dataSetId = context.getObject("dataSetId").toString();
 
-        getDatasetsColumnSemanticTypes(semanticTypeId, columnId, dataSetId);
+        getDatasetsColumnSemanticTypes(semanticTypeId, columnId, dataSetId, true);
     }
 
     @Then("^I check that the semantic type \"(.*)\" exists the types list of the column \"(.*)\" of the dataset \"(.*)\"$")
     public void thenICheckSemanticTypeExist(String semanticTypeId, String columnId, String dataSetName)
             throws IOException, InterruptedException {
         String dataSetId = context.getDatasetId(suffixName(dataSetName));
-        getDatasetsColumnSemanticTypes(semanticTypeId, columnId, dataSetId);
+        getDatasetsColumnSemanticTypes(semanticTypeId, columnId, dataSetId, true);
     }
 
-    private void getDatasetsColumnSemanticTypes(String semanticTypeId, String columnId, String dataSetId) {
+    @Then("^I check that the semantic type \"(.*)\" does not exist the types list of the column \"(.*)\" of the dataset \"(.*)\"$")
+    public void thenICheckSemanticTypeDoesNotExist(String semanticTypeId, String columnId, String dataSetName)
+            throws IOException, InterruptedException {
+        String dataSetId = context.getDatasetId(suffixName(dataSetName));
+        getDatasetsColumnSemanticTypes(semanticTypeId, columnId, dataSetId, false);
+    }
+
+    private void getDatasetsColumnSemanticTypes(String semanticTypeId, String columnId, String dataSetId,
+            boolean expected) {
         Response response = api.getDatasetsColumnSemanticTypes(columnId, dataSetId);
         response.then().statusCode(200);
 
-        assertEquals(1,
+        assertEquals(expected ? 1 : 0,
                 response
                         .body()
                         .jsonPath()
@@ -157,6 +164,7 @@ public class DatasetStep extends DataPrepStep {
 
         }
         context.storeDatasetRef(datasetId, suffixedName);
+        // context.storeObject("dataSetId", datasetId);
     }
 
     @Given("^I have a dataset with parameters:$")


### PR DESCRIPTION
…cloud integration)

- Scenario 1 (after meeting) (CREATE and PUBLISHED) Tenant A and Tenant B specific category dictionary without test on the quality bar and the percentage of match

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5323

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
