### PR TITLE
fix: dq tests

### DIFF
--- a/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/DataSetServiceTest.java
+++ b/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/DataSetServiceTest.java
@@ -1734,7 +1734,7 @@ public class DataSetServiceTest extends DataSetBaseTest {
          */
         Assert.assertEquals(200, response.getStatusCode());
         final JsonNode rootNode = mapper.readTree(response.asInputStream());
-        Assert.assertEquals(7, rootNode.size());
+        Assert.assertEquals(6, rootNode.size());
         for (JsonNode type : rootNode) {
             assertTrue(type.has("id"));
             assertTrue(type.has("label"));

--- a/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/analysis/synchronous/SchemaAnalysisTest.java
+++ b/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/analysis/synchronous/SchemaAnalysisTest.java
@@ -132,8 +132,8 @@ public class SchemaAnalysisTest extends DataSetBaseTest {
             assertThat(column.getType(), is(expectedTypes[i].getName()));
             assertThat(column.getDomain(), is(expectedDomains[i++]));
             assertThat(column.getSemanticDomains()).isNotNull().isNotEmpty().hasSize(2).contains(
-                    new SemanticDomain("GENDER", "Gender", (float) 35), //
-                    new SemanticDomain("CIVILITY", "Civility", (float) 20.833334));
+                    new SemanticDomain("GENDER", "Gender", (float) 30), //
+                    new SemanticDomain("CIVILITY", "Civility", (float) 20));
         }
     }
 

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformationServiceTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformationServiceTest.java
@@ -347,7 +347,7 @@ public class TransformationServiceTest extends TransformationServiceBaseTest {
          */
         assertEquals(200, response.getStatusCode());
         final JsonNode rootNode = mapper.readTree(response.asInputStream());
-        assertEquals(7, rootNode.size());
+        assertEquals(6, rootNode.size());
         for (JsonNode type : rootNode) {
             assertTrue(type.has("id"));
             assertTrue(type.has("label"));


### PR DESCRIPTION
**DataSetServiceTest.java**

Type CITY has been removed. Semantic types count goes from 7 to 6.

**SchemaAnalysisTest.java**

As seen with the DQ team, 6.0.0-SNAPSHOT has been republished. The way the library attributes the score based on the metadata has evolved. This result is totally consistent ; our test has to be fixed.

**TransformationServiceTest.java**

Type CITY has been removed. Semantic types count goes from 7 to 6.