### PR TITLE
fix(TDP-5734): first execution of maintenance tasks should be async

### DIFF
--- a/dataprep-maintenance/src/main/java/org/talend/dataprep/maintenance/executor/MaintenanceScheduler.java
+++ b/dataprep-maintenance/src/main/java/org/talend/dataprep/maintenance/executor/MaintenanceScheduler.java
@@ -13,6 +13,7 @@ import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.security.Security;
@@ -32,11 +33,14 @@ public class MaintenanceScheduler {
     @Autowired
     private Security security;
 
+    @Autowired
+    private TaskExecutor taskExecutor;
+
     private Map<String, Long> runningTask = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void launchOnceTask() {
-        runMaintenanceTask(ONCE);
+        taskExecutor.execute(() -> runMaintenanceTask(ONCE));
     }
 
     @Scheduled(cron = "${maintenance.scheduled.cron}")

--- a/dataprep-maintenance/src/test/java/org/talend/dataprep/maintenance/executor/MaintenanceSchedulerTest.java
+++ b/dataprep-maintenance/src/test/java/org/talend/dataprep/maintenance/executor/MaintenanceSchedulerTest.java
@@ -1,5 +1,15 @@
 package org.talend.dataprep.maintenance.executor;
 
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -7,17 +17,6 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.talend.dataprep.maintenance.BaseMaintenanceTest;
 import org.talend.dataprep.security.Security;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class MaintenanceSchedulerTest extends BaseMaintenanceTest {
 


### PR DESCRIPTION
* use a TaskExecutor in order to run asynchronously the first maintenance tasks iteration

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5734

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
