### PR TITLE
fix(TDP-5891): publish DatasetUpdateEvent after unlock

### DIFF
--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/DataSetService.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/DataSetService.java
@@ -52,7 +52,6 @@ import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import javax.annotation.Resource;
 
 import org.apache.commons.compress.utils.IOUtils;
@@ -933,11 +932,8 @@ public class DataSetService extends BaseDataSetService {
                 metadataForUpdate.getContent().setNbRecords(0);
                 dataSetMetadataRepository.save(metadataForUpdate);
 
-                // all good mate!! so send that to jms
                 // Asks for a in depth schema analysis (for column type information).
                 analyzeDataSet(dataSetId, singletonList(FormatAnalysis.class));
-
-                publisher.publishEvent(new DatasetUpdatedEvent(dataSetMetadata));
             } catch (TDPException e) {
                 throw e;
             } catch (Exception e) {
@@ -946,6 +942,7 @@ public class DataSetService extends BaseDataSetService {
         } finally {
             lock.unlock();
         }
+        publisher.publishEvent(new DatasetUpdatedEvent(dataSetMetadata));
     }
 
     /**


### PR DESCRIPTION
* apply the same strategy than TDP-5873/75 - publish event after unlock the initial lock because publish event will create a new lock with the technical user

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5891

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
