### PR TITLE
fix(TDP-5888): Add missing metadata in preparation details

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/PreparationDetailsDTO.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/PreparationDetailsDTO.java
@@ -3,6 +3,7 @@ package org.talend.dataprep.api.preparation;
 import java.util.List;
 
 import org.talend.dataprep.api.action.ActionForm;
+import org.talend.dataprep.api.dataset.RowMetadata;
 
 public class PreparationDetailsDTO {
 
@@ -33,6 +34,16 @@ public class PreparationDetailsDTO {
     private boolean allowDistributedRun;
 
     private boolean allowFullRun = false;
+
+    private RowMetadata rowMetadata;
+
+    public RowMetadata getRowMetadata() {
+        return rowMetadata;
+    }
+
+    public void setRowMetadata(RowMetadata rowMetadata) {
+        this.rowMetadata = rowMetadata;
+    }
 
     public String getId() {
         return id;

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/configuration/PreparationConversions.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/configuration/PreparationConversions.java
@@ -97,6 +97,10 @@ public class PreparationConversions extends BeanConversionServiceWrapper {
                 .collect(toList());
         target.setDiff(diffs);
 
+        // TDP-5888: It is important for Spark runs to have a row metadata to describe initial data schema.
+        final PersistentPreparation preparation = preparationRepository.get(source.getId(), PersistentPreparation.class);
+        target.setRowMetadata(preparation.getRowMetadata());
+
         return target;
     }
 


### PR DESCRIPTION
* Re-add missing row metadata in preparation details for Spark jobs.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5888

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
