### PR TITLE
fix(TDP-5790): content is loaded twice when loading a preparation

### DIFF
--- a/dataprep-webapp/src/app/services/playground/playground-service.js
+++ b/dataprep-webapp/src/app/services/playground/playground-service.js
@@ -161,6 +161,7 @@ export default function PlaygroundService(
 		FilterService.initFilters(dataset, preparation);
 
 		updateGridSelection(dataset, preparation);
+		updatePlayground(data);
 
 		// preparation specific init
 		if (preparation) {
@@ -175,15 +176,12 @@ export default function PlaygroundService(
 			TitleService.setStrict(dataset.name);
 		}
 
-		return $q.all(
-			this.updateDatagrid(),
-			this.updatePreparationDetails()
-				.then(() => {
-					if (state.playground.recipe.current.steps.length) {
-						StateService.showRecipe();
-					}
-				}),
-		);
+		return this.updatePreparationDetails()
+			.then(() => {
+				if (state.playground.recipe.current.steps.length) {
+					StateService.showRecipe();
+				}
+			});
 	}
 
 	/**
@@ -455,7 +453,7 @@ export default function PlaygroundService(
 	 * @description Move the preparation head to the specified step
 	 * @returns {promise} The process promise
 	 */
-	function setPreparationHead(preparationId, headId, columnToFocus) {
+	function setPreparationHead(preparationId, headId) {
 		startLoader();
 
 		let promise = PreparationService.setHead(preparationId, headId);
@@ -479,7 +477,7 @@ export default function PlaygroundService(
 		// load the recipe and grid head in parallel
 		else {
 			promise = promise.then(() => {
-				return $q.all([this.updatePreparationDetails(), updatePreparationDatagrid(columnToFocus)]);
+				return $q.all([this.updatePreparationDetails(), updatePreparationDatagrid()]);
 			});
 		}
 
@@ -504,10 +502,8 @@ export default function PlaygroundService(
 		const previousHead = StepUtilsService.getLastStep(state.playground.recipe);
 
 		return getCurrentPreparation()
-		// append step
-			.then((preparation) => {
-				return PreparationService.appendStep(preparation.id, actions);
-			})
+			// append step
+			.then(preparation => PreparationService.appendStep(preparation.id, actions))
 			// update recipe and datagrid
 			.then(() => {
 				return $q.all([this.updatePreparationDetails(), updatePreparationDatagrid()]);
@@ -651,13 +647,11 @@ export default function PlaygroundService(
 				currentStepId,
 				nextParentStepId,
 			)
-			// update recipe and datagrid
-				.then(() => {
-					return $q.all([
-						this.updatePreparationDetails(),
-						updatePreparationDatagrid(),
-					]);
-				})
+				// update recipe and datagrid (due to backend implementation:
+				// getContent should be called first so that updated stepRowMetadata
+				// is available for getContent)
+				.then(updatePreparationDatagrid)
+				.then(this.updatePreparationDetails)
 				// add entry in history for undo/redo
 				.then(() => {
 					const actualHead = StepUtilsService.getLastStep(recipe)
@@ -936,14 +930,14 @@ export default function PlaygroundService(
 	 * @description Perform an datagrid refresh with the preparation head
 	 */
 	function updatePreparationDatagrid() {
+		startLoader();
 		return PreparationService.getContent(
 			state.playground.preparation.id,
 			'head',
 			state.playground.sampleType
-		).then((response) => {
-			DatagridService.updateData(response);
-			PreviewService.reset(false);
-		});
+		)
+			.then(updatePlayground)
+			.finally(stopLoader);
 	}
 
 	function updateDatasetDatagrid(tql) {
@@ -951,14 +945,14 @@ export default function PlaygroundService(
 		if (!dataset) {
 			return;
 		}
+		startLoader();
 		return DatasetService.getContent(
 			dataset.id,
 			true,
 			tql
-		).then((response) => {
-			DatagridService.updateData(response);
-			PreviewService.reset(false);
-		});
+		)
+			.then(updatePlayground)
+			.finally(stopLoader);
 	}
 
 	function updateDatagrid() {
@@ -1113,5 +1107,10 @@ export default function PlaygroundService(
 		else {
 			$state.go(state.route.previous, state.route.previousOptions);
 		}
+	}
+
+	function updatePlayground(data) {
+		DatagridService.updateData(data);
+		PreviewService.reset(false);
 	}
 }


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5790

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
