### PR TITLE
fix(TDP-4712): Add Accept-Language forward to Hystrix commands.

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/command/GenericCommand.java
@@ -13,7 +13,6 @@
 package org.talend.dataprep.command;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -38,6 +37,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.talend.daikon.exception.ExceptionContext;
 import org.talend.daikon.exception.error.ErrorCode;
@@ -216,11 +217,14 @@ public class GenericCommand<T> extends HystrixCommand<T> {
 
         // update request header with security token
         if (StringUtils.isNotBlank(getAuthenticationToken())) {
-            request.addHeader(AUTHORIZATION, getAuthenticationToken());
+            request.addHeader(HttpHeaders.AUTHORIZATION, getAuthenticationToken());
         } else {
             // Intentionally left as debug to prevent log flood in open source edition.
             LOGGER.debug("No current authentication token for {}.", this.getClass());
         }
+
+        // Forward locale to target
+        request.addHeader(HttpHeaders.ACCEPT_LANGUAGE, LocaleContextHolder.getLocale().toLanguageTag());
 
         final HttpResponse response;
         try {

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/command/GenericCommandTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/command/GenericCommandTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Scope;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.TestPropertySource;
@@ -111,6 +112,20 @@ public class GenericCommandTest extends ServiceBaseTest {
         // Then
         assertThat(result, is(security.getAuthenticationToken()));
         assertThat(lastException, nullValue());
+    }
+
+    @Test
+    public void testLanguageHeader() throws Exception {
+        // Given
+        LocaleContextHolder.setLocale(Locale.JAPANESE);
+        final GenericCommand<String> command =
+                getCommand("http://localhost:" + port + "/command/test/language", GenericCommandTest::error);
+
+        // When
+        final String result = command.run();
+
+        // Then
+        assertThat(result, is("ja"));
     }
 
     @Test

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/command/GenericCommandTestService.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/command/GenericCommandTestService.java
@@ -18,6 +18,7 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -39,6 +40,11 @@ public class GenericCommandTestService {
     @RequestMapping(value = "/command/test/success", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
     public String success() throws IOException {
         return "success";
+    }
+
+    @RequestMapping(value = "/command/test/language", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
+    public String testLanguage(@RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE) String language) throws IOException {
+        return language;
     }
 
     @RequestMapping(value = "/command/test/authentication/token", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/i18n/DataprepLocaleContextResolverTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/i18n/DataprepLocaleContextResolverTest.java
@@ -79,6 +79,19 @@ public class DataprepLocaleContextResolverTest {
     }
 
     @Test
+    public void resolveLocaleContextWithMissingLocaleSupport() throws Exception {
+        DataprepLocaleContextResolver resolver = new DataprepLocaleContextResolver(Locale.US.getLanguage());
+        when(request.getHeader(eq(HttpHeaders.ACCEPT_LANGUAGE))).thenReturn("fr"); // Use constant to mimic IAM's
+                                                                                   // behavior
+        when(request.getLocale()).thenReturn(Locale.FRENCH);
+        when(request.getLocales()).thenReturn(Collections.enumeration(Collections.singletonList(Locale.US)));
+
+        Locale locale = resolver.resolveLocale(request);
+        assertNotNull(locale);
+        assertEquals(Locale.FRENCH, locale);
+    }
+
+    @Test
     public void resolveLocaleContextWithMalformedLocale() throws Exception {
         DataprepLocaleContextResolver resolver = new DataprepLocaleContextResolver("@@&&");
 


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4172

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
