### PR TITLE
chore: make PreparationUtils static again.

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/api/preparation/PreparationUtils.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/api/preparation/PreparationUtils.java
@@ -121,7 +121,7 @@ public class PreparationUtils {
 
     }
 
-    private void __listSteps(final List<Step> steps, final String limit, final Step step,
+    private static void __listSteps(final List<Step> steps, final String limit, final Step step,
             final PreparationRepository repository) {
         if (step == null) {
             return;
@@ -142,7 +142,7 @@ public class PreparationUtils {
      * @param repository The identifiable repository
      * @return The list of step ids from root to step
      */
-    public List<String> listStepsIds(final String stepId, final PreparationRepository repository) {
+    public static List<String> listStepsIds(final String stepId, final PreparationRepository repository) {
         return listStepsIds(stepId, Step.ROOT_STEP.getId(), repository);
     }
 
@@ -154,7 +154,8 @@ public class PreparationUtils {
      * @param repository The identifiable repository
      * @return The list of step ids from starting (limit) to step
      */
-    public List<String> listStepsIds(final String stepId, final String limit, final PreparationRepository repository) {
+    public static List<String> listStepsIds(final String stepId, final String limit,
+            final PreparationRepository repository) {
         return listSteps(repository.get(stepId, Step.class), limit, repository).stream() //
                 .map(Step::id) //
                 .collect(toList());
@@ -173,7 +174,7 @@ public class PreparationUtils {
      * @see Step#id()
      * @see Step#getParent()
      */
-    public List<Step> listSteps(String headStepId, PreparationRepository repository) {
+    public static List<Step> listSteps(String headStepId, PreparationRepository repository) {
         return listSteps(repository.get(headStepId, Step.class), Step.ROOT_STEP.getId(), repository);
     }
 
@@ -188,7 +189,7 @@ public class PreparationUtils {
      * @see Step#id()
      * @see Step#getParent()
      */
-    public List<Step> listSteps(final Step step, final String limit, final PreparationRepository repository) {
+    public static List<Step> listSteps(final Step step, final String limit, final PreparationRepository repository) {
         if (repository == null) {
             throw new IllegalArgumentException("Repository cannot be null.");
         }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/PreparationRepositoryConfiguration.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/PreparationRepositoryConfiguration.java
@@ -104,10 +104,10 @@ public class PreparationRepositoryConfiguration {
                                  * Warning: doing so has some performance impacts (list may perform many getById calls
                                  * depending on preparation size)
                                  */
-                            final PreparationUtils preparationUtils = applicationContext.getBean(PreparationUtils.class);
                             final PreparationRepository repository = applicationContext.getBean(PreparationRepository.class);
                             if (preparation.getHeadId() != null) {
-                                final List<String> storageSteps = preparationUtils.listStepsIds(preparation.getHeadId(),
+                                final List<String> storageSteps =
+                                        PreparationUtils.listStepsIds(preparation.getHeadId(),
                                         repository);
                                 persistentPreparation.setSteps(storageSteps);
                             }
@@ -135,9 +135,8 @@ public class PreparationRepositoryConfiguration {
                                 preparation.setSteps(steps);
                             }
                         } else {
-                            final PreparationUtils preparationUtils = applicationContext.getBean(PreparationUtils.class);
-                            final List<String> stepIds = preparationUtils.listStepsIds(preparation.getHeadId(), repository);
-
+                            final List<String> stepIds =
+                                    PreparationUtils.listStepsIds(preparation.getHeadId(), repository);
                             final List<Step> steps = stepIds.stream() //
                                     .map(stepId -> repository.get(stepId, Step.class)) //
                                     .collect(Collectors.toList());

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/api/preparation/PreparationUtilsTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/api/preparation/PreparationUtilsTest.java
@@ -16,10 +16,17 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.talend.tql.api.TqlBuilder.eq;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 
 import org.apache.commons.io.output.NullOutputStream;
 import org.junit.Test;
@@ -39,9 +46,6 @@ public class PreparationUtilsTest extends ServiceBaseTest {
     @Autowired
     private VersionService versionService;
 
-    @Autowired
-    private PreparationUtils preparationUtils;
-
     @Test
     public void should_list_steps_ids_history_from_root() {
         // given
@@ -59,7 +63,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         repository.add(step2);
 
         // when
-        List<String> ids = preparationUtils.listStepsIds(step1.id(), repository);
+        List<String> ids = PreparationUtils.listStepsIds(step1.id(), repository);
 
         // then
         assertThat(ids, hasItem(Step.ROOT_STEP.id()));
@@ -67,7 +71,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         assertThat(ids, not(hasItem(step2.id())));
 
         // when
-        ids = preparationUtils.listStepsIds(step2.id(), repository);
+        ids = PreparationUtils.listStepsIds(step2.id(), repository);
 
         // then
         assertThat(ids, hasItem(Step.ROOT_STEP.id()));
@@ -92,7 +96,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         repository.add(step2);
 
         // when
-        List<String> ids = preparationUtils.listStepsIds(step2.id(), step1.getId(), repository);
+        List<String> ids = PreparationUtils.listStepsIds(step2.id(), step1.getId(), repository);
 
         // then
         assertThat(ids, not(hasItem(Step.ROOT_STEP.id())));
@@ -100,7 +104,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         assertThat(ids, hasItem(step2.id()));
 
         // when
-        ids = preparationUtils.listStepsIds(step2.id(), step2.getId(), repository);
+        ids = PreparationUtils.listStepsIds(step2.id(), step2.getId(), repository);
 
         // then
         assertThat(ids, not(hasItem(Step.ROOT_STEP.id())));
@@ -125,7 +129,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         repository.add(step2);
 
         // when
-        List<Step> steps = preparationUtils.listSteps(step1.id(), repository);
+        List<Step> steps = PreparationUtils.listSteps(step1.id(), repository);
 
         // then
         assertThat(steps, hasItem(Step.ROOT_STEP));
@@ -133,7 +137,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         assertThat(steps, not(hasItem(step2)));
 
         // when
-        steps = preparationUtils.listSteps(step2.id(), repository);
+        steps = PreparationUtils.listSteps(step2.id(), repository);
 
         // then
         assertThat(steps, hasItem(Step.ROOT_STEP));
@@ -158,7 +162,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         repository.add(step2);
 
         // when
-        List<Step> steps = preparationUtils.listSteps(step2, step1.getId(), repository);
+        List<Step> steps = PreparationUtils.listSteps(step2, step1.getId(), repository);
 
         // then
         assertThat(steps, not(hasItem(Step.ROOT_STEP)));
@@ -166,7 +170,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
         assertThat(steps, hasItem(step2));
 
         // when
-        steps = preparationUtils.listSteps(step2, step2.getId(), repository);
+        steps = PreparationUtils.listSteps(step2, step2.getId(), repository);
 
         // then
         assertThat(steps, not(hasItem(Step.ROOT_STEP)));
@@ -177,7 +181,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
     @Test
     public void should_return_empty_list_with_null_last_step() throws Exception {
         // when
-        final List<Step> steps = preparationUtils.listSteps(null, "limit", repository);
+        final List<Step> steps = PreparationUtils.listSteps(null, "limit", repository);
 
         // then
         assertThat(steps, hasSize(0));
@@ -186,7 +190,7 @@ public class PreparationUtilsTest extends ServiceBaseTest {
     @Test(expected = IllegalArgumentException.class)
     public void should_throw_exception_with_null_limit() throws Exception {
         // when
-        preparationUtils.listSteps(Step.ROOT_STEP, null, repository);
+        PreparationUtils.listSteps(Step.ROOT_STEP, null, repository);
 
         // then
         fail("Should have thrown IllegalArgumentException because limit step is null");

--- a/dataprep-maintenance/src/main/java/org/talend/dataprep/maintenance/preparation/PreparationCleaner.java
+++ b/dataprep-maintenance/src/main/java/org/talend/dataprep/maintenance/preparation/PreparationCleaner.java
@@ -29,7 +29,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.preparation.Preparation;
 import org.talend.dataprep.api.preparation.PreparationActions;
-import org.talend.dataprep.api.preparation.PreparationUtils;
 import org.talend.dataprep.api.preparation.Step;
 import org.talend.dataprep.api.preparation.StepRowMetadata;
 import org.talend.dataprep.preparation.store.PersistentStep;
@@ -54,9 +53,6 @@ public class PreparationCleaner {
 
     @Autowired
     private SecurityProxy securityProxy;
-
-    @Autowired
-    private PreparationUtils preparationUtils;
 
     @Autowired(required = false)
     private List<OrphanStepsFinder> orphanStepsFinders;

--- a/dataprep-maintenance/src/main/java/org/talend/dataprep/maintenance/preparation/PreparationOrphanStepsFinder.java
+++ b/dataprep-maintenance/src/main/java/org/talend/dataprep/maintenance/preparation/PreparationOrphanStepsFinder.java
@@ -32,8 +32,6 @@ import org.talend.dataprep.preparation.store.PreparationRepository;
 @Component
 public class PreparationOrphanStepsFinder implements OrphanStepsFinder {
 
-    private final PreparationUtils preparationUtils = new PreparationUtils();
-
     @Autowired
     private PreparationRepository repository;
 
@@ -50,7 +48,7 @@ public class PreparationOrphanStepsFinder implements OrphanStepsFinder {
 
     private Set<String> getUsedSteps() {
         return repository.list(Preparation.class) //
-                .flatMap(prep -> preparationUtils.listStepsIds(prep.getHeadId(), repository).stream()) //
+                .flatMap(prep -> PreparationUtils.listStepsIds(prep.getHeadId(), repository).stream()) //
                 .collect(toSet());
     }
 

--- a/dataprep-upgrade/src/main/java/org/talend/dataprep/upgrade/to_2_1_0_PE/StepListPreparationsMigration.java
+++ b/dataprep-upgrade/src/main/java/org/talend/dataprep/upgrade/to_2_1_0_PE/StepListPreparationsMigration.java
@@ -36,9 +36,6 @@ public class StepListPreparationsMigration implements BaseUpgradeTaskTo_2_1_0_PE
     @Autowired
     private PreparationRepository preparationRepository;
 
-    @Autowired
-    private PreparationUtils preparationUtils;
-
     @Override
     public void run() {
         LOGGER.info("Migration of step ids in preparation...");
@@ -46,7 +43,7 @@ public class StepListPreparationsMigration implements BaseUpgradeTaskTo_2_1_0_PE
         preparationRepository.list(PersistentPreparation.class) //
                 .forEach(p -> {
                     LOGGER.info("Migration of preparation #{}", p.getId());
-                    final List<String> stepsIds = preparationUtils.listStepsIds(p.getHeadId(), preparationRepository);
+                    final List<String> stepsIds = PreparationUtils.listStepsIds(p.getHeadId(), preparationRepository);
                     p.setSteps(stepsIds);
 
                     preparationRepository.add(p);

--- a/dataprep-upgrade/src/main/java/org/talend/dataprep/upgrade/to_2_1_0_PE/ToPEPersistentIdentifiable.java
+++ b/dataprep-upgrade/src/main/java/org/talend/dataprep/upgrade/to_2_1_0_PE/ToPEPersistentIdentifiable.java
@@ -44,9 +44,6 @@ public class ToPEPersistentIdentifiable implements BaseUpgradeTaskTo_2_1_0_PE {
     private static final Logger LOGGER = getLogger(ToPEPersistentIdentifiable.class);
 
     @Autowired
-    private PreparationUtils preparationUtils;
-
-    @Autowired
     private PreparationRepository preparationRepository;
 
     @Autowired
@@ -90,7 +87,7 @@ public class ToPEPersistentIdentifiable implements BaseUpgradeTaskTo_2_1_0_PE {
         final Stream<PersistentPreparation> persistentPreparations = preparationRepository.list(PersistentPreparation.class);
         persistentPreparations.forEach(p -> {
             LOGGER.info("Migration of preparation #{}", p.getId());
-            final List<String> stepsIds = preparationUtils.listStepsIds(p.getHeadId(), preparationRepository);
+            final List<String> stepsIds = PreparationUtils.listStepsIds(p.getHeadId(), preparationRepository);
             p.setSteps(stepsIds);
 
             final DataSetMetadata metadata = dataSetMetadataRepository.get(p.getDataSetId());


### PR DESCRIPTION
**Link to the JIRA issue**
(no jira)

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
