### PR TITLE
fix(TDP-5908): fix out of memory in xlsx loading, backport on summer 18

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/streaming/StreamingSheetReader.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/streaming/StreamingSheetReader.java
@@ -20,7 +20,11 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.events.*;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.poi.ss.usermodel.BuiltinFormats;
@@ -28,7 +32,7 @@ import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.util.CellReference;
-import org.apache.poi.xssf.model.SharedStringsTable;
+import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
 import org.apache.poi.xssf.model.StylesTable;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFRichTextString;
@@ -44,7 +48,7 @@ public class StreamingSheetReader implements Iterable<Row> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger( StreamingSheetReader.class);
 
-    private final SharedStringsTable sst;
+    private final ReadOnlySharedStringsTable sst;
 
     private final StylesTable stylesTable;
 
@@ -75,7 +79,7 @@ public class StreamingSheetReader implements Iterable<Row> {
     // <dimension ref="A1:B60"/>
     private String dimension = StringUtils.EMPTY;
 
-    public StreamingSheetReader(SharedStringsTable sst, StylesTable stylesTable, XMLEventReader parser, int rowCacheSize) {
+    public StreamingSheetReader(ReadOnlySharedStringsTable sst, StylesTable stylesTable, XMLEventReader parser, int rowCacheSize) {
         this.sst = sst;
         this.stylesTable = stylesTable;
         this.parser = parser;

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/streaming/StreamingWorkbookReader.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/streaming/StreamingWorkbookReader.java
@@ -38,12 +38,13 @@ import org.apache.poi.poifs.crypt.Decryptor;
 import org.apache.poi.poifs.crypt.EncryptionInfo;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
 import org.apache.poi.xssf.eventusermodel.XSSFReader;
-import org.apache.poi.xssf.model.SharedStringsTable;
 import org.apache.poi.xssf.model.StylesTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.dataprep.util.FilesHelper;
+import org.xml.sax.SAXException;
 
 import com.monitorjbl.xlsx.exceptions.OpenException;
 import com.monitorjbl.xlsx.exceptions.ReadException;
@@ -120,20 +121,20 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, AutoCloseable {
 
             XSSFReader reader = new XSSFReader(pkg);
 
-            SharedStringsTable sst = reader.getSharedStringsTable();
+            ReadOnlySharedStringsTable sst = new ReadOnlySharedStringsTable(pkg);
             StylesTable styles = reader.getStylesTable();
 
             loadSheets(reader, sst, styles, builder.getRowCacheSize());
         } catch (IOException e) {
             throw new OpenException("Failed to open file", e);
-        } catch (OpenXML4JException | XMLStreamException e) {
+        } catch (OpenXML4JException | XMLStreamException | SAXException e) {
             throw new ReadException("Unable to read workbook", e);
         } catch (GeneralSecurityException e) {
             throw new ReadException("Unable to read workbook - Decryption failed", e);
         }
     }
 
-    void loadSheets(XSSFReader reader, SharedStringsTable sst, StylesTable stylesTable, int rowCacheSize)
+    void loadSheets(XSSFReader reader, ReadOnlySharedStringsTable sst, StylesTable stylesTable, int rowCacheSize)
             throws IOException, InvalidFormatException, XMLStreamException {
         lookupSheetNames(reader.getWorkbookData());
         Iterator<InputStream> iter = reader.getSheetsData();

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/schema/xls/streaming/StreamingSheetTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/schema/xls/streaming/StreamingSheetTest.java
@@ -24,8 +24,8 @@ import javax.xml.stream.XMLInputFactory;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.eventusermodel.ReadOnlySharedStringsTable;
 import org.apache.poi.xssf.eventusermodel.XSSFReader;
-import org.apache.poi.xssf.model.SharedStringsTable;
 import org.apache.poi.xssf.model.StylesTable;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +39,7 @@ public class StreamingSheetTest {
         OPCPackage pkg = OPCPackage.open(StreamingSheetTest.class.getResourceAsStream("../dates.xlsx"));
         XSSFReader reader = new XSSFReader(pkg);
 
-        SharedStringsTable sst = reader.getSharedStringsTable();
+        ReadOnlySharedStringsTable sst = new ReadOnlySharedStringsTable(pkg);
         StylesTable styles = reader.getStylesTable();
 
         Iterator<InputStream> iter = reader.getSheetsData();


### PR DESCRIPTION
* use ReadOnlySharedStringsTable (lighter memory print when you want to only read a XLSX file) instead of SharedStringsTable (for read/write operation)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5908

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
