### PR TITLE
Revert "fix(TDP-5898) Previous preparation results are no longer used (#1486)"

### DIFF
--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/OptimizedExportStrategy.java
@@ -274,9 +274,6 @@ public class OptimizedExportStrategy extends BaseSampleExportStrategy {
             if (StringUtils.equals("head", stepId) || StringUtils.isEmpty(stepId)) {
                 version = steps.get(steps.size() - 1);
                 previousVersion = steps.get(steps.size() - 2);
-            } else {
-                version = stepId;
-                previousVersion = steps.get(preparation.getSteps().indexOf(version) - 1);
             }
             // Get metadata of previous step
             final TransformationMetadataCacheKey transformationMetadataCacheKey = cacheKeyGenerator.generateMetadataKey(preparationId, previousVersion, sourceType);


### PR DESCRIPTION

This reverts commit f3c624c77118163c3bacb96fbf4b5313f9e660c9.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-XXXX

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
