### PR TITLE
fix(TDP-5895): Fix wrong owner in shared preparations

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/PreparationAPI.java
@@ -85,7 +85,6 @@ import org.talend.dataprep.command.preparation.PreparationGetActions;
 import org.talend.dataprep.command.preparation.PreparationSummaryGet;
 import org.talend.dataprep.command.preparation.PreparationUpdate;
 import org.talend.dataprep.conversions.inject.DataSetNameInjection;
-import org.talend.dataprep.conversions.inject.OwnerInjection;
 import org.talend.dataprep.dataset.adapter.DatasetClient;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.APIErrorCodes;
@@ -130,9 +129,8 @@ public class PreparationAPI extends APIService {
             @ApiParam(value = "Order for sort key (desc or asc), defaults to 'desc'.") @RequestParam(defaultValue = "desc") Order order) {
         GenericCommand<InputStream> command = getCommand(PreparationList.class, name, folderPath, path, sort, order);
         if ("summary".equalsIgnoreCase(format)) {
-            final OwnerInjection ownerInjection = context.getBean(OwnerInjection.class);
             return toStream(PreparationDTO.class, mapper, command) //
-                    .map(dto -> beanConversionService.convert(dto, PreparationListItemDTO.class, dataSetNameInjection, ownerInjection));
+                    .map(dto -> beanConversionService.convert(dto, PreparationListItemDTO.class, dataSetNameInjection));
         } else {
             return toStream(PreparationDTO.class, mapper, command) //
                     .map(dto -> beanConversionService.convert(dto, PreparationListItemDTO.class, dataSetNameInjection));

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/DefaultOwnerInjection.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/DefaultOwnerInjection.java
@@ -1,0 +1,33 @@
+package org.talend.dataprep.conversions.inject;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.talend.dataprep.api.preparation.PreparationDTO;
+import org.talend.dataprep.api.share.Owner;
+import org.talend.dataprep.security.Security;
+
+/**
+ * A default implementation of {@link OwnerInjection} dedicated to environments with no security enabled.
+ */
+public class DefaultOwnerInjection implements OwnerInjection {
+
+    @Autowired
+    private Security security;
+
+    private Owner defaultOwner;
+
+    @PostConstruct
+    public void init() {
+        defaultOwner = new Owner(security.getUserId(), security.getUserDisplayName(), StringUtils.EMPTY);
+    }
+
+    @Override
+    public PreparationDTO apply(Object o, PreparationDTO dto) {
+        if (dto.getOwner() == null) {
+            dto.setOwner(defaultOwner);
+        }
+        return dto;
+    }
+}

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/Injections.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/Injections.java
@@ -16,7 +16,7 @@ public class Injections {
     @Bean
     @Scope("prototype")
     public OwnerInjection ownerInjection() {
-        return new OwnerInjection();
+        return new DefaultOwnerInjection();
     }
 
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/Injections.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/Injections.java
@@ -1,5 +1,8 @@
 package org.talend.dataprep.conversions.inject;
 
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_SINGLETON;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -8,13 +11,13 @@ import org.springframework.context.annotation.Scope;
 public class Injections {
 
     @Bean
-    @Scope("singleton")
+    @Scope(SCOPE_SINGLETON)
     public DataSetNameInjection dataSetNameInjection()  {
         return new DataSetNameInjection();
     }
 
     @Bean
-    @Scope("prototype")
+    @Scope(SCOPE_PROTOTYPE)
     public OwnerInjection ownerInjection() {
         return new DefaultOwnerInjection();
     }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/OwnerInjection.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/OwnerInjection.java
@@ -2,29 +2,12 @@ package org.talend.dataprep.conversions.inject;
 
 import java.util.function.BiFunction;
 
-import javax.annotation.PostConstruct;
+import org.talend.dataprep.api.preparation.PreparationDTO;
 
-import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.talend.dataprep.api.share.Owner;
-import org.talend.dataprep.api.share.SharedResource;
-import org.talend.dataprep.security.Security;
-
-public class OwnerInjection<T extends SharedResource> implements BiFunction<Object, T, T> {
-
-    @Autowired
-    private Security security;
-
-    private Owner owner;
-
-    @PostConstruct
-    public void init() {
-        owner = new Owner(security.getUserId(), security.getUserDisplayName(), StringUtils.EMPTY);
-    }
-
-    @Override
-    public T apply(Object persistentPreparation, T dto) {
-        dto.setOwner(owner);
-        return dto;
-    }
+/**
+ * An API to ease {@link org.talend.dataprep.api.share.Owner} injection in {@link PreparationDTO} instances.
+ *
+ * @see org.talend.dataprep.conversions.BeanConversionService#convert(Object, Class, BiFunction[])
+ */
+public interface OwnerInjection extends BiFunction<Object, PreparationDTO, PreparationDTO> {
 }


### PR DESCRIPTION
* Add OS implementation in DefaultOwnerInjection

[refactoring]
* OwnerInjection is now an interface to allow OS / EE differences.
* Expose an internal method of ACL service to ease role set.

[misc]
* Removes unused owner injection at API level.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5895

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
