### PR TITLE
fix(TDP-5968): Migrate to dataset name in preparation

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/Preparation.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/Preparation.java
@@ -65,6 +65,8 @@ public class Preparation extends Identifiable implements Serializable {
     /** The user locking the preparation. */
     private BasicUserLock lock;
 
+    private String dataSetName;
+
     /**
      * Default empty constructor.
      */
@@ -243,5 +245,13 @@ public class Preparation extends Identifiable implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(id, rowMetadata, dataSetId, author, name, creationDate, lastModificationDate, headId);
+    }
+
+    public void setDataSetName(String dataSetName) {
+        this.dataSetName = dataSetName;
+    }
+
+    public String getDataSetName() {
+        return dataSetName;
     }
 }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/PreparationDTO.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/PreparationDTO.java
@@ -21,6 +21,8 @@ public class PreparationDTO implements SharedResource {
     /** The creation date. */
     private String dataSetId;
 
+    private String dataSetName;
+
     /** The preparation name. */
     private String name;
 
@@ -38,6 +40,19 @@ public class PreparationDTO implements SharedResource {
 
     private String headId;
 
+    public String getDataSetName() {
+        return dataSetName;
+    }
+
+    public void setDataSetName(String dataSetName) {
+        this.dataSetName = dataSetName;
+    }
+
+    /**
+     * @return The data set id
+     * @deprecated Use {@link #dataSetName} instead.
+     */
+    @Deprecated
     public String getDataSetId() {
         return dataSetId;
     }

--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/PreparationListItemDTO.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/PreparationListItemDTO.java
@@ -26,6 +26,8 @@ public class PreparationListItemDTO implements SharedResource {
     /** The preparation name. */
     private String name;
 
+    private String dataSetName;
+
     private List<String> steps;
 
     private Owner owner;

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/DataSetNameInjection.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/DataSetNameInjection.java
@@ -39,10 +39,8 @@ public class DataSetNameInjection implements BiFunction<PreparationDTO, Preparat
 
     @Override
     public PreparationListItemDTO apply(PreparationDTO dto, PreparationListItemDTO item) {
-        if (dto.getDataSetName() != null) {
-            item.getDataSet().setDataSetName(dto.getDataSetName());
-            return item;
-        } else {
+        String dataSetName = dto.getDataSetName();
+        if (dataSetName == null) {
             try {
                 final String tenantId = security.getTenantId();
                 final Cache<String, String> tenantCache = cache.get(tenantId, this::initTenant);
@@ -54,12 +52,13 @@ public class DataSetNameInjection implements BiFunction<PreparationDTO, Preparat
                         securityProxy.releaseIdentity();
                     }
                 }
-                item.getDataSet().setDataSetName(tenantCache.getIfPresent(dto.getDataSetId()));
-                return item;
+                dataSetName = tenantCache.getIfPresent(dto.getDataSetId());
             } catch (ExecutionException e) {
                 throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
             }
         }
+        item.getDataSet().setDataSetName(dataSetName);
+        return item;
     }
 
     private Cache<String, String> initTenant() {

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/DataSetNameInjection.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/DataSetNameInjection.java
@@ -5,24 +5,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
 import org.talend.dataprep.api.preparation.PreparationDTO;
 import org.talend.dataprep.api.preparation.PreparationListItemDTO;
 import org.talend.dataprep.dataset.adapter.DatasetClient;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
 import org.talend.dataprep.security.Security;
+import org.talend.dataprep.security.SecurityProxy;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import org.talend.dataprep.security.SecurityProxy;
 
 public class DataSetNameInjection implements BiFunction<PreparationDTO, PreparationListItemDTO, PreparationListItemDTO> {
 
     private final Cache<String, Cache<String, String>> cache;
-
-    @Autowired
-    private ApplicationContext applicationContext;
 
     @Autowired
     private Security security;
@@ -43,21 +39,26 @@ public class DataSetNameInjection implements BiFunction<PreparationDTO, Preparat
 
     @Override
     public PreparationListItemDTO apply(PreparationDTO dto, PreparationListItemDTO item) {
-        try {
-            final String tenantId = security.getTenantId();
-            final Cache<String, String> tenantCache = cache.get(tenantId, this::initTenant);
-            if (tenantCache.getIfPresent(dto.getDataSetId()) == null) {
-                securityProxy.asTechnicalUserForDataSet();
-                try{
-                    tenantCache.put(dto.getDataSetId(), datasetClient.getDataSetMetadata(dto.getDataSetId()).getName());
-                } finally {
-                    securityProxy.releaseIdentity();
-                }
-            }
-            item.getDataSet().setDataSetName(tenantCache.getIfPresent(dto.getDataSetId()));
+        if (dto.getDataSetName() != null) {
+            item.getDataSet().setDataSetName(dto.getDataSetName());
             return item;
-        } catch (ExecutionException e) {
-            throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
+        } else {
+            try {
+                final String tenantId = security.getTenantId();
+                final Cache<String, String> tenantCache = cache.get(tenantId, this::initTenant);
+                if (tenantCache.getIfPresent(dto.getDataSetId()) == null) {
+                    securityProxy.asTechnicalUserForDataSet();
+                    try {
+                        tenantCache.put(dto.getDataSetId(), datasetClient.getDataSetMetadata(dto.getDataSetId()).getName());
+                    } finally {
+                        securityProxy.releaseIdentity();
+                    }
+                }
+                item.getDataSet().setDataSetName(tenantCache.getIfPresent(dto.getDataSetId()));
+                return item;
+            } catch (ExecutionException e) {
+                throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
+            }
         }
     }
 

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/preparation/store/PersistentPreparation.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/preparation/store/PersistentPreparation.java
@@ -36,8 +36,14 @@ public class PersistentPreparation extends PersistentIdentifiable {
     @Version
     private Long version;
 
-    /** The dataset id. */
+    /**
+     * The dataset id.
+     * @deprecated Use {@link #dataSetName} instead.
+     */
+    @Deprecated
     private String dataSetId;
+
+    private String dataSetName;
 
     /** Metadata on which the preparation is based. **/
     private RowMetadata rowMetadata;
@@ -95,10 +101,20 @@ public class PersistentPreparation extends PersistentIdentifiable {
         this.name = name;
     }
 
+    public String getDataSetName() {
+        return dataSetName;
+    }
+
+    public void setDataSetName(String dataSetName) {
+        this.dataSetName = dataSetName;
+    }
+
+    @Deprecated
     public String getDataSetId() {
         return dataSetId;
     }
 
+    @Deprecated
     public void setDataSetId(String dataSetId) {
         this.dataSetId = dataSetId;
     }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/util/SortAndOrderHelper.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/util/SortAndOrderHelper.java
@@ -13,7 +13,6 @@
 package org.talend.dataprep.util;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.slf4j.LoggerFactory.getLogger;
 import static org.talend.daikon.exception.ExceptionContext.build;
 import static org.talend.dataprep.exception.error.CommonErrorCodes.ILLEGAL_ORDER_FOR_LIST;
 import static org.talend.dataprep.exception.error.CommonErrorCodes.ILLEGAL_SORT_FOR_LIST;
@@ -23,7 +22,6 @@ import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.slf4j.Logger;
 import org.talend.dataprep.api.dataset.DataSetMetadata;
 import org.talend.dataprep.api.folder.Folder;
 import org.talend.dataprep.api.preparation.Preparation;
@@ -85,8 +83,6 @@ public final class SortAndOrderHelper {
             return snakeToCamelCaseConverter.convert(name());
         }
     }
-
-    private static final Logger LOGGER = getLogger(SortAndOrderHelper.class);
 
     private static final Converter<String, String> snakeToCamelCaseConverter = CaseFormat.UPPER_UNDERSCORE
             .converterTo(CaseFormat.LOWER_CAMEL);
@@ -233,7 +229,7 @@ public final class SortAndOrderHelper {
                 keyExtractor = preparation -> preparation.getSteps().size();
                 break;
             case DATASET_NAME:
-                keyExtractor = PreparationDTO::getDataSetName;
+                keyExtractor = p -> Optional.ofNullable(p.getDataSetName()).orElse(EMPTY);
                 break;
             default:
                 // this should not be possible

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/util/SortAndOrderHelperTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/util/SortAndOrderHelperTest.java
@@ -183,20 +183,16 @@ public class SortAndOrderHelperTest {
             long firstSize, long secondSize, //
             String firstDsName, String secondDsName, //
             Sort sort, Order order) {
-        String firstDsId = "firstDsId";
         PreparationDTO firstUserPrep = createUserPreparation(firstName, firstAuthor, firstCreation, firstModification, firstSize,
-                firstDsId);
-        DataSetMetadata firstDs = new DataSetMetadata(firstDsId, firstDsName, null, 0, 0, null, null);
+                firstDsName);
 
-        String secondDsId = "secondDsId";
         PreparationDTO secondUserPrep = createUserPreparation(secondName, secondAuthor, secondCreation, secondModification,
-                secondSize, secondDsId);
-        DataSetMetadata secondDs = new DataSetMetadata(secondDsId, secondDsName, null, 0, 0, null, null);
+                secondSize, secondDsName);
 
-        PreparationDTO firstPrep = createUserPreparation(firstName, firstAuthor, firstCreation, firstModification, firstSize, firstDsId);
+        PreparationDTO firstPrep = createUserPreparation(firstName, firstAuthor, firstCreation, firstModification, firstSize, firstDsName);
 
         PreparationDTO secondPrep = createUserPreparation(secondName, secondAuthor, secondCreation, secondModification, secondSize,
-                secondDsId);
+                secondDsName);
 
         // when
         Comparator<PreparationDTO> preparationComparator = SortAndOrderHelper.getPreparationComparator(sort, order
@@ -298,9 +294,9 @@ public class SortAndOrderHelperTest {
     }
 
     private PreparationDTO createUserPreparation(String name, String author, long creation, long modification, long size,
-                                                 String dsId) {
+                                                 String dataSetName) {
         PreparationDTO firstPrep = new PreparationDTO();
-        firstPrep.setDataSetId(dsId);
+        firstPrep.setDataSetName(dataSetName);
         firstPrep.setName(name);
         firstPrep.setAuthor("1234");
         firstPrep.setOwner(new Owner("1234", author, ""));

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/util/SortAndOrderHelperTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/util/SortAndOrderHelperTest.java
@@ -31,7 +31,6 @@ import java.beans.PropertyEditor;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 
 import org.junit.Test;
 import org.talend.dataprep.api.dataset.DataSetMetadata;
@@ -200,9 +199,8 @@ public class SortAndOrderHelperTest {
                 secondDsId);
 
         // when
-        Comparator<PreparationDTO> preparationComparator = SortAndOrderHelper.getPreparationComparator(sort, order,
-                p -> Objects.equals(p.getDataSetId(), firstDsId) ? firstDs
-                        : (Objects.equals(p.getDataSetId(), secondDsId) ? secondDs : null));
+        Comparator<PreparationDTO> preparationComparator = SortAndOrderHelper.getPreparationComparator(sort, order
+        );
 
         // then
         assertNotNull(preparationComparator);

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/event/PreparationEventUtil.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/event/PreparationEventUtil.java
@@ -115,10 +115,7 @@ public class PreparationEventUtil {
             preparationRepository
                     .list(PersistentPreparation.class, eq("dataSetId", dataSetId)) //
                     .forEach(preparation -> {
-                        // Update dataset name in preparation
                         preparation.setDataSetName(dataSetMetadata.getName());
-
-                        // Reset preparation row metadata.
                         preparation.setRowMetadata(rowMetadata);
                         preparationRepository.add(preparation);
 

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/event/PreparationEventUtil.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/event/PreparationEventUtil.java
@@ -24,7 +24,7 @@ import org.talend.dataprep.security.SecurityProxy;
 /**
  * Utility class to remove all {@link StepRowMetadata} associated to a preparation that uses a given dataset.
  *
- * @see #removePreparationStepRowMetadata(String)
+ * @see #updatesFromDataSetMetadata(String)
  */
 @Component
 public class PreparationEventUtil {
@@ -54,9 +54,9 @@ public class PreparationEventUtil {
 
     public void performUpdateEvent(String datasetId) {
         LOGGER.debug("Performing update event for dataset {}", datasetId);
-        this.cleanTransformationCache(datasetId);
-        this.cleanTransformationMetadataCache(datasetId);
-        this.removePreparationStepRowMetadata(datasetId);
+        cleanTransformationCache(datasetId);
+        cleanTransformationMetadataCache(datasetId);
+        updatesFromDataSetMetadata(datasetId);
     }
 
     private void cleanTransformationCache(String datasetId) {
@@ -85,12 +85,18 @@ public class PreparationEventUtil {
     }
 
     /**
-     * Removes all {@link StepRowMetadata} of preparations that use the provided {@link DataSetMetadata} metadata.
+     * Perform all {@link DataSetMetadata} related operations:
+     * <ul>
+     * <li>Removes all {@link StepRowMetadata} of preparations that use the provided {@link DataSetMetadata}
+     * metadata.</li>
+     * <li>Update preparation's data set name.</li>
+     * </ul>
+     * Do all operations in <b>one</b> method to prevent multiple lookup for a given dataset.
      *
-     * @param dataSetId The data set id to be used in preparation search (code searches preparations
-     * that use this <code>dataSetId</code>).
+     * @param dataSetId The data set id to be used in preparation search (code searches preparations that use this
+     * <code>dataSetId</code>).
      */
-    private void removePreparationStepRowMetadata(String dataSetId) {
+    private void updatesFromDataSetMetadata(String dataSetId) {
         DataSetMetadata dataSetMetadata;
         try {
             securityProxy.asTechnicalUserForDataSet();
@@ -109,6 +115,9 @@ public class PreparationEventUtil {
             preparationRepository
                     .list(PersistentPreparation.class, eq("dataSetId", dataSetId)) //
                     .forEach(preparation -> {
+                        // Update dataset name in preparation
+                        preparation.setDataSetName(dataSetMetadata.getName());
+
                         // Reset preparation row metadata.
                         preparation.setRowMetadata(rowMetadata);
                         preparationRepository.add(preparation);

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -177,7 +177,12 @@ public class PreparationService {
         toCreate.setName(preparation.getName());
         toCreate.setDataSetId(preparation.getDataSetId());
         toCreate.setRowMetadata(preparation.getRowMetadata());
-        toCreate.setDataSetName(datasetClient.getDataSetMetadata(preparation.getDataSetId()).getName());
+        try {
+            toCreate.setDataSetName(datasetClient.getDataSetMetadata(preparation.getDataSetId()).getName());
+        } catch (Exception e) {
+            LOGGER.warn("Unable to find dataset name for preparation '{}'", preparation.getId());
+            toCreate.setDataSetId(preparation.getDataSetId());
+        }
 
         preparationRepository.add(toCreate);
 

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -177,6 +177,7 @@ public class PreparationService {
         toCreate.setName(preparation.getName());
         toCreate.setDataSetId(preparation.getDataSetId());
         toCreate.setRowMetadata(preparation.getRowMetadata());
+        toCreate.setDataSetName(datasetClient.getDataSetMetadata(preparation.getDataSetId()).getName());
 
         preparationRepository.add(toCreate);
 
@@ -268,7 +269,7 @@ public class PreparationService {
         final OwnerInjection ownerInjection = springContext.getBean(OwnerInjection.class);
         return preparationStream
                 .map(p -> beanConversionService.convert(p, PreparationDTO.class, ownerInjection)) //
-                .sorted(getPreparationComparator(sort, order, p -> datasetClient.getDataSetMetadata(p.getDataSetId())));
+                .sorted(getPreparationComparator(sort, order));
     }
 
     /**

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -181,7 +181,6 @@ public class PreparationService {
             toCreate.setDataSetName(datasetClient.getDataSetMetadata(preparation.getDataSetId()).getName());
         } catch (Exception e) {
             LOGGER.warn("Unable to find dataset name for preparation '{}'", preparation.getId());
-            toCreate.setDataSetId(preparation.getDataSetId());
         }
 
         preparationRepository.add(toCreate);

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/event/PreparationEventUtilTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/event/PreparationEventUtilTest.java
@@ -2,6 +2,7 @@ package org.talend.dataprep.preparation.event;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -94,4 +95,25 @@ public class PreparationEventUtilTest {
         verify(securityProxy, times(1)).asTechnicalUserForDataSet();
         verify(securityProxy, times(3)).releaseIdentity();
     }
+
+    @Test
+    public void shouldUpdateDataSetName() {
+        // given
+        final DataSetMetadata metadata = new DataSetMetadata();
+        metadata.setId("ds-1234");
+        metadata.setName("My updated name");
+
+        final PersistentPreparation preparation = mock(PersistentPreparation.class);
+
+        when(preparationRepository.list(eq(PersistentPreparation.class), eq(TqlBuilder.eq("dataSetId", "ds-1234"))))
+                .thenReturn(Stream.of(preparation), Stream.of(preparation));
+        when(datasetClient.getDataSetMetadata(eq("ds-1234"))).thenReturn(metadata);
+
+        // when
+        preparationEventUtil.performUpdateEvent(metadata.getId());
+
+        // then
+        verify(preparation, times(1)).setDataSetName(eq("My updated name"));
+    }
+
 }


### PR DESCRIPTION
[POJO changes]
* Add dataSetName in Preparation POJO.
* Deprecate dataSetId.
* Adapt DTOs to include dataset name.

[Data set name update]
* If dataset name misses in list operation, performs a look up to dataset service.
* Create a preparation also add linked dataset name.
* Add dataset name update operation in preparation listener for kafka event.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5968

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
