### PR TITLE
chore: protect our connection pools by autoclosing DataSet

### DIFF
--- a/dataprep-api/src/main/resources/application.properties
+++ b/dataprep-api/src/main/resources/application.properties
@@ -44,7 +44,7 @@ mail.smtp.from=SJ/7CwYHSaPFefC0cJ18AGKTLKWZH6gTWBCSp6D+1sM=
 # http.pool.size=50
 # http.pool.maxPerRoute=50
 
-dataset.records.limit=10000
+dataset.records.limit=30000
 
 ############# LOGGING #############
 ## Path of the log file

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/DataSet.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/dataset/DataSet.java
@@ -64,6 +64,8 @@ public class DataSet implements AutoCloseable {
 
     @Override
     public void close() {
-        records.close();
+        if (records != null) {
+            records.close();
+        }
     }
 }

--- a/dataprep-dataset/src/main/resources/application.properties
+++ b/dataprep-dataset/src/main/resources/application.properties
@@ -29,7 +29,7 @@ service.documentation.description=This service exposes operations on data sets.
 service.paths=datasets,version
 
 # size limit for dataset in lines (if dataset.lines > limit, dataset is truncated)
-dataset.records.limit=10000
+dataset.records.limit=30000
 # size limit for locally imported dataset in number of bytes
 dataset.local.file.size.limit=2000000000
 

--- a/dataprep-preparation/src/main/resources/application.properties
+++ b/dataprep-preparation/src/main/resources/application.properties
@@ -42,7 +42,7 @@ folder.store.file.location=/tmp/dataprep/store/preparations/folders
 lock.preparation.store=none
 lock.preparation.delay=600
 
-dataset.records.limit=10000
+dataset.records.limit=30000
 
 # Needed to sort preparations on datasets names
 dataset.service.url=http://localhost:8080

--- a/dataprep-preparation/src/test/resources/application.properties
+++ b/dataprep-preparation/src/test/resources/application.properties
@@ -33,7 +33,7 @@ dataset.service.url=
 lock.preparation.store=none
 lock.preparation.delay=600
 
-dataset.records.limit=10000
+dataset.records.limit=30000
 
 spring.main.banner-mode=off
 

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -493,8 +493,7 @@ public class TransformationService extends BaseTransformationService {
 
         boolean identityReleased = false;
         securityProxy.asTechnicalUser();
-        try {
-            final DataSet dataSet = datasetClient.getDataSet(previewParameters.getDataSetId());
+        try (final DataSet dataSet = datasetClient.getDataSet(previewParameters.getDataSetId())) {
             securityProxy.releaseIdentity();
             identityReleased = true;
 

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/DataSetExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/DataSetExportStrategy.java
@@ -54,17 +54,18 @@ public class DataSetExportStrategy extends BaseSampleExportStrategy {
         return outputStream -> {
             // get the dataset content (in an auto-closable block to make sure it is properly closed)
             final String datasetId = parameters.getDatasetId();
-            DataSet dataSet = datasetClient.getDataSet(datasetId);
-            // get the actions to apply (no preparation ==> dataset export ==> no actions)
-            Configuration configuration = Configuration.builder() //
-                    .args(parameters.getArguments()) //
-                    .outFilter(rm -> filterService.build(parameters.getFilter(), rm)) //
-                    .format(format.getName()) //
-                    .volume(Configuration.Volume.SMALL) //
-                    .output(outputStream) //
-                    .limit(limit) //
-                    .build();
-            factory.get(configuration).buildExecutable(dataSet, configuration).execute();
+            try(DataSet dataSet = datasetClient.getDataSet(datasetId)) {
+                // get the actions to apply (no preparation ==> dataset export ==> no actions)
+                Configuration configuration = Configuration.builder() //
+                        .args(parameters.getArguments()) //
+                        .outFilter(rm -> filterService.build(parameters.getFilter(), rm)) //
+                        .format(format.getName()) //
+                        .volume(Configuration.Volume.SMALL) //
+                        .output(outputStream) //
+                        .limit(limit) //
+                        .build();
+                factory.get(configuration).buildExecutable(dataSet, configuration).execute();
+            }
         };
     }
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategy.java
@@ -89,8 +89,7 @@ public class PreparationExportStrategy extends BaseSampleExportStrategy {
 
         boolean releasedIdentity = false;
         securityProxy.asTechnicalUser(); // Allow get dataset and get dataset metadata access whatever share status is
-        try {
-            DataSet dataSet = datasetClient.getDataSet(dataSetId);
+        try (DataSet dataSet = datasetClient.getDataSet(dataSetId)) {
             // head is not allowed as step id
             final String version = getCleanStepId(preparation, stepId);
 

--- a/dataprep-transformation/src/main/resources/application.properties
+++ b/dataprep-transformation/src/main/resources/application.properties
@@ -46,7 +46,7 @@ content-service.store.local.path=${java.io.tmpdir}/dataprep
 # http.pool.size=50
 # http.pool.maxPerRoute=50
 
-dataset.records.limit=10000
+dataset.records.limit=30000
 
 ############# LOGGING #############
 ## Path of the log file


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-XXXX

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
