### PR TITLE
fix(TDP-5538): Fix breaking change in column ids. (#1270)

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/datablending/Lookup.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/datablending/Lookup.java
@@ -21,14 +21,24 @@ import static org.talend.dataprep.parameters.ParameterType.STRING;
 import static org.talend.dataprep.transformation.actions.Providers.get;
 import static org.talend.dataprep.transformation.actions.category.ActionScope.HIDDEN_IN_ACTION_LIST;
 import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.COLUMN_ID;
-import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.*;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_DS_ID;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_DS_NAME;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_JOIN_ON;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_JOIN_ON_NAME;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_SELECTED_COLS;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.CANCELED;
 import static org.talend.dataprep.transformation.api.action.context.ActionContext.ActionStatus.OK;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.dataprep.api.action.Action;
@@ -46,6 +56,7 @@ import org.talend.dataprep.transformation.api.action.context.ActionContext;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 
 /**
  * Lookup action used to blend a (or a part of a) dataset into another one.
@@ -157,12 +168,11 @@ public class Lookup extends AbstractActionMetadata implements DataSetAction {
             final String columnId = parameters.get(COLUMN_ID.getKey());
             final RowMetadata lookupRowMetadata = rowMatcher.getRowMetadata();
             final RowMetadata rowMetadata = context.getRowMetadata();
-            colsToAdd = Lists.reverse(colsToAdd);
-            colsToAdd.forEach(toAdd -> {
+            final List<String> addedColumns = colsToAdd.stream().map(toAdd -> {
                 // create the new column
                 final String toAddColumnId = toAdd.getId();
                 final ColumnMetadata metadata = lookupRowMetadata.getById(toAddColumnId);
-                context.column(toAddColumnId, r -> {
+                return context.column(toAddColumnId, r -> {
                     final ColumnMetadata colMetadata = //
                             column() //
                             .copy(metadata) //
@@ -171,7 +181,9 @@ public class Lookup extends AbstractActionMetadata implements DataSetAction {
                     rowMetadata.insertAfter(columnId, colMetadata);
                     return colMetadata;
                 });
-            });
+            }).collect(Collectors.toList());
+
+            Lists.reverse(addedColumns).forEach(column -> rowMetadata.moveAfter(columnId, column));
         }
     }
 

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/datablending/LookupTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/datablending/LookupTest.java
@@ -13,13 +13,21 @@
 
 package org.talend.dataprep.transformation.actions.datablending;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.COLUMN_ID;
-import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.*;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_DS_ID;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_JOIN_ON;
+import static org.talend.dataprep.transformation.actions.datablending.Lookup.Parameters.LOOKUP_SELECTED_COLS;
 
 import java.io.IOException;
 import java.text.DecimalFormat;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -118,12 +126,12 @@ public class LookupTest extends AbstractMetadataBaseTest<Lookup> {
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then (check values)
-        DataSetRow expected = ActionMetadataTestUtils.getRow("Atlanta", "GA", "Philips Arena", "Atlanta", "Georgia");
+        DataSetRow expected = ActionMetadataTestUtils.getRow("Atlanta", "GA", "Philips Arena", "Georgia", "Atlanta");
         Assert.assertEquals(expected, row);
 
         // and (check metadata)
-        checkMergedMetadata(row.getRowMetadata().getById("0003"), "Capital", "string", "CITY");
-        checkMergedMetadata(row.getRowMetadata().getById("0004"), "State", "string", "US_STATE");
+        checkMergedMetadata(row.getRowMetadata().getById("0004"), "Capital", "string", "CITY");
+        checkMergedMetadata(row.getRowMetadata().getById("0003"), "State", "string", "US_STATE");
     }
 
     @Test
@@ -140,14 +148,22 @@ public class LookupTest extends AbstractMetadataBaseTest<Lookup> {
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then (check values)
-        DataSetRow expected = ActionMetadataTestUtils.getRow("Dallas", "TX",
-                "32.790556°N 96.810278°W", "American Airlines Center", "Dallas Mavericks");
+        DataSetRow expected = ActionMetadataTestUtils.getRow("Dallas", "TX", "Dallas Mavericks",
+                "American Airlines Center", "32.790556°N 96.810278°W");
         Assert.assertEquals(expected, row);
 
         // and (check metadata)
-        checkMergedMetadata(row.getRowMetadata().getById("0002"), "Coordinates", "string", "");
+        checkMergedMetadata(row.getRowMetadata().getById("0004"), "Coordinates", "string", "");
         checkMergedMetadata(row.getRowMetadata().getById("0003"), "Stadium", "string", "");
-        checkMergedMetadata(row.getRowMetadata().getById("0004"), "Team", "string", "");
+        checkMergedMetadata(row.getRowMetadata().getById("0002"), "Team", "string", "");
+
+        // and
+        final String[] orderedValues = row.order().toArray(DataSetRow.SKIP_TDP_ID);
+        assertEquals("Dallas", orderedValues[0]);
+        assertEquals("TX", orderedValues[1]);
+        assertEquals("Dallas Mavericks", orderedValues[2]);
+        assertEquals("American Airlines Center", orderedValues[3]);
+        assertEquals("32.790556°N 96.810278°W", orderedValues[4]);
     }
 
     @Test
@@ -165,8 +181,8 @@ public class LookupTest extends AbstractMetadataBaseTest<Lookup> {
         Assert.assertEquals(expected, row);
 
         // and (metadata)
-        checkMergedMetadata(row.getRowMetadata().getById("0003"), "Capital", "string", "CITY");
-        checkMergedMetadata(row.getRowMetadata().getById("0004"), "State", "string", "US_STATE");
+        checkMergedMetadata(row.getRowMetadata().getById("0004"), "Capital", "string", "CITY");
+        checkMergedMetadata(row.getRowMetadata().getById("0003"), "State", "string", "US_STATE");
 
     }
 
@@ -185,8 +201,8 @@ public class LookupTest extends AbstractMetadataBaseTest<Lookup> {
         Assert.assertEquals(expected, row);
 
         // and (metadata)
-        checkMergedMetadata(row.getRowMetadata().getById("0003"), "Capital", "string", "CITY");
-        checkMergedMetadata(row.getRowMetadata().getById("0004"), "State", "string", "US_STATE");
+        checkMergedMetadata(row.getRowMetadata().getById("0004"), "Capital", "string", "CITY");
+        checkMergedMetadata(row.getRowMetadata().getById("0003"), "State", "string", "US_STATE");
     }
 
     @Test
@@ -205,11 +221,11 @@ public class LookupTest extends AbstractMetadataBaseTest<Lookup> {
 
         // then (check values)
         DataSetRow[] expectedRows = new DataSetRow[] {
-                ActionMetadataTestUtils.getRow("Atlanta", "GA", "Philips Arena", "Atlanta", "Georgia"),
-                ActionMetadataTestUtils.getRow("Miami", "FL", "American Airlines Arena", "Tallahassee", "Florida"),
-                ActionMetadataTestUtils.getRow("Chicago", "IL", "United Center", "Springfield", "Illinois"),
-                ActionMetadataTestUtils.getRow("San Antonio", "TX", "AT&T Center", "Austin", "Texas"),
-                ActionMetadataTestUtils.getRow("Oakland", "CA", "Oracle Arena", "Sacramento", "California") };
+                ActionMetadataTestUtils.getRow("Atlanta", "GA", "Philips Arena", "Georgia", "Atlanta"),
+                ActionMetadataTestUtils.getRow("Miami", "FL", "American Airlines Arena", "Florida", "Tallahassee"),
+                ActionMetadataTestUtils.getRow("Chicago", "IL", "United Center", "Illinois", "Springfield"),
+                ActionMetadataTestUtils.getRow("San Antonio", "TX", "AT&T Center", "Texas", "Austin"),
+                ActionMetadataTestUtils.getRow("Oakland", "CA", "Oracle Arena", "California", "Sacramento") };
         for (int i = 0; i < rows.length; i++) {
             Assert.assertEquals(expectedRows[i], rows[i]);
         }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/RowMetadata.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/RowMetadata.java
@@ -306,4 +306,34 @@ public class RowMetadata implements Serializable {
     public Schema toSchema() {
         return RowMetadataUtils.toSchema(this);
     }
+
+    /**
+     * Move column with id <code>movedColumnId</code> <b>after</b> <code>columnId</code>. If you have:
+     * 
+     * <pre>
+     *     [0001, 0002, 0003, 0004]
+     * </pre>
+     * 
+     * And call <code>moveAfter(0004, 0001)</code>, you will change order of columns with:
+     * 
+     * <pre>
+     *     [0001, 0004, 0002, 0003]
+     * </pre>
+     *
+     * @param columnId The column where <code>movedColumnId</code> should be next to.
+     * @param movedColumnId The column to move.
+     */
+    public void moveAfter(@Nonnull String columnId, @Nonnull String movedColumnId) {
+        final ColumnMetadata columnMetadata = getById(columnId);
+        if (columnMetadata == null) {
+            return;
+        }
+        final ColumnMetadata movedColumn = getById(movedColumnId);
+        if (movedColumn == null) {
+            return;
+        }
+
+        columns.remove(movedColumn);
+        columns.add(columns.indexOf(columnMetadata) + 1, movedColumn);
+    }
 }

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/api/dataset/RowMetadataTest.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/api/dataset/RowMetadataTest.java
@@ -15,7 +15,11 @@ package org.talend.dataprep.api.dataset;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.talend.dataprep.api.dataset.row.Flag.UPDATE;
 import static org.talend.dataprep.test.SerializableMatcher.isSerializable;
 
