### PR TITLE
Revert "fix(TDP-4926): bug change date format statistics (#1095)"

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/ActionsUtils.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/ActionsUtils.java
@@ -11,19 +11,19 @@
 
 package org.talend.dataprep.transformation.actions.common;
 
-import org.apache.commons.lang.StringUtils;
-import org.talend.dataprep.api.dataset.ColumnMetadata;
-import org.talend.dataprep.api.dataset.RowMetadata;
-import org.talend.dataprep.api.type.Type;
-import org.talend.dataprep.parameters.Parameter;
-import org.talend.dataprep.transformation.api.action.context.ActionContext;
+import static org.talend.dataprep.parameters.ParameterType.BOOLEAN;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.talend.dataprep.parameters.ParameterType.BOOLEAN;
+import org.apache.commons.lang.StringUtils;
+import org.talend.dataprep.api.dataset.ColumnMetadata;
+import org.talend.dataprep.api.dataset.RowMetadata;
+import org.talend.dataprep.api.type.Type;
+import org.talend.dataprep.parameters.Parameter;
+import org.talend.dataprep.transformation.api.action.context.ActionContext;
 
 public class ActionsUtils {
 
@@ -65,42 +65,42 @@ public class ActionsUtils {
 
     /**
      * Used by compile(ActionContext actionContext), evaluate if a new column needs to be created, if yes creates one.
-     * <p>
+     *
      * Actions that creates more than one column ('split', 'extract email parts', etc...) should manage this on their own.
      */
     public static void createNewColumn(ActionContext context, List<AdditionalColumn> additionalColumns) {
         String columnId = context.getColumnId();
         RowMetadata rowMetadata = context.getRowMetadata();
 
-        context.evict(TARGET_COLUMN_CONTEXT_KEY);
-        context.get(TARGET_COLUMN_CONTEXT_KEY, r -> createNewColumnsImpl(context, additionalColumns, columnId, rowMetadata));
+        context.evict(TARGET_COLUMN_CONTEXT_KEY);context.get(TARGET_COLUMN_CONTEXT_KEY, r -> createNewColumnsImpl(context, additionalColumns, columnId, rowMetadata));
     }
 
-    private static Map<String, String> createNewColumnsImpl(ActionContext context, List<AdditionalColumn> additionalColumns, String columnId, RowMetadata rowMetadata) {
-        final Map<String, String> cols = new HashMap<>();
-        String nextId = columnId; // id of the column to put the new one after, initially the current column
-        for (AdditionalColumn additionalColumn : additionalColumns) {
-            ColumnMetadata.Builder brandNewColumnBuilder = ColumnMetadata.Builder.column();
-            // it's often important to copy the original column type for the action which needs statistics
-            if (additionalColumn.getCopyMetadataFromId() != null) {
-                ColumnMetadata newColumn = context.getRowMetadata().getById(additionalColumn.getCopyMetadataFromId());
-                brandNewColumnBuilder.copy(newColumn).computedId(StringUtils.EMPTY);
-                brandNewColumnBuilder.type(Type.get(newColumn.getType()));
-            } else {
-                brandNewColumnBuilder.type(additionalColumn.getType());
+    private static Map<String, String> createNewColumnsImpl(ActionContext context, List<AdditionalColumn> additionalColumns, String columnId, RowMetadata rowMetadata){
+            final Map<String, String> cols = new HashMap<>();
+            String nextId = columnId; // id of the column to put the new one after, initially the current column
+            for (AdditionalColumn additionalColumn : additionalColumns) {
+                ColumnMetadata.Builder brandNewColumnBuilder = ColumnMetadata.Builder.column();
+
+                if (additionalColumn.getCopyMetadataFromId() != null) {
+                    ColumnMetadata newColumn = context.getRowMetadata().getById(additionalColumn.getCopyMetadataFromId());
+                    brandNewColumnBuilder.copy(newColumn).computedId(StringUtils.EMPTY);
+                    brandNewColumnBuilder.type(Type.get(newColumn.getType()));
+                } else {
+                    brandNewColumnBuilder.type(additionalColumn.getType());
+                }if (additionalColumn.getName() != null) {
+                brandNewColumnBuilder.name(additionalColumn.getName());}
+                ColumnMetadata columnMetadata = brandNewColumnBuilder.build();
+                rowMetadata.insertAfter(nextId, columnMetadata);
+                nextId = columnMetadata.getId(); // the new column to put next one after, is the fresh new one
+                cols.put(additionalColumn.getKey(), columnMetadata.getId());
             }
-            brandNewColumnBuilder.name(additionalColumn.getName());
-            ColumnMetadata columnMetadata = brandNewColumnBuilder.build();
-            rowMetadata.insertAfter(nextId, columnMetadata);
-            nextId = columnMetadata.getId(); // the new column to put next one after, is the fresh new one
-            cols.put(additionalColumn.getKey(), columnMetadata.getId());
-        }
-        return cols;
+            return cols;
+
     }
 
     /**
      * Helper to retrieve the target column Id stored in the context.
-     * <p>
+     *
      * It can be the current column id if the function applies in place or id of the new column if the function creates one.
      * Must not be used for function that creates many columns. Use getTargetColumnIds(ActionContext context) instead in this case.
      *
@@ -129,7 +129,7 @@ public class ActionsUtils {
      * For TDP-3798, add a checkbox for most actions to allow the user to choose if action is applied in place or if it
      * creates a new column.
      * This method is used by framework to evaluate if this step (action+parameters) creates a new column or is applied in place.
-     * <p>
+     *
      * For most actions, the default implementation is ok, but some actions (like 'split' that always creates new column) may
      * override it. In this case, no need to override createNewColumnParamVisible() and true.
      *
@@ -148,7 +148,7 @@ public class ActionsUtils {
 
     /**
      * Bean used to described all columns that can be created by a function.
-     * <p>
+     *
      * This will be used by createNewColumn(ActionContext context) to create all the new columns.
      */
     public static final class AdditionalColumn {

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/ChangeDatePattern.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/ChangeDatePattern.java
@@ -32,11 +32,7 @@ import org.talend.dataprep.transformation.api.action.context.ActionContext;
 
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -103,53 +99,38 @@ public class ChangeDatePattern extends AbstractDate implements ColumnAction {
     @Override
     public void compile(ActionContext actionContext) {
         super.compile(actionContext);
-        boolean doesCreateNewColumn = ActionsUtils.doesCreateNewColumn(actionContext.getParameters(), CREATE_NEW_COLUMN_DEFAULT);
-
-        if (doesCreateNewColumn) {
-            ActionsUtils.createNewColumn(actionContext, singletonList(ActionsUtils.additionalColumn().withName(actionContext.getColumnName() + NEW_COLUMN_SUFFIX).withCopyMetadataFromId(actionContext.getColumnId())));
+        if (ActionsUtils.doesCreateNewColumn(actionContext.getParameters(), CREATE_NEW_COLUMN_DEFAULT)) {
+            ActionsUtils.createNewColumn(actionContext, singletonList(ActionsUtils.additionalColumn().withName(actionContext.getColumnName() + NEW_COLUMN_SUFFIX)));
         }
-
         if (actionContext.getActionStatus() == OK) {
             compileDatePattern(actionContext);
 
-            if (actionContext.getActionStatus() == OK) {
-                // register the new pattern in column's stats as the most used pattern,
-                // to be able to process date action more efficiently later
-                final DatePattern newPattern = actionContext.get(COMPILED_DATE_PATTERN);
+            // register the new pattern in column stats as most used pattern, to be able to process date action more
+            // efficiently later
+            final DatePattern newPattern = actionContext.get(COMPILED_DATE_PATTERN);
+            final RowMetadata rowMetadata = actionContext.getRowMetadata();
+            final String columnId = actionContext.getColumnId();
+            final ColumnMetadata column = rowMetadata.getById(columnId);
+            final Statistics statistics = column.getStatistics();
 
-                final RowMetadata rowMetadata = actionContext.getRowMetadata();
-
-                // target column
-                String targetId = ActionsUtils.getTargetColumnId(actionContext);
-                final ColumnMetadata targetColumn = rowMetadata.getById(targetId);
-
-                // origin column
-                final String columnId = actionContext.getColumnId();
-                final ColumnMetadata column = rowMetadata.getById(columnId);
-
-                // if the target column is not the original column, we souldn't use the same statitics object
-                final Statistics statistics;
-                if (doesCreateNewColumn) {
-                    statistics = new Statistics(column.getStatistics());
-                    targetColumn.setStatistics(statistics);
-                } else {
-                    statistics = targetColumn.getStatistics();
-                }
-
-                actionContext.get(FROM_DATE_PATTERNS, p -> compileFromDatePattern(actionContext));
-
-                final PatternFrequency newPatternFrequency = statistics.getPatternFrequencies().stream()
-                        .filter(patternFrequency -> StringUtils.equals(patternFrequency.getPattern(), newPattern.getPattern()))
-                        .findFirst().orElseGet(() -> {
-                            final PatternFrequency newPatternFreq = new PatternFrequency(newPattern.getPattern(), 0);
-                            statistics.getPatternFrequencies().add(newPatternFreq);
-                            return newPatternFreq;
-                        });
-
-                long mostUsedPatternCount = getMostUsedPatternCount(column);
-                newPatternFrequency.setOccurrences(mostUsedPatternCount + 1);
-                rowMetadata.update(targetId, targetColumn);
+            final ColumnMetadata targetColumn = rowMetadata.getById(ActionsUtils.getTargetColumnId(actionContext));
+            if (!Objects.equals(targetColumn.getId(), columnId)) {
+                targetColumn.setStatistics(statistics);
             }
+
+            actionContext.get(FROM_DATE_PATTERNS, p -> compileFromDatePattern(actionContext));
+
+            final PatternFrequency newPatternFrequency = statistics.getPatternFrequencies().stream()
+                    .filter(patternFrequency -> StringUtils.equals(patternFrequency.getPattern(), newPattern.getPattern()))
+                    .findFirst().orElseGet(() -> {
+                        final PatternFrequency newPatternFreq = new PatternFrequency(newPattern.getPattern(), 0);
+                        statistics.getPatternFrequencies().add(newPatternFreq);
+                        return newPatternFreq;
+                    });
+
+            long mostUsedPatternCount = getMostUsedPatternCount(column);
+            newPatternFrequency.setOccurrences(mostUsedPatternCount + 1);
+            rowMetadata.update(ActionsUtils.getTargetColumnId(actionContext), targetColumn);
         }
     }
 

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/DateCalendarConverter.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/DateCalendarConverter.java
@@ -19,7 +19,6 @@ import org.talend.dataprep.api.action.Action;
 import org.talend.dataprep.api.dataset.ColumnMetadata;
 import org.talend.dataprep.api.dataset.RowMetadata;
 import org.talend.dataprep.api.dataset.row.DataSetRow;
-import org.talend.dataprep.api.dataset.statistics.Statistics;
 import org.talend.dataprep.api.type.Type;
 import org.talend.dataprep.parameters.Parameter;
 import org.talend.dataprep.transformation.actions.Providers;
@@ -159,9 +158,6 @@ public class DateCalendarConverter extends AbstractActionMetadata implements Col
         super.compile(actionContext);
         if (ActionsUtils.doesCreateNewColumn(actionContext.getParameters(), CREATE_NEW_COLUMN_DEFAULT)) {
             ActionsUtils.createNewColumn(actionContext, singletonList(ActionsUtils.additionalColumn().withName(actionContext.getColumnName() + NEW_COLUMN_SUFFIX)));
-            ColumnMetadata targetColumn = actionContext.getRowMetadata().getById(ActionsUtils.getTargetColumnId(actionContext));
-            ColumnMetadata originalColumn = actionContext.getRowMetadata().getById(actionContext.getColumnId());
-            targetColumn.setStatistics(new Statistics(originalColumn.getStatistics()));
         }
         if (actionContext.getActionStatus() == OK) {
             dateCalendarConverterMap = new HashMap<>();

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokens.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokens.java
@@ -271,7 +271,7 @@ public class ExtractDateTokens extends AbstractDate implements ColumnAction {
 
     @Override
     public Set<Behavior> getBehavior() {
-        return EnumSet.of(Behavior.METADATA_CREATE_COLUMNS, Behavior.NEED_STATISTICS_PATTERN);
+        return EnumSet.of(Behavior.METADATA_CREATE_COLUMNS);
     }
 
     private static class DateFieldMappingBean {

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/text/Trim.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/text/Trim.java
@@ -12,26 +12,6 @@
 
 package org.talend.dataprep.transformation.actions.text;
 
-import org.talend.dataprep.api.action.Action;
-import org.talend.dataprep.api.action.ActionDefinition;
-import org.talend.dataprep.api.dataset.ColumnMetadata;
-import org.talend.dataprep.api.dataset.row.DataSetRow;
-import org.talend.dataprep.api.type.Type;
-import org.talend.dataprep.parameters.Parameter;
-import org.talend.dataprep.parameters.ParameterType;
-import org.talend.dataprep.transformation.actions.category.ActionCategory;
-import org.talend.dataprep.transformation.actions.category.ScopeCategory;
-import org.talend.dataprep.transformation.actions.common.AbstractMultiScopeAction;
-import org.talend.dataprep.transformation.actions.common.ActionsUtils;
-import org.talend.dataprep.transformation.api.action.context.ActionContext;
-import org.talend.dataquality.converters.StringTrimmer;
-
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang.StringUtils.EMPTY;
 import static org.talend.dataprep.api.type.Type.STRING;
@@ -40,6 +20,24 @@ import static org.talend.dataprep.parameters.SelectParameter.selectParameter;
 import static org.talend.dataprep.transformation.actions.category.ScopeCategory.COLUMN;
 import static org.talend.dataprep.transformation.actions.category.ScopeCategory.DATASET;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.OK;
+
+import java.util.*;
+
+import org.talend.dataprep.api.action.Action;
+import org.talend.dataprep.api.action.ActionDefinition;
+import org.talend.dataprep.api.dataset.ColumnMetadata;
+import org.talend.dataprep.api.dataset.row.DataSetRow;
+import org.talend.dataprep.api.type.Type;
+import org.talend.dataprep.parameters.Parameter;
+import org.talend.dataprep.parameters.ParameterType;
+import org.talend.dataprep.transformation.actions.category.ActionCategory;
+
+import org.talend.dataprep.transformation.actions.category.ScopeCategory;
+import org.talend.dataprep.transformation.actions.common.AbstractMultiScopeAction;
+import org.talend.dataprep.transformation.actions.common.ActionsUtils;
+
+import org.talend.dataprep.transformation.api.action.context.ActionContext;
+import org.talend.dataquality.converters.StringTrimmer;
 
 /**
  * Trim leading and trailing characters.
@@ -52,19 +50,13 @@ public class Trim extends AbstractMultiScopeAction {
      */
     public static final String TRIM_ACTION_NAME = "trim"; //$NON-NLS-1$
 
-    /**
-     * Padding Character.
-     */
+    /** Padding Character. */
     static final String PADDING_CHAR_PARAMETER = "padding_character"; //$NON-NLS-1$
 
-    /**
-     * Custom Padding Character.
-     */
+    /** Custom Padding Character. */
     static final String CUSTOM_PADDING_CHAR_PARAMETER = "custom_padding_character"; //$NON-NLS-1$
 
-    /**
-     * String Converter help class.
-     */
+    /** String Converter help class. */
     private static final String STRING_TRIMMER = "string_trimmer"; //$NON-NLS-1$
 
     /**
@@ -103,8 +95,7 @@ public class Trim extends AbstractMultiScopeAction {
 
     protected List<ActionsUtils.AdditionalColumn> getAdditionalColumns(ActionContext context) {
         return singletonList(
-                ActionsUtils.additionalColumn().withName(context.getColumnName() + NEW_COLUMN_SUFFIX).withType(STRING)
-                        .withCopyMetadataFromId(context.getColumnId()));
+                ActionsUtils.additionalColumn().withName(context.getColumnName() + NEW_COLUMN_SUFFIX).withType(STRING));
     }
 
     @Override
@@ -117,11 +108,11 @@ public class Trim extends AbstractMultiScopeAction {
         // @formatter:off
         parameters.add(selectParameter(locale)
                 .name(PADDING_CHAR_PARAMETER)
-                .item(WHITESPACE, WHITESPACE)
+                .item(WHITESPACE,WHITESPACE)
                 .item(CUSTOM, CUSTOM, parameter(locale).setName(CUSTOM_PADDING_CHAR_PARAMETER).setType(ParameterType.STRING).setDefaultValue(EMPTY).build(this))
                 .canBeBlank(true)
                 .defaultValue(WHITESPACE)
-                .build(this));
+                .build(this ));
         // @formatter:on
         return parameters;
     }
@@ -161,9 +152,9 @@ public class Trim extends AbstractMultiScopeAction {
     @Override
     public Set<Behavior> getBehavior() {
         if (DATASET.equals(scope)) {
-            return EnumSet.of(Behavior.VALUES_ALL, Behavior.NEED_STATISTICS_PATTERN);
+            return EnumSet.of(Behavior.VALUES_ALL);
         } else {
-            return EnumSet.of(Behavior.VALUES_COLUMN, Behavior.NEED_STATISTICS_PATTERN);
+            return EnumSet.of(Behavior.VALUES_COLUMN);
         }
     }
 

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/ActionMetadataTestUtils.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/ActionMetadataTestUtils.java
@@ -101,13 +101,4 @@ public class ActionMetadataTestUtils {
         return builder.build();
     }
 
-    public static DataSetRow getTypedRow(Type type, String... values) {
-        AbstractMetadataBaseTest.ValuesBuilder builder = builder();
-        DecimalFormat format = new DecimalFormat("0000");
-        for (int i = 0; i < values.length; i++) {
-            builder = builder.with(value(values[i]).type(type).name(format.format(i)));
-        }
-        return builder.build();
-    }
-
 }

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ChangeDatePatternTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ChangeDatePatternTest.java
@@ -29,25 +29,14 @@ import org.talend.dataprep.transformation.actions.common.ImplicitParameters;
 import org.talend.dataprep.transformation.api.action.ActionTestWorkbench;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
 import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValueBuilder.value;
 import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValuesBuilder.builder;
-import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getColumn;
-import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getRow;
-import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.setStatistics;
+import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.*;
 import static org.talend.dataprep.transformation.actions.common.ActionsUtils.CREATE_NEW_COLUMN;
 
 /**
@@ -155,51 +144,19 @@ public class ChangeDatePatternTest extends BaseDateTest<ChangeDatePattern> {
     @Test
     public void test_apply_in_newcolumn() throws Exception {
         // given
-        final DataSetRow row1 = builder() //
+        final DataSetRow row = builder() //
                 .with(value("toto").type(Type.STRING).name("recipe")) //
-                .with(value("04/25/1999").type(Type.DATE).name("last update").statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
-                .with(value("tata").type(Type.STRING).name("recipe")) //
-                .build();
-        final DataSetRow row2 = builder() //
-                .with(value("tata").type(Type.STRING).name("recipe")) //
-                .with(value("01/22/2018").type(Type.DATE).name("last update").statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
-                .with(value("toto").type(Type.STRING).name("recipe")) //
-                .build();
-        final DataSetRow row3 = builder() //
-                .with(value("tata").type(Type.STRING).name("recipe")) //
-                .with(value("22/01/2018").type(Type.DATE).name("last update").statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
-                .with(value("toto").type(Type.STRING).name("recipe")) //
+                .with(value("04/25/1999").type(Type.STRING).name("recipe").statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
+                .with(value("tata").type(Type.DATE).name("last update")) //
                 .build();
         parameters.put(CREATE_NEW_COLUMN, "true");
 
-        // then
-        assertEquals(7, row1.getRowMetadata().getColumns().get(1).getStatistics().getPatternFrequencies().size());
-
         // when
-        ActionTestWorkbench.test(Arrays.asList(row1, row2, row3), actionRegistry, factory.create(action, parameters));
+        ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
-        final DataSetRow expectedRow1 = getRow("toto", "04/25/1999", "tata", "25 - Apr - 1999");
-        final DataSetRow expectedRow2 = getRow("tata", "01/22/2018", "toto", "22 - Jan - 2018");
-        final DataSetRow expectedRow3 = getRow("tata", "22/01/2018", "toto");
-        assertEquals(expectedRow1.values(), row1.values());
-        assertEquals(expectedRow2.values(), row2.values());
-        assertEquals(expectedRow3.values(), row3.values());
-
-        ColumnMetadata column1 = row1.getRowMetadata().getColumns().get(1);
-        ColumnMetadata column2 = row1.getRowMetadata().getColumns().get(2);
-        List<PatternFrequency> listPatternFirstColumn = column1.getStatistics().getPatternFrequencies();
-        List<PatternFrequency> listPatternSecondColumn = column2.getStatistics().getPatternFrequencies();
-
-        // check that the stats on the from column are not changed
-        assertEquals(7, listPatternFirstColumn.size());
-        assertEquals("MM/dd/yyyy", listPatternSecondColumn.get(0).getPattern());
-        // check that the stats on the target column are changed, and the new target pattern is added to the known ones
-        assertEquals(8, listPatternSecondColumn.size());
-        assertEquals("dd - MMM - yyyy", listPatternSecondColumn.get(7).getPattern());
-        // the new added pattern should had the biggest frequency : so it is the old most used pattern count + 1
-        assertEquals(listPatternSecondColumn.get(7).getOccurrences(),
-                listPatternSecondColumn.get(0).getOccurrences() + 1);
+        final DataSetRow expectedRow = getRow("toto", "04/25/1999", "tata", "25 - Apr - 1999");
+        assertEquals(expectedRow.values(), row.values());
     }
 
     @Test
@@ -290,9 +247,9 @@ public class ChangeDatePatternTest extends BaseDateTest<ChangeDatePattern> {
     public void should_set_new_pattern_as_most_used_one() throws Exception {
         // given
         final DataSetRow row = builder() //
-                .with(value("toto").type(Type.STRING).name("tips")) //
-                .with(value("04/25/1999").type(Type.DATE).name("date").statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
-                .with(value("tata").type(Type.STRING).name("test")) //
+                .with(value("toto").type(Type.STRING).name("recipe")) //
+                .with(value("04/25/1999").type(Type.STRING).name("recipe").statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
+                .with(value("tata").type(Type.DATE).name("last update")) //
                 .build();
 
         // when
@@ -319,8 +276,8 @@ public class ChangeDatePatternTest extends BaseDateTest<ChangeDatePattern> {
         // given
         final DataSetRow row = builder() //
                 .with(value("toto").type(Type.STRING).name("recipe")) //
-                .with(value("04/25/1999").type(Type.DATE).name("recipe").statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
-                .with(value("tata").type(Type.STRING).name("last update")) //
+                .with(value("04/25/1999").type(Type.STRING).name("recipe").statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
+                .with(value("tata").type(Type.DATE).name("last update")) //
                 .build();
         parameters.put(CREATE_NEW_COLUMN, "true");
 

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ComputeTimeSinceTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ComputeTimeSinceTest.java
@@ -12,11 +12,33 @@
 //  ============================================================================
 package org.talend.dataprep.transformation.actions.date;
 
+import static java.time.temporal.ChronoUnit.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
+import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValueBuilder.value;
+import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValuesBuilder.builder;
+import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getColumn;
+import static org.talend.dataprep.transformation.actions.common.OtherColumnParameters.OTHER_COLUMN_MODE;
+import static org.talend.dataprep.transformation.actions.common.OtherColumnParameters.SELECTED_COLUMN_PARAMETER;
+import static org.talend.dataprep.transformation.actions.date.ComputeTimeSince.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.util.*;
+
 import org.apache.commons.lang.StringUtils;
 import org.assertj.core.data.MapEntry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.talend.dataprep.api.action.ActionDefinition;
 import org.talend.dataprep.api.dataset.ColumnMetadata;
 import org.talend.dataprep.api.dataset.row.DataSetRow;
 import org.talend.dataprep.api.type.Type;
@@ -26,41 +48,6 @@ import org.talend.dataprep.transformation.actions.ActionMetadataTestUtils;
 import org.talend.dataprep.transformation.actions.category.ActionCategory;
 import org.talend.dataprep.transformation.actions.common.ActionsUtils;
 import org.talend.dataprep.transformation.api.action.ActionTestWorkbench;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.Temporal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TreeMap;
-
-import static java.time.temporal.ChronoUnit.DAYS;
-import static java.time.temporal.ChronoUnit.HOURS;
-import static java.time.temporal.ChronoUnit.MONTHS;
-import static java.time.temporal.ChronoUnit.YEARS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
-import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValueBuilder.value;
-import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValuesBuilder.builder;
-import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getColumn;
-import static org.talend.dataprep.transformation.actions.common.OtherColumnParameters.OTHER_COLUMN_MODE;
-import static org.talend.dataprep.transformation.actions.common.OtherColumnParameters.SELECTED_COLUMN_PARAMETER;
-import static org.talend.dataprep.transformation.actions.date.ComputeTimeSince.Behavior;
-import static org.talend.dataprep.transformation.actions.date.ComputeTimeSince.SINCE_WHEN_PARAMETER;
-import static org.talend.dataprep.transformation.actions.date.ComputeTimeSince.SPECIFIC_DATE_MODE;
-import static org.talend.dataprep.transformation.actions.date.ComputeTimeSince.SPECIFIC_DATE_PARAMETER;
-import static org.talend.dataprep.transformation.actions.date.ComputeTimeSince.TIME_UNIT_PARAMETER;
 
 /**
  * Test class for ComputeTimeSince action. Creates one consumer, and test it.
@@ -95,7 +82,7 @@ public class ComputeTimeSinceTest extends BaseDateTest<ComputeTimeSince> {
     }
 
     @Override
-    protected CreateNewColumnPolicy getCreateNewColumnPolicy() {
+    protected CreateNewColumnPolicy getCreateNewColumnPolicy(){
         return CreateNewColumnPolicy.VISIBLE_ENABLED;
     }
 
@@ -587,9 +574,8 @@ public class ComputeTimeSinceTest extends BaseDateTest<ComputeTimeSince> {
 
     @Test
     public void should_have_expected_behavior() {
-        assertEquals(2, action.getBehavior().size());
-        assertTrue(action.getBehavior().contains(Behavior.METADATA_CREATE_COLUMNS));
-        assertTrue(action.getBehavior().contains(Behavior.NEED_STATISTICS_PATTERN));
+        assertEquals(1, action.getBehavior().size());
+        assertTrue(action.getBehavior().contains(ActionDefinition.Behavior.METADATA_CREATE_COLUMNS));
     }
 
 }

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
@@ -350,9 +350,8 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
 
     @Test
     public void should_have_expected_behavior() {
-        assertEquals(2, action.getBehavior().size());
+        assertEquals(1, action.getBehavior().size());
         assertTrue(action.getBehavior().contains(ActionDefinition.Behavior.METADATA_CREATE_COLUMNS));
-        assertTrue(action.getBehavior().contains(ActionDefinition.Behavior.NEED_STATISTICS_PATTERN));
     }
 
 }

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/math/ExtractNumberTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/math/ExtractNumberTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
 import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getColumn;
 import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getRow;
-import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getTypedRow;
 
 import java.io.InputStream;
 import java.util.*;
@@ -26,7 +25,6 @@ import java.util.*;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.talend.dataprep.api.action.ActionDefinition;
 import org.talend.dataprep.api.dataset.ColumnMetadata;
@@ -245,7 +243,7 @@ public class ExtractNumberTest extends AbstractMetadataBaseTest<ExtractNumber> {
 
     private void inner_test(String from, String expected, Type expectedType) {
         // given
-        DataSetRow row = getTypedRow(Type.DOUBLE, from);
+        DataSetRow row = getRow(from);
         Assertions.assertThat(row.getRowMetadata().getColumns()).isNotEmpty().hasSize(1);
 
         // when

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/text/TrimTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/text/TrimTest.java
@@ -227,9 +227,8 @@ public class TrimTest extends AbstractMetadataBaseTest<Trim> {
 
     @Test
     public void should_have_expected_behavior() {
-        assertEquals(2, action.getBehavior().size());
+        assertEquals(1, action.getBehavior().size());
         assertTrue(action.getBehavior().contains(ActionDefinition.Behavior.VALUES_COLUMN));
-        assertTrue(action.getBehavior().contains(ActionDefinition.Behavior.NEED_STATISTICS_PATTERN));
     }
 
 }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/ColumnMetadata.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/ColumnMetadata.java
@@ -13,22 +13,22 @@
 
 package org.talend.dataprep.api.dataset;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import static java.util.Collections.emptyList;
+
+import java.io.Serializable;
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import org.apache.commons.lang.StringUtils;
 import org.talend.dataprep.api.dataset.row.FlagNames;
 import org.talend.dataprep.api.dataset.statistics.SemanticDomain;
 import org.talend.dataprep.api.dataset.statistics.Statistics;
 import org.talend.dataprep.api.type.Type;
 
-import java.io.Serializable;
-import java.text.DecimalFormat;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import static java.util.Collections.emptyList;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Represents information about a column in a data set. It includes:
@@ -36,54 +36,38 @@ import static java.util.Collections.emptyList;
  * <li>Name ({@link #getId()})</li>
  * <li>Type ({@link #getType()})</li>
  * </ul>
- *
+ * 
  * @see ColumnMetadata.Builder
  */
 public class ColumnMetadata implements Serializable {
 
-    /**
-     * Serialization UID.
-     */
+    /** Serialization UID. */
     private static final long serialVersionUID = 1L;
 
-    /**
-     * Quality of the column.
-     */
+    /** Quality of the column. */
     @JsonProperty("quality")
     private final Quality quality = new Quality();
 
-    /**
-     * Technical id of the column (generated when instantiated).
-     */
+    /** Technical id of the column (generated when instantiated). */
     @JsonProperty("id")
     private String id;
 
-    /**
-     * Human readable name of the column.
-     */
+    /** Human readable name of the column. */
     private String name;
 
-    /**
-     * Type of the column (N/A as default).
-     */
+    /** Type of the column (N/A as default). */
     @JsonProperty("type")
     private String typeName = "N/A"; //$NON-NLS-1$
 
-    /**
-     * Number of first lines with a text header (none per default).
-     */
+    /** Number of first lines with a text header (none per default). */
     private int headerSize = 0;
 
-    /**
-     * Optional diff flag that shows diff status of this column metadata.
-     */
+    /** Optional diff flag that shows diff status of this column metadata. */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonProperty(value = FlagNames.COLUMN_DIFF_KEY)
     private String diffFlagValue;
 
-    /**
-     * Statistics of the column.
-     */
+    /** Statistics of the column. */
     @JsonProperty("statistics")
     private Statistics statistics = new Statistics();
 
@@ -99,15 +83,11 @@ public class ColumnMetadata implements Serializable {
     @JsonProperty("semanticDomains")
     private List<SemanticDomain> semanticDomains = emptyList();
 
-    /**
-     * if the domain has been changed/forced manually by the user
-     */
+    /** if the domain has been changed/forced manually by the user */
     @JsonProperty("domainForced")
     private boolean domainForced;
 
-    /**
-     * if the type has been changed/forced manually by the user
-     */
+    /** if the type has been changed/forced manually by the user */
     @JsonProperty("typeForced")
     private boolean typeForced;
 
@@ -121,7 +101,7 @@ public class ColumnMetadata implements Serializable {
     /**
      * Create a column metadata from the given parameters.
      *
-     * @param name     the column name.
+     * @param name the column name.
      * @param typeName the column type.
      */
     private ColumnMetadata(String name, String typeName) {
@@ -330,49 +310,31 @@ public class ColumnMetadata implements Serializable {
      */
     public static class Builder {
 
-        /**
-         * The column id.
-         */
+        /** The column id. */
         private String id;
 
-        /**
-         * The column name.
-         */
+        /** The column name. */
         private String name;
 
-        /**
-         * The column type.
-         */
+        /** The column type. */
         private Type type;
 
-        /**
-         * The column empty value.
-         */
+        /** The column empty value. */
         private int empty;
 
-        /**
-         * The column invalid value count.
-         */
+        /** The column invalid value count. */
         private int invalid;
 
-        /**
-         * The column valid value count.
-         */
+        /** The column valid value count. */
         private int valid;
 
-        /**
-         * The column header size.
-         */
+        /** The column header size. */
         private int headerSize;
 
-        /**
-         * The column diff flag (null by default).
-         */
+        /** The column diff flag (null by default). */
         private String diffFlagValue = null;
 
-        /**
-         * The column statistics.
-         */
+        /** The column statistics. */
         private Statistics statistics;
 
         private String domain;
@@ -396,7 +358,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Set the name of the column.
-         *
+         * 
          * @param name the name of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -407,7 +369,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Set the id of the column.
-         *
+         * 
          * @param id the id of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -440,7 +402,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Set the type of the column.
-         *
+         * 
          * @param type the type of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -454,7 +416,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Set the empty value of the column.
-         *
+         * 
          * @param value the empty value of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -465,7 +427,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Set the invalid value of the column.
-         *
+         * 
          * @param value the invalid value of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -476,7 +438,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Set the valid value of the column.
-         *
+         * 
          * @param value the valid value of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -487,7 +449,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Set the header size value of the column.
-         *
+         * 
          * @param headerSize the header size value of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -497,6 +459,7 @@ public class ColumnMetadata implements Serializable {
         }
 
         /**
+         *
          * @param domain the domain value of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -506,6 +469,7 @@ public class ColumnMetadata implements Serializable {
         }
 
         /**
+         *
          * @param domainLabel the domain label value of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -515,6 +479,7 @@ public class ColumnMetadata implements Serializable {
         }
 
         /**
+         *
          * @param domainFrequency the frequency of value with this domain of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -524,6 +489,7 @@ public class ColumnMetadata implements Serializable {
         }
 
         /**
+         *
          * @param semanticDomains the semantic domains of the column to set.
          * @return the builder to carry on building the column.
          */
@@ -533,6 +499,7 @@ public class ColumnMetadata implements Serializable {
         }
 
         /**
+         *
          * @param semanticDomainForced if semantic domain has been forced on this column.
          * @return the builder to carry on building the column.
          */
@@ -542,6 +509,7 @@ public class ColumnMetadata implements Serializable {
         }
 
         /**
+         *
          * @param typeForced if type has been forced on this column.
          * @return the builder to carry on building the column.
          */
@@ -552,7 +520,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Copy the column from the given one.
-         *
+         * 
          * @param original the column to copy.
          * @return the builder to carry on building the column.
          */
@@ -578,7 +546,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Copy the column metadata type (without statistics)
-         *
+         * 
          * @param original the original column to copy.
          * @return the column metadata that only match the type.
          */
@@ -597,7 +565,7 @@ public class ColumnMetadata implements Serializable {
 
         /**
          * Build the column with the previously entered values.
-         *
+         * 
          * @return the built column metadata.
          */
         public ColumnMetadata build() {

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/statistics/Quantiles.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/statistics/Quantiles.java
@@ -13,15 +13,13 @@
 
 package org.talend.dataprep.api.dataset.statistics;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Quantiles implements Serializable {
 
-    /**
-     * Serialization UID.
-     */
+    /** Serialization UID. */
     private static final long serialVersionUID = 1L;
 
     @JsonProperty("median")
@@ -32,15 +30,6 @@ public class Quantiles implements Serializable {
 
     @JsonProperty("upperQuantile")
     private double upperQuantile = Double.NaN;
-
-    Quantiles() {
-    }
-
-    Quantiles(Quantiles originalQuantiles) {
-        this.median = originalQuantiles.median;
-        this.lowerQuantile = originalQuantiles.lowerQuantile;
-        this.upperQuantile = originalQuantiles.upperQuantile;
-    }
 
     public double getMedian() {
         return median;
@@ -104,5 +93,4 @@ public class Quantiles implements Serializable {
         result = 31 * result + (int) (temp ^ (temp >>> 32));
         return result;
     }
-
 }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/statistics/Statistics.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/statistics/Statistics.java
@@ -13,16 +13,16 @@
 
 package org.talend.dataprep.api.dataset.statistics;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
-
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
 @JsonRootName("statistics")
-public class Statistics implements Cloneable, Serializable {
+public class Statistics implements Serializable {
 
     /**
      * Serialization UID.
@@ -73,27 +73,6 @@ public class Statistics implements Cloneable, Serializable {
 
     @JsonProperty("textLengthSummary")
     private TextLengthSummary textLengthSummary = new TextLengthSummary();
-
-    public Statistics() {
-    }
-
-    public Statistics(Statistics original) {
-        this.count = original.count;
-        this.valid = original.valid;
-        this.invalid = original.invalid;
-        this.empty = original.empty;
-        this.max = original.max;
-        this.min = original.min;
-        this.mean = original.mean;
-        this.variance = original.variance;
-        this.distinctCount = original.distinctCount;
-        this.duplicateCount = original.duplicateCount;
-        this.dataFrequencies = new LinkedList<>(original.dataFrequencies);
-        this.patternFrequencies = new LinkedList<>(original.patternFrequencies);
-        this.quantiles = original.quantiles == null ? new Quantiles() : new Quantiles(original.quantiles);
-        this.histogram = original.histogram;
-        this.textLengthSummary = original.textLengthSummary == null ? new TextLengthSummary() : new TextLengthSummary(original.textLengthSummary);
-    }
 
     public long getCount() {
         return count;

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/statistics/TextLengthSummary.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/statistics/TextLengthSummary.java
@@ -13,16 +13,17 @@
 
 package org.talend.dataprep.api.dataset.statistics;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TextLengthSummary implements Serializable {
 
-    /**
-     * Serialization UID.
-     */
+    /** Serialization UID. */
     private static final long serialVersionUID = 1L;
+
+    public TextLengthSummary() {
+    }
 
     @JsonProperty("minimalLength")
     private double minimalLength = Double.NaN;
@@ -32,15 +33,6 @@ public class TextLengthSummary implements Serializable {
 
     @JsonProperty("averageLength")
     private double averageLength = Double.NaN;
-
-    TextLengthSummary() {
-    }
-
-    TextLengthSummary(TextLengthSummary originalTextLengthSummary) {
-        this.minimalLength = originalTextLengthSummary.minimalLength;
-        this.maximalLength = originalTextLengthSummary.maximalLength;
-        this.averageLength = originalTextLengthSummary.averageLength;
-    }
 
     public double getMinimalLength() {
         return minimalLength;

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/quality/AnalyzerService.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/quality/AnalyzerService.java
@@ -15,7 +15,13 @@ package org.talend.dataprep.quality;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/Pipeline.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/Pipeline.java
@@ -12,6 +12,21 @@
 
 package org.talend.dataprep.transformation.pipeline;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.slf4j.Logger;
 import org.talend.dataprep.api.action.ActionDefinition;
 import org.talend.dataprep.api.dataset.DataSet;
@@ -32,38 +47,17 @@ import org.talend.dataprep.transformation.pipeline.node.BasicNode;
 import org.talend.dataprep.transformation.pipeline.node.FilteredNode;
 import org.talend.dataprep.transformation.pipeline.node.LimitNode;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.slf4j.LoggerFactory.getLogger;
-
 public class Pipeline implements Node, RuntimeNode, Serializable {
 
-    /**
-     * This class' logger.
-     */
+    /** This class' logger. */
     private static final Logger LOG = getLogger(Pipeline.class);
 
-    /**
-     * For the Serialization interface.
-     */
+    /** For the Serialization interface. */
     private static final long serialVersionUID = 1L;
 
     private Node node;
 
-    /**
-     * Flag used to know if the pipeline is stopped or not.
-     */
+    /** Flag used to know if the pipeline is stopped or not. */
     private final AtomicBoolean isStopped = new AtomicBoolean();
 
     /**
@@ -216,7 +210,7 @@ public class Pipeline implements Node, RuntimeNode, Serializable {
 
         private PreparationMessage preparation;
 
-        private Function<Step, RowMetadata> previousStepRowMetadataSupplier = s -> null;
+        private Function<Step, RowMetadata> rowMetadataSupplier = s -> null;
 
         private Long limit = null;
 
@@ -224,8 +218,8 @@ public class Pipeline implements Node, RuntimeNode, Serializable {
             return new Builder();
         }
 
-        public Builder withStepMetadataSupplier(Function<Step, RowMetadata> previousStepRowMetadataSupplier) {
-            this.previousStepRowMetadataSupplier = previousStepRowMetadataSupplier;
+        public Builder withStepMetadataSupplier(Function<Step, RowMetadata> rowMetadataSupplier) {
+            this.rowMetadataSupplier = rowMetadataSupplier;
             return this;
         }
 
@@ -347,7 +341,7 @@ public class Pipeline implements Node, RuntimeNode, Serializable {
             if (preparation != null) {
                 LOG.debug("Applying step node transformations...");
                 actionsNode.logStatus(LOG, "Before transformation\n{}");
-                final Node node = StepNodeTransformer.transform(actionsNode, preparation.getSteps(), previousStepRowMetadataSupplier);
+                final Node node = StepNodeTransformer.transform(actionsNode, preparation.getSteps(), rowMetadataSupplier);
                 current.to(node);
                 node.logStatus(LOG, "After transformation\n{}");
             } else {

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/StepNodeTransformation.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/StepNodeTransformation.java
@@ -12,6 +12,14 @@
 
 package org.talend.dataprep.transformation.pipeline;
 
+import static java.util.Optional.ofNullable;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.dataprep.api.dataset.RowMetadata;
@@ -23,14 +31,6 @@ import org.talend.dataprep.transformation.pipeline.node.CompileNode;
 import org.talend.dataprep.transformation.pipeline.node.SourceNode;
 import org.talend.dataprep.transformation.pipeline.node.StepNode;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
-
-import static java.util.Optional.ofNullable;
-
 /**
  * An {@link Visitor} for node that groups all step related nodes into a {@link StepNode}.
  */
@@ -40,7 +40,7 @@ class StepNodeTransformation extends Visitor {
 
     private final Iterator<Step> steps;
 
-    private final Function<Step, RowMetadata> previousStepRowMetadataSupplier;
+    private final Function<Step, RowMetadata> rowMetadataSupplier;
 
     private State DISPATCH = new Dispatch();
 
@@ -54,16 +54,16 @@ class StepNodeTransformation extends Visitor {
      * Build a new visitor to transform nodes into new node pipeline which will eventually use {@link StepNode} if
      * applicable. For each new {@link StepNode}, one of the <code>steps</code> is consumed.
      *
-     * @param steps                           The {@link Step steps} to be used when creating new {@link StepNode}.
-     * @param previousStepRowMetadataSupplier An function that allows this code to fetch {@link RowMetadata} to associate with step.
+     * @param steps The {@link Step steps} to be used when creating new {@link StepNode}.
+     * @param rowMetadataSupplier An function that allows this code to fetch {@link RowMetadata} to associate with step.
      */
-    StepNodeTransformation(List<Step> steps, Function<Step, RowMetadata> previousStepRowMetadataSupplier) {
+    StepNodeTransformation(List<Step> steps, Function<Step, RowMetadata> rowMetadataSupplier) {
         if (!steps.isEmpty() && !Step.ROOT_STEP.getId().equals(steps.get(0).getId())) {
             // Code expects root step to be located at the beginning of iterator.
             Collections.reverse(steps);
         }
         this.steps = steps.iterator();
-        this.previousStepRowMetadataSupplier = previousStepRowMetadataSupplier;
+        this.rowMetadataSupplier = rowMetadataSupplier;
     }
 
     Node getTransformedNode() {
@@ -183,7 +183,7 @@ class StepNodeTransformation extends Visitor {
                 final NodeCopy copy = new NodeCopy();
                 node.accept(copy);
 
-                final StepNode stepNode = new StepNode(step, previousStepRowMetadataSupplier.apply(step), copy.getCopy(), copy.getLastNode());
+                final StepNode stepNode = new StepNode(step, rowMetadataSupplier.apply(step), copy.getCopy(), copy.getLastNode());
                 // and plug the previous link to the new StepNode
                 ofNullable(previous).ifPresent(n -> n.setLink(new BasicLink(stepNode)));
                 builder.to(stepNode);
@@ -207,19 +207,13 @@ class StepNodeTransformation extends Visitor {
          */
         class NodeCopy extends Visitor {
 
-            /**
-             * The builder used to copy.
-             */
+            /** The builder used to copy. */
             private final NodeBuilder builder = NodeBuilder.source();
 
-            /**
-             * Flag set to true when the copy is finished.
-             */
+            /** Flag set to true when the copy is finished. */
             private boolean hasEnded = false;
 
-            /**
-             * The last node to copy.
-             */
+            /** The last node to copy. */
             private Node lastNode;
 
             @Override

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/StepNodeTransformer.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/StepNodeTransformer.java
@@ -12,11 +12,11 @@
 
 package org.talend.dataprep.transformation.pipeline;
 
-import org.talend.dataprep.api.dataset.RowMetadata;
-import org.talend.dataprep.api.preparation.Step;
-
 import java.util.List;
 import java.util.function.Function;
+
+import org.talend.dataprep.api.dataset.RowMetadata;
+import org.talend.dataprep.api.preparation.Step;
 
 /**
  * A utility class to transformer a pipeline (with nodes) and replace step-related nodes with
@@ -31,14 +31,14 @@ public class StepNodeTransformer {
      * Groups all nodes (accessible from <code>node</code>) into {@link org.talend.dataprep.transformation.pipeline.node.StepNode
      * step nodes} when applicable. Each group node will consume a {@link Step} from <code>steps</code>.
      *
-     * @param node                            : The pipeline (as {@link Node}) to transform.
-     * @param steps                           : The {@link Step steps} to use when creating group nodes.
-     * @param previousStepRowMetadataSupplier : A function that allows visitor code to associate a row metadata with a step.
+     * @param node The pipeline (as {@link Node}) to transform.
+     * @param steps The {@link Step steps} to use when creating group nodes.
+     * @param rowMetadataSupplier A function that allows visitor code to associate a row metadata with a step.
      * @return The transformed pipeline, based on copies of the original <code>node</code> (no modification done on the pipeline
      * reachable from <code>node/code>).
      */
-    public static Node transform(Node node, List<Step> steps, Function<Step, RowMetadata> previousStepRowMetadataSupplier) {
-        final StepNodeTransformation visitor = new StepNodeTransformation(steps, previousStepRowMetadataSupplier);
+    public static Node transform(Node node, List<Step> steps, Function<Step, RowMetadata> rowMetadataSupplier) {
+        final StepNodeTransformation visitor = new StepNodeTransformation(steps, rowMetadataSupplier);
         node.accept(visitor);
         return visitor.getTransformedNode();
     }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/builder/StatisticsNodesBuilder.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/builder/StatisticsNodesBuilder.java
@@ -1,5 +1,16 @@
 package org.talend.dataprep.transformation.pipeline.builder;
 
+import static org.talend.dataprep.api.action.ActionDefinition.Behavior.NEED_STATISTICS_INVALID;
+import static org.talend.dataprep.api.action.ActionDefinition.Behavior.NEED_STATISTICS_PATTERN;
+import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.FILTER;
+
+import java.util.List;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
 import org.apache.commons.lang.StringUtils;
 import org.talend.dataprep.api.action.ActionDefinition;
 import org.talend.dataprep.api.dataset.ColumnMetadata;
@@ -15,17 +26,6 @@ import org.talend.dataprep.transformation.pipeline.node.StatisticsNode;
 import org.talend.dataprep.transformation.pipeline.node.TypeDetectionNode;
 import org.talend.dataquality.common.inference.Analyzer;
 import org.talend.dataquality.common.inference.Analyzers;
-
-import java.util.List;
-import java.util.Map;
-import java.util.MissingResourceException;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Predicate;
-
-import static org.talend.dataprep.api.action.ActionDefinition.Behavior.NEED_STATISTICS_INVALID;
-import static org.talend.dataprep.api.action.ActionDefinition.Behavior.NEED_STATISTICS_PATTERN;
-import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.FILTER;
 
 public class StatisticsNodesBuilder {
 
@@ -135,10 +135,7 @@ public class StatisticsNodesBuilder {
             if (needIntermediateStatistics(nextAction)) {
                 final Set<ActionDefinition.Behavior> behavior = actionToMetadata.get(nextAction).getBehavior();
                 if (behavior.contains(NEED_STATISTICS_PATTERN)) {
-                    // the type detection is needed by some actions : see bug TDP-4926
-                    // this modification needs performance analysis
-                    node = NodeBuilder.from(getTypeDetectionNode(actionsProfile.getFilterForFullAnalysis()))
-                            .to(getPatternDetectionNode(actionsProfile.getFilterForPatternAnalysis())).build();
+                    node = NodeBuilder.from(getPatternDetectionNode(actionsProfile.getFilterForPatternAnalysis())).build();
                 } else {
                     // 2 cases remain as this point: action needs invalid values or filter attached to action does
                     node = NodeBuilder.from(getTypeDetectionNode(actionsProfile.getFilterForFullAnalysis()))

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/node/StepNode.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/node/StepNode.java
@@ -38,11 +38,11 @@ public class StepNode extends BasicNode {
 
     private RowMetadata lastRowMetadata;
 
-    private RowMetadata previousStepRowMetadata;
+    private RowMetadata stepRowMetadata;
 
-    public StepNode(Step step, RowMetadata previousStepRowMetadata, Node entryNode, Node lastNode) {
+    public StepNode(Step step, RowMetadata stepRowMetadata, Node entryNode, Node lastNode) {
         this.step = step;
-        this.previousStepRowMetadata = previousStepRowMetadata;
+        this.stepRowMetadata = stepRowMetadata;
         this.entryNode = entryNode;
         this.lastNode = lastNode;
     }
@@ -58,9 +58,9 @@ public class StepNode extends BasicNode {
     @Override
     public void receive(DataSetRow row, RowMetadata metadata) {
         RowMetadata processingRowMetadata = metadata;
-        if (previousStepRowMetadata != null) {
+        if (stepRowMetadata != null) {
             // Step node has associated metadata, use it instead of supplied one.
-            processingRowMetadata = previousStepRowMetadata;
+            processingRowMetadata = stepRowMetadata;
         }
 
         // make sure the last node (ActionNode) link is set to after the StepNode
@@ -79,7 +79,7 @@ public class StepNode extends BasicNode {
 
     @Override
     public Node copyShallow() {
-        return new StepNode(step, previousStepRowMetadata, entryNode, lastNode);
+        return new StepNode(step, stepRowMetadata, entryNode, lastNode);
     }
 
     /**

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/preparation/store/PersistentStep.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/preparation/store/PersistentStep.java
@@ -129,8 +129,7 @@ public class PersistentStep extends PersistentIdentifiable {
         result += '\'' + //
                 ", actions='" + contentId + '\'' + //
                 ", appVersion='" + appVersion + '\'' + //
-                ", diff=" + diff + '\'' +
-                ", rowMetadata=" + rowMetadata + //
+                ", diff=" + diff + //
                 '}';
         return result;
     }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineTransformer.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineTransformer.java
@@ -12,6 +12,12 @@
 
 package org.talend.dataprep.transformation.api.transformer.json;
 
+import static org.talend.dataprep.cache.ContentCache.TimeToLive.DEFAULT;
+import static org.talend.dataprep.transformation.api.transformer.configuration.Configuration.Volume.SMALL;
+
+import java.util.Optional;
+import java.util.function.Function;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,12 +44,6 @@ import org.talend.dataprep.transformation.pipeline.Signal;
 import org.talend.dataprep.transformation.pipeline.model.WriterNode;
 import org.talend.dataprep.transformation.service.StepMetadataRepository;
 import org.talend.dataprep.transformation.service.TransformationRowMetadataUtils;
-
-import java.util.Optional;
-import java.util.function.Function;
-
-import static org.talend.dataprep.cache.ContentCache.TimeToLive.DEFAULT;
-import static org.talend.dataprep.transformation.api.transformer.configuration.Configuration.Volume.SMALL;
 
 @Component
 public class PipelineTransformer implements Transformer {
@@ -90,11 +90,9 @@ public class PipelineTransformer implements Transformer {
         final TransformationMetadataCacheKey metadataKey = cacheKeyGenerator.generateMetadataKey(configuration.getPreparationId(),
                 configuration.stepId(), configuration.getSourceType());
         final PreparationMessage preparation = configuration.getPreparation();
-        // function that from a step gives the rowMetadata associated to the previous/parent step
-        final Function<Step, RowMetadata> previousStepRowMetadataSupplier = s -> Optional.ofNullable(s.getParent()) //
+        final Function<Step, RowMetadata> rowMetadataSupplier = s -> Optional.ofNullable(s.getRowMetadata()) //
                 .map(id -> preparationUpdater.get(id)) //
                 .orElse(null);
-
         final Pipeline pipeline = Pipeline.Builder.builder() //
                 .withAnalyzerService(analyzerService) //
                 .withActionRegistry(actionRegistry) //
@@ -107,7 +105,7 @@ public class PipelineTransformer implements Transformer {
                 .withFilterOut(configuration.getOutFilter()) //
                 .withOutput(() -> new WriterNode(writer, metadataWriter, metadataKey, fallBackRowMetadata)) //
                 .withStatisticsAdapter(adapter) //
-                .withStepMetadataSupplier(previousStepRowMetadataSupplier) //
+                .withStepMetadataSupplier(rowMetadataSupplier) //
                 .withGlobalStatistics(configuration.isGlobalStatistics()) //
                 .allowMetadataChange(configuration.isAllowMetadataChange()) //
                 .build();

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/UpdatedStepVisitor.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/UpdatedStepVisitor.java
@@ -49,18 +49,18 @@ class UpdatedStepVisitor extends Visitor {
                 final ActionContext.ActionStatus status = actionNode.getActionContext().getActionStatus();
                 final Step step = stepNode.getStep();
                 switch (status) {
-                    case NOT_EXECUTED:
-                    case CANCELED:
-                        LOGGER.debug("Not updating metadata for {} (action ended with status {}).", step.getId(), status);
-                        step.setRowMetadata(null);
-                        break;
-                    case OK:
-                    case DONE:
-                        LOGGER.debug("Keeping metadata {} (action ended with status {}).", step.getId(), status);
-                        break;
+                case NOT_EXECUTED:
+                case CANCELED:
+                    LOGGER.debug("Not updating metadata for {} (action ended with status {}).", step.getId(), status);
+                    step.setRowMetadata(null);
+                    break;
+                case OK:
+                case DONE:
+                    LOGGER.debug("Keeping metadata {} (action ended with status {}).", step.getId(), status);
+                    break;
                 }
 
-                preparationUpdater.update(step.id(), actionNode.getActionContext().getRowMetadata());
+                preparationUpdater.update(step.id(), stepNode.getRowMetadata());
             }
         });
         super.visitStepNode(stepNode);


### PR DESCRIPTION
This reverts commit 264902c

dataprep-api and dataprep-test-api skipped due to conflicts

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5530

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
