### PR TITLE
fix(TDP-5891): missing Schema & DataStore properties from TCOMPLocation

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/DataSetAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/DataSetAPI.java
@@ -323,7 +323,7 @@ public class DataSetAPI extends APIService {
         Stream<UserDataSetMetadata> listDataSets = list(sort, order, name, certified, favorite, limit);
         return listDataSets //
                 .map(m -> {
-                    LOG.debug("found dataset {} in the summary list" + m.getName());
+                    LOG.debug("found dataset [{}] in the summary list", m.getName());
                     // Add the related preparations list to the given dataset metadata.
                     final PreparationSearchByDataSetId getPreparations = getCommand(PreparationSearchByDataSetId.class,
                             m.getId());


### PR DESCRIPTION
* Add Schema and datastore properties from TCOMPLocation during the conversion of Dataset (Catalog) / DataSetMetadata

[misc]

fix debug log in DataSetAPI in summary endpoint

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5891
**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
