### PR TITLE
fix(TDP-5865): content is loaded twice when removing all filters after a fetch more

### DIFF
--- a/dataprep-webapp/src/app/services/filter/manager/filter-manager-service.js
+++ b/dataprep-webapp/src/app/services/filter/manager/filter-manager-service.js
@@ -102,7 +102,6 @@ export default function FilterManagerService($timeout, state, PlaygroundService,
 	function addFilter(type, colId, colName, args, removeFilterFn, keyName) {
 		FilterService.addFilter(type, colId, colName, args, removeFilterFn, keyName);
 		StatisticsService.updateFilteredStatistics();
-		PlaygroundService.updateDatagrid();
 		_saveFilters();
 	}
 
@@ -131,7 +130,6 @@ export default function FilterManagerService($timeout, state, PlaygroundService,
 	function removeAllFilters() {
 		FilterService.removeAllFilters();
 		StatisticsService.updateFilteredStatistics();
-		PlaygroundService.updateDatagrid();
 		StorageService.removeFilter(state.playground.preparation ?
 			state.playground.preparation.id : state.playground.dataset.id);
 	}
@@ -146,7 +144,6 @@ export default function FilterManagerService($timeout, state, PlaygroundService,
 	function removeFilter(filter) {
 		FilterService.removeFilter(filter);
 		StatisticsService.updateFilteredStatistics();
-		PlaygroundService.updateDatagrid();
 		_saveFilters();
 	}
 
@@ -159,7 +156,6 @@ export default function FilterManagerService($timeout, state, PlaygroundService,
 	function toggleFilters() {
 		FilterService.toggleFilters();
 		StatisticsService.updateFilteredStatistics();
-		PlaygroundService.updateDatagrid();
 	}
 
 	/**
@@ -188,7 +184,6 @@ export default function FilterManagerService($timeout, state, PlaygroundService,
 	function updateFilter(oldFilter, newValue, keyName) {
 		FilterService.updateFilter(oldFilter, newValue, keyName);
 		StatisticsService.updateFilteredStatistics();
-		PlaygroundService.updateDatagrid();
 		_saveFilters();
 	}
 


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5865

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
