### PR TITLE
fix(TDP-5254): revert the reverse of additional columns list

### DIFF
--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/ActionsUtils.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/common/ActionsUtils.java
@@ -11,17 +11,17 @@
 
 package org.talend.dataprep.transformation.actions.common;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
 import org.apache.commons.lang.StringUtils;
 import org.talend.dataprep.api.dataset.ColumnMetadata;
 import org.talend.dataprep.api.dataset.RowMetadata;
 import org.talend.dataprep.api.type.Type;
 import org.talend.dataprep.parameters.Parameter;
 import org.talend.dataprep.transformation.api.action.context.ActionContext;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 import static org.talend.dataprep.parameters.ParameterType.BOOLEAN;
 
@@ -37,7 +37,7 @@ public class ActionsUtils {
     /**
      * Key for the context map to retrieve column created by "Create new column" parameter.
      */
-    private static final String TARGET_COLUMN_CONTEXT_KEY = "target";
+    public static final String TARGET_COLUMN_CONTEXT_KEY = "target";
 
     private ActionsUtils() {
     }

--- a/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokens.java
+++ b/dataprep-actions/src/main/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokens.java
@@ -97,7 +97,7 @@ public class ExtractDateTokens extends AbstractDate implements ColumnAction {
     /** False constant value. */
     private static final String FALSE = "false";
 
-    private static final DateFieldMappingBean[] dateFields = new DateFieldMappingBean[] { //
+    private static final DateFieldMappingBean[] DATE_FIELDS = new DateFieldMappingBean[] { //
             new DateFieldMappingBean(YEAR, ChronoField.YEAR), //
             new DateFieldMappingBean(QUARTER, ChronoField.MONTH_OF_YEAR), //
             new DateFieldMappingBean(MONTH, ChronoField.MONTH_OF_YEAR), //
@@ -155,7 +155,7 @@ public class ExtractDateTokens extends AbstractDate implements ColumnAction {
         context.evict(TARGET_COLUMN_CONTEXT_KEY);
         context.get(TARGET_COLUMN_CONTEXT_KEY, r -> {
             Map<String, String> targetColumnIds = new HashMap<>();
-            for (DateFieldMappingBean dateField : dateFields) {
+            for (DateFieldMappingBean dateField : DATE_FIELDS) {
                 if (Boolean.valueOf(context.getParameters().get(dateField.key))) {
                     ColumnMetadata metadata = ColumnMetadata.Builder.column() //
                             .name(column.getName() + SEPARATOR + dateField.key) //
@@ -192,7 +192,7 @@ public class ExtractDateTokens extends AbstractDate implements ColumnAction {
         }
 
         // insert new extracted values
-        for (final DateFieldMappingBean date_field : dateFields) {
+        for (final DateFieldMappingBean date_field : DATE_FIELDS) {
             if (Boolean.valueOf(parameters.get(date_field.key))) {
                 String newValue = StringUtils.EMPTY;
                 if (temporalAccessor != null && // may occurs if date can not be parsed with pattern

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
@@ -13,16 +13,12 @@
 
 package org.talend.dataprep.transformation.actions.date;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
-import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValueBuilder.value;
-import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValuesBuilder.builder;
-import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getColumn;
-import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.setStatistics;
-
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +33,19 @@ import org.talend.dataprep.transformation.actions.category.ActionCategory;
 import org.talend.dataprep.transformation.api.action.ActionTestWorkbench;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.talend.dataprep.api.dataset.ColumnMetadata.Builder.column;
+import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValueBuilder.value;
+import static org.talend.dataprep.transformation.actions.AbstractMetadataBaseTest.ValuesBuilder.builder;
+import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.getColumn;
+import static org.talend.dataprep.transformation.actions.ActionMetadataTestUtils.setStatistics;
 
 public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
 
@@ -96,6 +105,7 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
 
         // then
         assertEquals(expectedValues, row.values());
+        assertEquals("_MINUTE", row.getRowMetadata().getColumns().get(2).getName());
     }
 
     @Test

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
@@ -152,11 +152,11 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
         final Map<String, String> expectedValues = new HashMap<>();
         expectedValues.put("0000", "toto");
         expectedValues.put("0001", "Dec-17-2017");
-        expectedValues.put("0007", "2017");
-        expectedValues.put("0006", "4");
+        expectedValues.put("0003", "2017");
+        expectedValues.put("0004", "4");
         expectedValues.put("0005", "12");
-        expectedValues.put("0004", "0");
-        expectedValues.put("0003", "0");
+        expectedValues.put("0006", "0");
+        expectedValues.put("0007", "0");
         expectedValues.put("0002", "tata");
 
         // when
@@ -164,6 +164,13 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
 
         // then
         assertEquals(expectedValues, row.values());
+
+        List<ColumnMetadata> columns = row.getRowMetadata().getColumns();
+        assertEquals("_MINUTE", columns.get(2).getName());
+        assertEquals("_HOUR_24", columns.get(3).getName());
+        assertEquals("_MONTH", columns.get(4).getName());
+        assertEquals("_QUARTER", columns.get(5).getName());
+        assertEquals("_YEAR", columns.get(6).getName());
     }
 
     @Test

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
@@ -1,15 +1,15 @@
-// ============================================================================
+//  ============================================================================
 //
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
 //
-// This source code is available under agreement available at
-// https://github.com/Talend/data-prep/blob/master/LICENSE
+//  This source code is available under agreement available at
+//  https://github.com/Talend/data-prep/blob/master/LICENSE
 //
-// You should have received a copy of the agreement
-// along with this program; if not, write to Talend SA
-// 9 rue Pages 92150 Suresnes, France
+//  You should have received a copy of the agreement
+//  along with this program; if not, write to Talend SA
+//  9 rue Pages 92150 Suresnes, France
 //
-// ============================================================================
+//  ============================================================================
 
 package org.talend.dataprep.transformation.actions.date;
 
@@ -57,11 +57,12 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
 
     @Before
     public void init() throws IOException {
-        parameters = ActionMetadataTestUtils.parseParameters(getDateTestJsonAsStream("extractDateTokensAction.json"));
+        parameters = ActionMetadataTestUtils
+                .parseParameters(getDateTestJsonAsStream("extractDateTokensAction.json"));
     }
 
     @Override
-    protected CreateNewColumnPolicy getCreateNewColumnPolicy() {
+    protected  CreateNewColumnPolicy getCreateNewColumnPolicy(){
         return CreateNewColumnPolicy.INVISIBLE_ENABLED;
     }
 
@@ -94,13 +95,13 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
         final Map<String, String> expectedValues = new HashMap<>();
         expectedValues.put("0000", "toto");
         expectedValues.put("0001", "04/25/1999");
-        expectedValues.put("0006", "1999");
-        expectedValues.put("0005", "4");
-        expectedValues.put("0004", "0");
-        expectedValues.put("0003", "0");
+        expectedValues.put("0003", "1999");
+        expectedValues.put("0004", "4");
+        expectedValues.put("0005", "0");
+        expectedValues.put("0006", "0");
         expectedValues.put("0002", "tata");
 
-        // when
+        //when
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
@@ -120,13 +121,13 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
         final Map<String, String> expectedValues = new HashMap<>();
         expectedValues.put("0000", "toto");
         expectedValues.put("0001", "Apr-25-1999");
-        expectedValues.put("0006", "1999");
-        expectedValues.put("0005", "4");
-        expectedValues.put("0004", "0");
-        expectedValues.put("0003", "0");
+        expectedValues.put("0003", "1999");
+        expectedValues.put("0004", "4");
+        expectedValues.put("0005", "0");
+        expectedValues.put("0006", "0");
         expectedValues.put("0002", "tata");
 
-        // when
+        //when
         ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
 
         // then
@@ -162,47 +163,22 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
     }
 
     @Test
-    public void test_TDP_1676() throws Exception {
-        // given
-        final DataSetRow row = builder() //
-                .with(value("toto").type(Type.STRING)) //
-                .with(value("Dec-17-2017").type(Type.DATE).statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy.json"))) //
-                .with(value("tata").type(Type.STRING)) //
-                .build();
-
-        final Map<String, String> expectedValues = new HashMap<>();
-        expectedValues.put("0000", "toto");
-        expectedValues.put("0001", "Dec-17-2017");
-        expectedValues.put("0006", "2017");
-        expectedValues.put("0005", "12");
-        expectedValues.put("0004", "0");
-        expectedValues.put("0003", "0");
-        expectedValues.put("0002", "tata");
-
-        // when
-        ActionTestWorkbench.test(row, actionRegistry, factory.create(action, parameters));
-
-        // then
-        assertEquals(expectedValues, row.values());
-    }
-
-    @Test
     public void should_process_row_with_time() throws Exception {
         // given
         final DataSetRow row = builder() //
                 .with(value("toto").type(Type.STRING)) //
-                .with(value("04/25/1999 15:45").type(Type.DATE)
-                        .statistics(getDateTestJsonAsStream("statistics_MM_dd_yyyy_HH_mm.json"))) //
+                .with(value("04/25/1999 15:45").type(Type.DATE).statistics(
+                        getDateTestJsonAsStream("statistics_MM_dd_yyyy_HH_mm.json"))) //
                 .with(value("tata").type(Type.STRING)) //
                 .build();
 
         final Map<String, String> expectedValues = new HashMap<>();
         expectedValues.put("0000", "toto");
         expectedValues.put("0001", "04/25/1999 15:45");
-        expectedValues.put("0006", "1999");
-        expectedValues.put("0005", "4");
-        expectedValues.put("0004", "15");
-        expectedValues.put("0003", "45");
+        expectedValues.put("0003", "1999");
+        expectedValues.put("0004", "4");
+        expectedValues.put("0005", "15");
+        expectedValues.put("0006", "45");
         expectedValues.put("0002", "tata");
 
         // when
@@ -227,10 +203,10 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
         final Map<String, String> expectedValues = new HashMap<>();
         expectedValues.put("0000", "toto");
         expectedValues.put("0001", "04-25-09");
-        expectedValues.put("0006", "2009");
-        expectedValues.put("0005", "4");
-        expectedValues.put("0004", "0");
-        expectedValues.put("0003", "0");
+        expectedValues.put("0003", "2009");
+        expectedValues.put("0004", "4");
+        expectedValues.put("0005", "0");
+        expectedValues.put("0006", "0");
         expectedValues.put("0002", "tata");
 
         // when

--- a/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
+++ b/dataprep-actions/src/test/java/org/talend/dataprep/transformation/actions/date/ExtractDateTokensTest.java
@@ -1,6 +1,6 @@
 //  ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
 //
 //  This source code is available under agreement available at
 //  https://github.com/Talend/data-prep/blob/master/LICENSE
@@ -106,7 +106,11 @@ public class ExtractDateTokensTest extends BaseDateTest<ExtractDateTokens> {
 
         // then
         assertEquals(expectedValues, row.values());
-        assertEquals("_MINUTE", row.getRowMetadata().getColumns().get(2).getName());
+        List<ColumnMetadata> columns = row.getRowMetadata().getColumns();
+        assertEquals("_MINUTE", columns.get(2).getName());
+        assertEquals("_HOUR_24", columns.get(3).getName());
+        assertEquals("_MONTH", columns.get(4).getName());
+        assertEquals("_YEAR", columns.get(5).getName());
     }
 
     @Test


### PR DESCRIPTION
-  revert edea36043b204af6b287c4877f8393e9097ecb53

- cannot use ActionsUtils.createNewColumn because rowMetadata insertion is always on context column id (instead of last column id in ActionUtils)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5254
https://jira.talendforge.org/browse/TPS-2360

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
