### PR TITLE
fix(TDP-5977): Fix missing Zipkin spans for preparation list operation

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/FolderAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/FolderAPI.java
@@ -16,18 +16,13 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
-import static org.talend.daikon.exception.ExceptionContext.build;
-import static org.talend.dataprep.command.CommandHelper.toPublisher;
+import static org.talend.dataprep.command.CommandHelper.toStream;
 
-import java.io.EOFException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -57,12 +52,11 @@ import org.talend.dataprep.metrics.Timed;
 import org.talend.dataprep.util.SortAndOrderHelper.Order;
 import org.talend.dataprep.util.SortAndOrderHelper.Sort;
 
-import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.hystrix.HystrixCommand;
 
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
-import reactor.core.publisher.Flux;
 
 @RestController
 public class FolderAPI extends APIService {
@@ -179,7 +173,7 @@ public class FolderAPI extends APIService {
     @RequestMapping(value = "/api/folders/{id}/preparations", method = RequestMethod.GET, produces = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Get all preparations for a given id.", notes = "Returns the list of preparations for the given id the current user is allowed to see.")
     @Timed
-    public StreamingResponseBody listPreparationsByFolder(
+    public ListPreparationsByFolder listPreparationsByFolder(
             @PathVariable @ApiParam(name = "id", value = "The destination to search preparations from.") final String id, //
             @ApiParam(value = "Sort key (by name or date), defaults to 'date'.") @RequestParam(defaultValue = "creationDate") final Sort sort, //
             @ApiParam(value = "Order for sort key (desc or asc), defaults to 'desc'.") @RequestParam(defaultValue = "desc") final Order order) {
@@ -191,86 +185,24 @@ public class FolderAPI extends APIService {
 
         LOG.info("Listing preparations in folder {}", id);
 
-        return output -> {
-            try (final JsonGenerator generator = mapper.getFactory().createGenerator(output)) {
-                generator.writeStartObject();
-                // Folder list
-                final FolderChildrenList commandListFolders = getCommand(FolderChildrenList.class, id, sort, order);
-                final Flux<Folder> folders = Flux.from(toPublisher(Folder.class, mapper, commandListFolders));
-                writeFluxToJsonArray(folders, "folders", generator);
-                // Preparation list
-                final PreparationListByFolder listPreparations = getCommand(PreparationListByFolder.class, id, sort, order);
+        final ListPreparationsByFolder result = new ListPreparationsByFolder();
+        final FolderChildrenList commandListFolders = getCommand(FolderChildrenList.class, id, sort, order);
+        result.folders = toStream(Folder.class, mapper, commandListFolders);
 
-                final Stream<PreparationListItemDTO> preparations = CommandHelper.toStream(PreparationDTO.class, mapper, listPreparations)
-                        .map(dto -> beanConversionService.convert(dto, PreparationListItemDTO.class, dataSetNameInjection));
+        final PreparationListByFolder listPreparations = getCommand(PreparationListByFolder.class, id, sort, order);
+        result.preparations = toStream(PreparationDTO.class, mapper, listPreparations)
+                .map(dto -> beanConversionService.convert(dto, PreparationListItemDTO.class, dataSetNameInjection));
 
-                generator.writeObjectField("preparations", preparations);
-                generator.writeEndObject();
-            } catch (EOFException e) {
-                LOG.debug("Output stream has been closed before finishing preparation writing.", e);
-            } catch (IOException e) {
-                throw new TDPException(APIErrorCodes.UNABLE_TO_LIST_FOLDER_ENTRIES, e, build().put("destination", id));
-            }
-        };
+        return result;
     }
 
-    private static <T> void writeFluxToJsonArray(Flux<T> flux, String arrayElement, JsonGenerator generator) {
-        flux.subscribe(new WriteJsonArraySubscriber<>(generator, arrayElement));
+    public static class ListPreparationsByFolder {
+        @JsonProperty("folders")
+        Stream<Folder> folders;
+
+        @JsonProperty("preparations")
+        Stream<PreparationListItemDTO> preparations;
+
     }
 
-    private static class WriteJsonArraySubscriber<T> implements Subscriber<T> {
-
-        private final JsonGenerator generator;
-
-        private final String arrayElement;
-
-        private Subscription subscription;
-
-        public WriteJsonArraySubscriber(JsonGenerator generator, String arrayElement) {
-            this.generator = generator;
-            this.arrayElement = arrayElement;
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            try {
-                generator.writeArrayFieldStart(arrayElement);
-            } catch (EOFException eofe) {
-                LOG.debug("JsonGenerator was closed before finish streaming.", eofe);
-                subscription.cancel();
-            } catch (IOException e) {
-                LOG.error("Unable to write content.", e);
-            }
-            subscription = s;
-            s.request(Long.MAX_VALUE);
-        }
-
-        @Override
-        public void onNext(T aLong) {
-            try {
-                generator.writeObject(aLong);
-            } catch (EOFException eofe) {
-                LOG.debug("JsonGenerator was closed before finish streaming.", eofe);
-                subscription.cancel();
-            } catch (IOException e) {
-                LOG.error("Unable to write content.", e);
-            }
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            onComplete();
-        }
-
-        @Override
-        public void onComplete() {
-            try {
-                generator.writeEndArray();
-            } catch (EOFException eofe) {
-                LOG.debug("JsonGenerator was closed before finish streaming.", eofe);
-            } catch (IOException e) {
-                LOG.error("Unable to write content.", e);
-            }
-        }
-    }
 }


### PR DESCRIPTION
* Remove use of Flux to prevent non traced requests.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5977

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
