### PR TITLE
fix(5771): Update spring cloud version to Dalston.SR4

### DIFF
--- a/dataprep-backend-service/src/main/resources/org/talend/dataprep/configuration/default.properties
+++ b/dataprep-backend-service/src/main/resources/org/talend/dataprep/configuration/default.properties
@@ -38,3 +38,5 @@ dataprep.display.version=7.1.M0
 
 #dataset.service.provider=legacy|catalog
 dataset.service.provider=legacy
+
+spring.zipkin.enabled=false

--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -41,7 +41,7 @@
         <org.talend.dataquality.standardization.version>${dataquality-libraries.version}</org.talend.dataquality.standardization.version>
         <org.talend.dataquality.converters.version>${dataquality-libraries.version}</org.talend.dataquality.converters.version>
         <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-        <spring-cloud.version>Dalston.SR1</spring-cloud.version>
+        <spring-cloud.version>Dalston.SR4</spring-cloud.version>
         <project.inceptionYear>2015</project.inceptionYear>
         <project.organization>Talend</project.organization>
         <!-- This version should match the one pulled by tika-parsers -> geoapi -->


### PR DESCRIPTION
* SpringSleuthSettersConfiguration from daikon need sleuth 1.2.5.RELEASE (provided in spring cloud Dalston SR4)

https://github.com/spring-projects/spring-cloud/wiki/Spring-Cloud-Dalston-Release-Notes#dalstonsr4

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5771

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
