### PR TITLE
fix(TDP-5968): Fix missing dataset name after preparation update

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/PreparationListItemDTO.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/preparation/PreparationListItemDTO.java
@@ -26,8 +26,6 @@ public class PreparationListItemDTO implements SharedResource {
     /** The preparation name. */
     private String name;
 
-    private String dataSetName;
-
     private List<String> steps;
 
     private Owner owner;

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/preparation/store/PersistentPreparation.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/preparation/store/PersistentPreparation.java
@@ -221,6 +221,7 @@ public class PersistentPreparation extends PersistentIdentifiable {
         merge.creationDate = min(other.getCreationDate(), creationDate);
         merge.id = other.getId() != null ? other.getId() : this.id;
         merge.dataSetId = other.getDataSetId() != null ? other.getDataSetId() : dataSetId;
+        merge.dataSetName = other.getDataSetName() != null ? other.getDataSetName() : dataSetName;
         merge.author = other.getAuthor() != null ? other.getAuthor() : author;
         merge.name = other.getName() != null ? other.getName() : name;
         merge.lastModificationDate = max(other.getLastModificationDate(), lastModificationDate);

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/preparation/store/PersistentPreparationTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/preparation/store/PersistentPreparationTest.java
@@ -17,6 +17,7 @@ public class PersistentPreparationTest {
         theOtherOne.setAuthor("Joss Stone");
         theOtherOne.setCreationDate(source.getCreationDate() - 1000);
         theOtherOne.setDataSetId("ds#123456");
+        theOtherOne.setDataSetName("My Dataset Name");
         theOtherOne.setLastModificationDate(theOtherOne.getCreationDate() + 12345682);
         theOtherOne.setName("my preparation name");
         theOtherOne.setHeadId(Step.ROOT_STEP.id());
@@ -26,6 +27,7 @@ public class PersistentPreparationTest {
         assertEquals("Joss Stone", actual.getAuthor());
         assertEquals(source.getCreationDate() - 1000, actual.getCreationDate());
         assertEquals("ds#123456", actual.getDataSetId());
+        assertEquals("My Dataset Name", actual.getDataSetName());
         assertEquals(theOtherOne.getCreationDate() + 12345682, actual.getLastModificationDate());
         assertEquals("my preparation name", actual.getName());
         assertEquals(Step.ROOT_STEP.id(), actual.getHeadId());
@@ -41,6 +43,7 @@ public class PersistentPreparationTest {
         source.setAuthor("Bloc Party");
         source.setCreationDate(theOtherOne.getCreationDate() - 1000);
         source.setDataSetId("ds#65478");
+        source.setDataSetName("My Dataset Name");
         source.setLastModificationDate(source.getCreationDate() + 2658483);
         source.setName("banquet");
         source.setHeadId(Step.ROOT_STEP.id());
@@ -50,6 +53,7 @@ public class PersistentPreparationTest {
         assertEquals("#23874", actual.getId());
         assertEquals("Bloc Party", actual.getAuthor());
         assertEquals("ds#65478", actual.getDataSetId());
+        assertEquals("My Dataset Name", actual.getDataSetName());
     }
 
 }

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -180,7 +180,7 @@ public class PreparationService {
         try {
             toCreate.setDataSetName(datasetClient.getDataSetMetadata(preparation.getDataSetId()).getName());
         } catch (Exception e) {
-            LOGGER.warn("Unable to find dataset name for preparation '{}'", preparation.getId());
+            LOGGER.warn("Unable to find dataset name for preparation '{}'", preparation.getId(), e);
         }
 
         preparationRepository.add(toCreate);


### PR DESCRIPTION
[fix]
* Correctly copy dataset name from preparation during merge with previous preparation.
* Update unit test to follow change.

[misc]
* Remove unused top level data set name in PreparationListItemDTO.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5968

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [x] No, and no need to (backend changes only)
