### PR TITLE
chore: Default#convertResponse avoid toString before read JSON value

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/command/Defaults.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/command/Defaults.java
@@ -12,10 +12,17 @@
 
 package org.talend.dataprep.command;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.MappingIterator;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.talend.daikon.exception.ExceptionContext.build;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
@@ -30,16 +37,10 @@ import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
 import org.talend.dataprep.io.ReleasableInputStream;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.talend.daikon.exception.ExceptionContext.build;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A helper class for common behavior definition.
@@ -136,12 +137,11 @@ public class Defaults {
      */
     public static <T> BiFunction<HttpRequestBase, HttpResponse, T> convertResponse(ObjectMapper mapper, Class<T> clazz) {
         return (request, response) -> {
-            try (final InputStream content = response.getEntity().getContent()) {
-                final String contentAsString = IOUtils.toString(content, UTF_8);
-                if (StringUtils.isEmpty(contentAsString)) {
+            try (InputStream content = response.getEntity().getContent()) {
+                if (content.available() == 0) {
                     return null;
                 } else {
-                    return mapper.readerFor(clazz).readValue(contentAsString);
+                    return mapper.readerFor(clazz).readValue(content);
                 }
             } catch (IOException e) {
                 throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/command/Defaults.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/command/Defaults.java
@@ -138,11 +138,7 @@ public class Defaults {
     public static <T> BiFunction<HttpRequestBase, HttpResponse, T> convertResponse(ObjectMapper mapper, Class<T> clazz) {
         return (request, response) -> {
             try (InputStream content = response.getEntity().getContent()) {
-                if (content.available() == 0) {
-                    return null;
-                } else {
                     return mapper.readerFor(clazz).readValue(content);
-                }
             } catch (IOException e) {
                 throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
             } finally {
@@ -180,7 +176,7 @@ public class Defaults {
         return (request, response) -> {
             try (InputStream content = response.getEntity().getContent()) {
                 return mapper.readerFor(typeReference).readValue(content);
-            } catch (Exception e) {
+            } catch (IOException e) {
                 return errorHandler.apply(e);
             } finally {
                 request.releaseConnection();


### PR DESCRIPTION
Avoid useless (and costly) usage of `IOUtils.toString` before Jackson object mapping.

note: `Defaults#convertResponse(ObjectMapper mapper,
            TypeReference<T> typeReference, Function<Exception, T> errorHandler` already use InputStream as parameter of `ObjectMapper#readValue` method

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
