### PR TITLE
fix(TDP-4665): use Zipkin 2 and enable zipkin kafka sender from daikon

### DIFF
--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -41,7 +41,7 @@
         <org.talend.dataquality.standardization.version>${dataquality-libraries.version}</org.talend.dataquality.standardization.version>
         <org.talend.dataquality.converters.version>${dataquality-libraries.version}</org.talend.dataquality.converters.version>
         <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-        <spring-cloud.version>Dalston.SR4</spring-cloud.version>
+        <spring-cloud.version>Edgware.SR3</spring-cloud.version>
         <project.inceptionYear>2015</project.inceptionYear>
         <project.organization>Talend</project.organization>
         <!-- This version should match the one pulled by tika-parsers -> geoapi -->


### PR DESCRIPTION
* Use the spring cloud Edware.SR3 version which is the last version supported for spring boot 1.5.X

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4665

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
