### PR TITLE
fix(TDP-5891): Provide dataset rows value when listing TCOMP datasets

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/dataset/adapter/Dataset.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/dataset/adapter/Dataset.java
@@ -88,7 +88,7 @@ public class Dataset {
         private String sheetName;
         private String tag;
 
-        private long records;
+        private long nbRecords;
 
         public DataSetMetadataLegacy() {
         }
@@ -133,12 +133,12 @@ public class Dataset {
             this.tag = tag;
         }
 
-        public long getRecords() {
-            return records;
+        public long getNbRecords() {
+            return nbRecords;
         }
 
-        public void setRecords(long records) {
-            this.records = records;
+        public void setNbRecords(long nbRecords) {
+            this.nbRecords = nbRecords;
         }
     }
 

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/dataset/adapter/Dataset.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/dataset/adapter/Dataset.java
@@ -88,6 +88,8 @@ public class Dataset {
         private String sheetName;
         private String tag;
 
+        private long records;
+
         public DataSetMetadataLegacy() {
         }
 
@@ -131,6 +133,13 @@ public class Dataset {
             this.tag = tag;
         }
 
+        public long getRecords() {
+            return records;
+        }
+
+        public void setRecords(long records) {
+            this.records = records;
+        }
     }
 
     public Dataset() {

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/DatasetClient.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/DatasetClient.java
@@ -15,7 +15,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
 import javax.annotation.PostConstruct;
 
 import org.apache.avro.Schema;
@@ -273,7 +272,6 @@ public class DatasetClient {
                 && rowMetadata.getColumns().stream().map(ColumnMetadata::getStatistics).anyMatch(this::isComputedStatistics)) {
             AnalysisResult analysisResult = datasetAnalysisSupplier.apply(dataset.getId());
             metadata.setRowMetadata(new RowMetadata(analysisResult.rowMetadata));
-            metadata.setDataSetSize(analysisResult.rowcount);
             metadata.getContent().setNbRecords(analysisResult.rowcount);
         }
 

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversion.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversion.java
@@ -104,7 +104,6 @@ public class DatasetBeanConversion extends BeanConversionServiceWrapper {
                         dataSetMetadata.setDraft(dataSetMetadataLegacy.isDraft());
                         dataSetMetadata.setEncoding(dataSetMetadataLegacy.getEncoding());
                         dataSetMetadata.setTag(dataSetMetadataLegacy.getTag());
-                        dataSetMetadata.setDataSetSize(dataSetMetadataLegacy.getNbRecords());
                         dataSetMetadata.getContent().setNbRecords(dataSetMetadataLegacy.getNbRecords());
                     }
 

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversion.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversion.java
@@ -104,8 +104,8 @@ public class DatasetBeanConversion extends BeanConversionServiceWrapper {
                         dataSetMetadata.setDraft(dataSetMetadataLegacy.isDraft());
                         dataSetMetadata.setEncoding(dataSetMetadataLegacy.getEncoding());
                         dataSetMetadata.setTag(dataSetMetadataLegacy.getTag());
-                        dataSetMetadata.setDataSetSize(dataSetMetadataLegacy.getRecords());
-                        dataSetMetadata.getContent().setNbRecords(dataSetMetadataLegacy.getRecords());
+                        dataSetMetadata.setDataSetSize(dataSetMetadataLegacy.getNbRecords());
+                        dataSetMetadata.getContent().setNbRecords(dataSetMetadataLegacy.getNbRecords());
                     }
 
                     return dataSetMetadata;

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversion.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversion.java
@@ -104,6 +104,8 @@ public class DatasetBeanConversion extends BeanConversionServiceWrapper {
                         dataSetMetadata.setDraft(dataSetMetadataLegacy.isDraft());
                         dataSetMetadata.setEncoding(dataSetMetadataLegacy.getEncoding());
                         dataSetMetadata.setTag(dataSetMetadataLegacy.getTag());
+                        dataSetMetadata.setDataSetSize(dataSetMetadataLegacy.getRecords());
+                        dataSetMetadata.getContent().setNbRecords(dataSetMetadataLegacy.getRecords());
                     }
 
                     return dataSetMetadata;

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/adapter/conversion/DataSetMetadataBeanConversion.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/adapter/conversion/DataSetMetadataBeanConversion.java
@@ -80,7 +80,7 @@ public class DataSetMetadataBeanConversion extends BeanConversionServiceWrapper 
                     metadataLegacy.setSchemaParserResult(dataSetMetadata.getSchemaParserResult());
                     metadataLegacy.setEncoding(dataSetMetadata.getEncoding());
                     metadataLegacy.setTag(dataSetMetadata.getTag());
-                    metadataLegacy.setRecords(dataSetMetadata.getContent().getNbRecords());
+                    metadataLegacy.setNbRecords(dataSetMetadata.getContent().getNbRecords());
                     dataset.setDataSetMetadataLegacy(metadataLegacy);
 
                     return dataset;

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/adapter/conversion/DataSetMetadataBeanConversion.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/adapter/conversion/DataSetMetadataBeanConversion.java
@@ -15,6 +15,8 @@
 
 package org.talend.dataprep.dataset.adapter.conversion;
 
+import static org.talend.dataprep.conversions.BeanConversionService.fromBean;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.dataset.DataSetGovernance;
@@ -29,8 +31,6 @@ import org.talend.dataprep.processor.BeanConversionServiceWrapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import static org.talend.dataprep.conversions.BeanConversionService.fromBean;
 
 @Component
 public class DataSetMetadataBeanConversion extends BeanConversionServiceWrapper {
@@ -80,6 +80,7 @@ public class DataSetMetadataBeanConversion extends BeanConversionServiceWrapper 
                     metadataLegacy.setSchemaParserResult(dataSetMetadata.getSchemaParserResult());
                     metadataLegacy.setEncoding(dataSetMetadata.getEncoding());
                     metadataLegacy.setTag(dataSetMetadata.getTag());
+                    metadataLegacy.setRecords(dataSetMetadata.getContent().getNbRecords());
                     dataset.setDataSetMetadataLegacy(metadataLegacy);
 
                     return dataset;

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/analysis/asynchronous/BackgroundAnalysis.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/analysis/asynchronous/BackgroundAnalysis.java
@@ -90,7 +90,7 @@ public class BackgroundAnalysis {
                 try (final Stream<DataSetRow> stream = store.stream(metadata)) {
                     try (Analyzer<Analyzers.Result> analyzer = analyzerService.schemaAnalysis(columns)) {
                         computeStatistics(analyzer, columns, stream);
-                        LOGGER.debug("Base statistics analysis done for{}", dataSetId);
+                        LOGGER.debug("Base statistics analysis done for {}", dataSetId);
                         // Save base analysis
                         saveAnalyzerResults(dataSetId, analyzer);
                     }


### PR DESCRIPTION
Manage records number in legacy dataset properties.
Since TDP-5822 (dc04617), we can't fetch the dataset content to analyse and set the dataset records number.

> LocalStoreLocation and JobLocation stores Dataset content and Location in Dataset properties 
(Dataset Catalog) as JSON.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5891

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
