### PR TITLE
fix(TDP-4665): set spring-cloud-sleuth-dependencies to 1.3.0.RELEASE

### DIFF
--- a/dataprep-backend-service-parent/pom.xml
+++ b/dataprep-backend-service-parent/pom.xml
@@ -41,6 +41,13 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-sleuth-dependencies</artifactId>
+                <version>${spring-cloud-sleuth-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>

--- a/dataprep-backend-service/pom.xml
+++ b/dataprep-backend-service/pom.xml
@@ -37,6 +37,13 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-sleuth-dependencies</artifactId>
+                <version>${spring-cloud-sleuth-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>

--- a/dataprep-backend/pom.xml
+++ b/dataprep-backend/pom.xml
@@ -42,6 +42,7 @@
         <org.talend.dataquality.converters.version>${dataquality-libraries.version}</org.talend.dataquality.converters.version>
         <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
         <spring-cloud.version>Dalston.SR5</spring-cloud.version>
+        <spring-cloud-sleuth-dependencies.version>1.3.0.RELEASE</spring-cloud-sleuth-dependencies.version>
         <project.inceptionYear>2015</project.inceptionYear>
         <project.organization>Talend</project.organization>
         <!-- This version should match the one pulled by tika-parsers -> geoapi -->


### PR DESCRIPTION
* override the provided version from spring-cloud-dependencies (1.2.6.RELEASE) with a spring-cloud-sleuth-dependencies BOM (should be declared before spring-cloud-dependencies)

* we can't upgrade the spring-cloud dependencies due to spring-cloud-stream that should be Chelsea.SR2

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-4665

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
