### PR TITLE
fix(TDP-5864): Fix missing call to parent's step metadata

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/Pipeline.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/Pipeline.java
@@ -215,7 +215,7 @@ public class Pipeline implements Node, RuntimeNode, Serializable {
 
         private PreparationDTO preparation;
 
-        private Function<String, RowMetadata> previousStepRowMetadataSupplier = s -> null;
+        private Function<String, RowMetadata> parentStepRowMetadataSupplier = s -> null;
 
         private Long limit = null;
 
@@ -224,7 +224,7 @@ public class Pipeline implements Node, RuntimeNode, Serializable {
         }
 
         public Builder withStepMetadataSupplier(Function<String, RowMetadata> previousStepRowMetadataSupplier) {
-            this.previousStepRowMetadataSupplier = previousStepRowMetadataSupplier;
+            this.parentStepRowMetadataSupplier = previousStepRowMetadataSupplier;
             return this;
         }
 
@@ -346,7 +346,7 @@ public class Pipeline implements Node, RuntimeNode, Serializable {
             if (preparation != null) {
                 LOG.debug("Applying step node transformations...");
                 actionsNode.logStatus(LOG, "Before transformation\n{}");
-                final Node node = StepNodeTransformer.transform(actionsNode, preparation.getSteps(), previousStepRowMetadataSupplier);
+                final Node node = StepNodeTransformer.transform(actionsNode, preparation.getSteps(), parentStepRowMetadataSupplier);
                 current.to(node);
                 node.logStatus(LOG, "After transformation\n{}");
             } else {

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/StepNodeTransformer.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/transformation/pipeline/StepNodeTransformer.java
@@ -33,12 +33,12 @@ public class StepNodeTransformer {
      *
      * @param node                            : The pipeline (as {@link Node}) to transform.
      * @param steps                           : The {@link Step steps} to use when creating group nodes.
-     * @param previousStepRowMetadataSupplier : A function that allows visitor code to associate a row metadata with a step.
+     * @param stepRowMetadataSupplier : A function that allows visitor code to associate a row metadata with a step.
      * @return The transformed pipeline, based on copies of the original <code>node</code> (no modification done on the pipeline
      * reachable from <code>node/code>).
      */
-    public static Node transform(Node node, List<String> steps, Function<String, RowMetadata> previousStepRowMetadataSupplier) {
-        final StepNodeTransformation visitor = new StepNodeTransformation(steps, previousStepRowMetadataSupplier);
+    public static Node transform(Node node, List<String> steps, Function<String, RowMetadata> stepRowMetadataSupplier) {
+        final StepNodeTransformation visitor = new StepNodeTransformation(steps, stepRowMetadataSupplier);
         node.accept(visitor);
         return visitor.getTransformedNode();
     }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineTransformer.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/PipelineTransformer.java
@@ -76,7 +76,7 @@ public class PipelineTransformer implements Transformer {
     private TransformationRowMetadataUtils transformationRowMetadataUtils;
 
     @Autowired
-    private StepMetadataRepository preparationUpdater;
+    private StepMetadataRepository stepMetadataRepository;
 
     @Autowired
     private Optional<Tracer> tracer;
@@ -95,8 +95,8 @@ public class PipelineTransformer implements Transformer {
                 configuration.stepId(), configuration.getSourceType());
         final PreparationDTO preparation = configuration.getPreparation();
         // function that from a step gives the rowMetadata associated to the previous/parent step
-        final Function<String, RowMetadata> previousStepRowMetadataSupplier = s -> Optional.ofNullable(s) //
-                .map(id -> preparationUpdater.get(id)) //
+        final Function<String, RowMetadata> stepRowMetadataSupplier = s -> Optional.ofNullable(s) //
+                .map(id -> stepMetadataRepository.get(id)) //
                 .orElse(null);
 
         final Pipeline pipeline = Pipeline.Builder.builder() //
@@ -111,7 +111,7 @@ public class PipelineTransformer implements Transformer {
                 .withFilterOut(configuration.getOutFilter()) //
                 .withOutput(() -> new WriterNode(writer, metadataWriter, metadataKey, fallBackRowMetadata)) //
                 .withStatisticsAdapter(adapter) //
-                .withStepMetadataSupplier(previousStepRowMetadataSupplier) //
+                .withStepMetadataSupplier(stepRowMetadataSupplier) //
                 .withGlobalStatistics(configuration.isGlobalStatistics()) //
                 .allowMetadataChange(configuration.isAllowMetadataChange()) //
                 .build();
@@ -136,7 +136,7 @@ public class PipelineTransformer implements Transformer {
                 }
 
                 if (preparation != null) {
-                    final UpdatedStepVisitor visitor = new UpdatedStepVisitor(preparationUpdater);
+                    final UpdatedStepVisitor visitor = new UpdatedStepVisitor(stepMetadataRepository);
                     pipeline.accept(visitor);
                 }
             }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/UpdatedStepVisitor.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/api/transformer/json/UpdatedStepVisitor.java
@@ -57,7 +57,7 @@ class UpdatedStepVisitor extends Visitor {
                     case OK:
                     case DONE:
                         LOGGER.debug("Keeping metadata {} (action ended with status {}).", step, status);
-                        preparationUpdater.update(step, stepNode.getRowMetadata());
+                        preparationUpdater.update(step, actionNode.getActionContext().getRowMetadata());
                         break;
                 }
 


### PR DESCRIPTION
* Use parent step output metadata iso. step's input metadata.
* Remove unused method in step node to avoid confusion.

(cherry picked from commit e3a4dbf3fbba8e4c5f7111c9a372829ee8934bcd)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5864

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
