### PR TITLE
fix(TDP-5378): Limit memory used in lookup cache (#1181)

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/datablending/Lookup.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/datablending/Lookup.java
@@ -21,14 +21,23 @@ import static org.talend.dataprep.parameters.ParameterType.STRING;
 import static org.talend.dataprep.transformation.actions.Providers.get;
 import static org.talend.dataprep.transformation.actions.category.ActionScope.HIDDEN_IN_ACTION_LIST;
 import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.COLUMN_ID;
-import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.*;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_DS_ID;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_DS_NAME;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_JOIN_ON;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_JOIN_ON_NAME;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_SELECTED_COLS;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.CANCELED;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.OK;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
-import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.dataprep.api.action.Action;
@@ -46,6 +55,7 @@ import org.talend.dataprep.transformation.api.action.context.ActionContext;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 
 /**
  * Lookup action used to blend a (or a part of a) dataset into another one.
@@ -211,7 +221,7 @@ public class Lookup extends AbstractActionMetadata implements DataSetAction {
      * @param parameters the action parameters.
      * @return the list of columns to merge.
      */
-    private List<LookupSelectedColumnParameter> getColsToAdd(Map<String, String> parameters) {
+    public static List<LookupSelectedColumnParameter> getColsToAdd(Map<String, String> parameters) {
         List<LookupSelectedColumnParameter> result;
         try {
             final String cols = parameters.get(LOOKUP_SELECTED_COLS.getKey());

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/transformation/actions/datablending/DataSetLookupRowMatcherTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/transformation/actions/datablending/DataSetLookupRowMatcherTest.java
@@ -1,0 +1,67 @@
+package org.talend.dataprep.transformation.actions.datablending;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.talend.dataprep.api.dataset.row.DataSetRow;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataSetLookupRowMatcherTest {
+
+    @InjectMocks
+    private DataSetLookupRowMatcher matcher = new DataSetLookupRowMatcher();
+
+    @Test
+    public void shouldPartiallyCache() {
+        // given
+        matcher.setJoinOnColumn("0000");
+        final LookupSelectedColumnParameter parameter = new LookupSelectedColumnParameter();
+        parameter.setId("0001");
+        matcher.setSelectedColumns(Collections.singletonList(parameter));
+
+        final Map<String, String> values1 = new HashMap<String, String>() {
+
+            {
+                put("0000", "NY");
+                put("0001", "New York");
+                put("0002", "Additional");
+                put("0003", "Information");
+                put("0004", "Not");
+                put("0005", "To");
+                put("0006", "Be");
+                put("0007", "Cached");
+            }
+        };
+        final Map<String, String> values2 = new HashMap<String, String>() {
+
+            {
+                put("0000", "CA");
+                put("0001", "California");
+                put("0002", "Additional");
+                put("0003", "Information");
+                put("0004", "Not");
+                put("0005", "To");
+                put("0006", "Be");
+                put("0007", "Cached");
+            }
+        };
+        final DataSetRow row1 = new DataSetRow(values1);
+        final DataSetRow row2 = new DataSetRow(values2);
+        matcher.setLookupIterator(Arrays.asList(row1, row2).iterator());
+
+        // when
+        final DataSetRow matchingRow = matcher.getMatchingRow("0000", "CA");
+
+        // then
+        assertEquals(1, matchingRow.values().size());
+        assertEquals("California", matchingRow.get("0001"));
+    }
+}


### PR DESCRIPTION
* fix(TDP-5378): Limit use of memory in lookup cache

* Filter dataset row to only include column used in Lookup action.

* * unit test for cache test.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5378

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
