### PR TITLE
chore(perf): Improve pipeline zipkin span names

### DIFF
--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineTransformer.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineTransformer.java
@@ -121,7 +121,12 @@ public class PipelineTransformer implements Transformer {
 
             @Override
             public void execute() {
-                final Optional<Span> span = tracer.map(t -> t.createSpan("pipeline-" + configuration.getPreparationId()));
+                final Optional<Span> span = tracer.map(t -> {
+                    final Span pipelineSpan = t.createSpan("transformer-pipeline");
+                    pipelineSpan.tag("preparation id", configuration.getPreparationId());
+                    pipelineSpan.tag("arguments", configuration.getArguments().toString());
+                    return pipelineSpan;
+                });
                 try {
                     LOGGER.debug("Before transformation: {}", pipeline);
                     pipeline.execute(input);


### PR DESCRIPTION
* Pipeline transformer now creates a span with constant name (prep id and argument in tags).

**Link to the JIRA issue**
(no jira)

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
