### PR TITLE
 fix(TDP-5687): Preparation suddenly inaccessible and dataset row count back to 0

### DIFF
--- a/dataprep-async-api/src/main/java/org/talend/dataprep/async/AsyncExecution.java
+++ b/dataprep-async-api/src/main/java/org/talend/dataprep/async/AsyncExecution.java
@@ -14,7 +14,6 @@ package org.talend.dataprep.async;
 
 import java.util.Comparator;
 import java.util.UUID;
-import java.util.function.Function;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -95,11 +94,11 @@ public class AsyncExecution implements Comparable<AsyncExecution> {
     }
 
     public static Comparator<AsyncExecution> reverseStartDateComparator() {
-        return Comparator.<AsyncExecution, Long>comparing(task -> task.getTime().getStartDate()).reversed();
+        return Comparator.<AsyncExecution, Long> comparing(task -> task.getTime().getStartDate()).reversed();
     }
 
     public static Comparator<AsyncExecution> reverseEndDateComparator() {
-        return Comparator.<AsyncExecution, Long>comparing(task -> task.getTime().getEndDate()).reversed();
+        return Comparator.<AsyncExecution, Long> comparing(task -> task.getTime().getEndDate()).reversed();
     }
 
     /**
@@ -183,7 +182,8 @@ public class AsyncExecution implements Comparable<AsyncExecution> {
     }
 
     /**
-     * Update execution status to a new {@link AsyncExecution.Status status}. This update status takes care of start / creation
+     * Update execution status to a new {@link AsyncExecution.Status status}. This update status takes care of start /
+     * creation
      * times.
      *
      * @param status the new {@link AsyncExecution.Status status} for this execution.
@@ -259,6 +259,10 @@ public class AsyncExecution implements Comparable<AsyncExecution> {
         }
         return id.equals(that.id);
 
+    }
+
+    public boolean isResumable() {
+        return this.getStatus() == Status.RUNNING || this.getStatus() == Status.NEW;
     }
 
     public String getTenantId() {

--- a/dataprep-async-runtime/src/main/java/org/talend/dataprep/async/SimpleManagedTaskExecutor.java
+++ b/dataprep-async-runtime/src/main/java/org/talend/dataprep/async/SimpleManagedTaskExecutor.java
@@ -75,7 +75,7 @@ public class SimpleManagedTaskExecutor implements ManagedTaskExecutor {
                     ExceptionContext.withBuilder().put("id", executionId).build());
         } else if (execution.isResumable()) {
             // Execution is expected to be created as "RUNNING" or "NEW" before the dispatcher resumes it.
-            LOGGER.error("Execution #{} can be resumed (status is {}) for tenant:", execution.getId(), execution.getStatus(), execution.getTenantId());
+            LOGGER.error("Execution #{} can be resumed (status is {}) for tenant: {}", execution.getId(), execution.getStatus(), execution.getTenantId());
             throw new TDPException(TransformationErrorCodes.UNABLE_TO_RESUME_EXECUTION,
                     ExceptionContext.withBuilder().put("id", executionId).build());
         }

--- a/dataprep-async-runtime/src/main/java/org/talend/dataprep/async/SimpleManagedTaskExecutor.java
+++ b/dataprep-async-runtime/src/main/java/org/talend/dataprep/async/SimpleManagedTaskExecutor.java
@@ -73,9 +73,9 @@ public class SimpleManagedTaskExecutor implements ManagedTaskExecutor {
             LOGGER.error("Execution #{} can be resumed (not found).", executionId);
             throw new TDPException(TransformationErrorCodes.UNABLE_TO_RESUME_EXECUTION,
                     ExceptionContext.withBuilder().put("id", executionId).build());
-        } else if (execution.isResumable()) {
+        } else if (!execution.isResumable()) {
             // Execution is expected to be created as "RUNNING" or "NEW" before the dispatcher resumes it.
-            LOGGER.error("Execution #{} can be resumed (status is {}) for tenant: {}", execution.getId(), execution.getStatus(), execution.getTenantId());
+            LOGGER.error("Execution #{} can't be resumed (status is {}) for tenant: {}", execution.getId(), execution.getStatus(), execution.getTenantId());
             throw new TDPException(TransformationErrorCodes.UNABLE_TO_RESUME_EXECUTION,
                     ExceptionContext.withBuilder().put("id", executionId).build());
         }


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5687

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
