### PR TITLE
fix(TDP-5795): details are loaded twice when loading a preparation

### DIFF
--- a/dataprep-webapp/src/app/services/playground/playground-service.js
+++ b/dataprep-webapp/src/app/services/playground/playground-service.js
@@ -167,6 +167,7 @@ export default function PlaygroundService(
 		if (preparation) {
 			ExportService.refreshTypes('preparations', preparation.id);
 			TitleService.setStrict(preparation.name);
+			RecipeService.refresh(preparation);
 		}
 
 		// dataset specific init
@@ -176,7 +177,6 @@ export default function PlaygroundService(
 			TitleService.setStrict(dataset.name);
 		}
 
-		RecipeService.refresh(preparation);
 		if (state.playground.recipe.current.steps.length) {
 			StateService.showRecipe();
 		}

--- a/dataprep-webapp/src/app/services/playground/playground-service.js
+++ b/dataprep-webapp/src/app/services/playground/playground-service.js
@@ -176,12 +176,10 @@ export default function PlaygroundService(
 			TitleService.setStrict(dataset.name);
 		}
 
-		return this.updatePreparationDetails()
-			.then(() => {
-				if (state.playground.recipe.current.steps.length) {
-					StateService.showRecipe();
-				}
-			});
+		RecipeService.refresh(preparation);
+		if (state.playground.recipe.current.steps.length) {
+			StateService.showRecipe();
+		}
 	}
 
 	/**


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5795

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