@@ -328,6 +332,65 @@ public class RowMetadataTest {
         assertEquals("0001", addedColumn.getId());
     }
 
+    @Test
+    public void shouldMoveAfter() throws Exception {
+        // given
+        RowMetadata value = new RowMetadata();
+        final ColumnMetadata first = value.addColumn(getColumnMetadata("first"));
+        value.addColumn(getColumnMetadata("second"));
+        final ColumnMetadata third = value.addColumn(getColumnMetadata("third"));
+
+        // when
+        value.moveAfter(first.getId(), third.getId());
+
+        // then
+        final List<ColumnMetadata> columns = value.getColumns();
+        assertEquals(3, columns.size());
+        assertEquals("first", columns.get(0).getName());
+        assertEquals("third", columns.get(1).getName());
+        assertEquals("second", columns.get(2).getName());
+    }
+
+    @Test
+    public void shouldMoveAfterIncorrectInputs() throws Exception {
+        // given
+        RowMetadata value = new RowMetadata();
+        value.addColumn(getColumnMetadata("first"));
+        value.addColumn(getColumnMetadata("second"));
+        value.addColumn(getColumnMetadata("third"));
+
+        // when
+        value.moveAfter("0001", null);
+
+        // then
+        assertMoveAfterIncorrectInput(value);
+
+        // when
+        value.moveAfter(null, "0001");
+
+        // then
+        assertMoveAfterIncorrectInput(value);
+
+        // when
+        value.moveAfter("0001", "0004");
+
+        // then
+        assertMoveAfterIncorrectInput(value);
+
+        // when
+        value.moveAfter("0004", "0004");
+
+        // then
+        assertMoveAfterIncorrectInput(value);
+    }
+
+    private static void assertMoveAfterIncorrectInput(RowMetadata value) {
+        final List<ColumnMetadata> columns = value.getColumns();
+        assertEquals(3, columns.size());
+        assertEquals("first", columns.get(0).getName());
+        assertEquals("second", columns.get(1).getName());
+        assertEquals("third", columns.get(2).getName());
+    }
 
     /**
      * @param name the column name.


### PR DESCRIPTION
* fix(TDP-5538): Fix breaking change in column ids.

* Fix breaking change in column ids (column names are still reversed but ids stay as previously).
* Introduce RowMetadata::moveAfter to move columns around in row metadata.
* Add Junit test for moveAfter()
* (review).

(cherry picked from commit 43f59be)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5538

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
