### PR TITLE
fix(TDP-5898) Previous preparation results are no longer used

### DIFF
--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -81,6 +81,7 @@ import org.talend.dataprep.api.preparation.StepDiff;
 import org.talend.dataprep.async.AsyncExecutionId;
 import org.talend.dataprep.async.AsyncOperation;
 import org.talend.dataprep.async.AsyncParameter;
+import org.talend.dataprep.async.conditional.ConditionalTest;
 import org.talend.dataprep.async.conditional.GetPrepContentAsyncCondition;
 import org.talend.dataprep.async.conditional.GetPrepMetadataAsyncCondition;
 import org.talend.dataprep.async.generator.ExportParametersExecutionIdGenerator;
@@ -225,20 +226,20 @@ public class TransformationService extends BaseTransformationService {
             value = "Preparation id to apply.") @RequestBody @Valid @AsyncParameter @AsyncExecutionId final ExportParameters parameters)
             throws IOException {
 
-        ExportParameters completeParameters = parameters;
+        ExportParameters completeParameters = exportParametersUtil.populateFromPreparationExportParameter(parameters);
 
-        if (StringUtils.isNotEmpty(completeParameters.getPreparationId())) {
-            // we deal with preparation transformation (not dataset)
-            completeParameters = exportParametersUtil.populateFromPreparationExportParameter(parameters);
-
-            ContentCacheKey cacheKey = cacheKeyGenerator.generateContentKey(completeParameters);
-
-            if (!contentCache.has(cacheKey)) {
-                preparationExportStrategy.performPreparation(completeParameters, new NullOutputStream());
-            }
+        // Async behavior
+        final ConditionalTest conditionalTest = applicationContext.getBean(GetPrepContentAsyncCondition.class);
+        if (conditionalTest.apply(completeParameters)) {
+            // write to cache
+            executeSampleExportStrategy(completeParameters).writeTo(new NullOutputStream());
+            return outputStream -> {
+                outputStream.close();
+            };
+        } else {
+            // sync behavior
+            return executeSampleExportStrategy(completeParameters);
         }
-
-        return executeSampleExportStrategy(completeParameters);
     }
 
     @RequestMapping(value = "/apply/preparation/{preparationId}/{stepId}/metadata", method = GET)

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -234,7 +234,6 @@ public class TransformationService extends BaseTransformationService {
             // write to cache
             executeSampleExportStrategy(completeParameters).writeTo(new NullOutputStream());
             return outputStream -> {
-                outputStream.close();
             };
         } else {
             // sync behavior

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
@@ -271,7 +271,7 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
                 LOGGER.debug("Not enough steps ({}) in preparation.", steps.size());
                 return null;
             }
-            if (StringUtils.equals("head", stepId) || StringUtils.isEmpty(stepId)) {
+            if ("head".equals(stepId)  || StringUtils.isEmpty(stepId) || steps.get(steps.size() - 1).equals(stepId)) {
                 version = steps.get(steps.size() - 1);
                 previousVersion = steps.get(steps.size() - 2);
             }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
@@ -271,9 +271,12 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
                 LOGGER.debug("Not enough steps ({}) in preparation.", steps.size());
                 return null;
             }
-            if ("head".equals(stepId)  || StringUtils.isEmpty(stepId) || steps.get(steps.size() - 1).equals(stepId)) {
+            if (StringUtils.equals("head", stepId) || StringUtils.isEmpty(stepId)) {
                 version = steps.get(steps.size() - 1);
                 previousVersion = steps.get(steps.size() - 2);
+            } else {
+                version = stepId;
+                previousVersion = steps.get(preparation.getSteps().indexOf(version) - 1);
             }
             // Get metadata of previous step
             final TransformationMetadataCacheKey transformationMetadataCacheKey = cacheKeyGenerator.generateMetadataKey(preparationId, previousVersion, sourceType);


### PR DESCRIPTION
* Use the executeSampleStrategy any time, to cache when we send a HTTP 202 to StreamingResponseBody otherwise.
* Fix the accept of OptimizedExportStrategy
* Fix the ApplyPreparationToContentStrategy

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5898

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
