### PR TITLE
fix(TDP-5961): fix fetch more (#1532)

### DIFF
--- a/dataprep-async-runtime/src/main/java/org/talend/dataprep/async/conditional/PreparationExportCondition.java
+++ b/dataprep-async-runtime/src/main/java/org/talend/dataprep/async/conditional/PreparationExportCondition.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 import org.talend.dataprep.api.export.ExportParameters;
 
 /**
- * Return TRUE if export deal with preparation (there is a preparationId and export parameters) and not a FILTER
+ * Return TRUE if export deal with preparation (there is a preparationId and export parameters)
  */
 @Component
 public class PreparationExportCondition implements ConditionalTest {
@@ -31,8 +31,7 @@ public class PreparationExportCondition implements ConditionalTest {
         Validate.isTrue(args.length == 1);
         Validate.isInstanceOf(ExportParameters.class, args[0]);
 
-        return StringUtils.isNotEmpty(((ExportParameters) args[0]).getPreparationId())
-                && ((ExportParameters) args[0]).getFrom() != ExportParameters.SourceType.FILTER;
+        return StringUtils.isNotEmpty(((ExportParameters) args[0]).getPreparationId());
     }
 
 }

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -227,18 +227,16 @@ public class TransformationService extends BaseTransformationService {
             value = "Preparation id to apply.") @RequestBody @Valid @AsyncParameter @AsyncExecutionId final ExportParameters parameters)
             throws IOException {
 
-        ExportParameters completeParameters = exportParametersUtil.populateFromPreparationExportParameter(parameters);
-
         // Async behavior
         final ConditionalTest conditionalTest = applicationContext.getBean(GetPrepContentAsyncCondition.class);
-        if (conditionalTest.apply(completeParameters)) {
+        if (conditionalTest.apply(parameters)) {
             // write to cache
-            executeSampleExportStrategy(completeParameters).writeTo(new NullOutputStream());
+            executeSampleExportStrategy(parameters).writeTo(new NullOutputStream());
             return outputStream -> {
             };
         } else {
             // sync behavior
-            return executeSampleExportStrategy(completeParameters);
+            return executeSampleExportStrategy(parameters);
         }
     }
 

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/ApplyPreparationExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/ApplyPreparationExportStrategy.java
@@ -93,8 +93,7 @@ public class ApplyPreparationExportStrategy extends BaseSampleExportStrategy {
         final PreparationDTO preparation = getPreparation(preparationId);
         final String dataSetId = parameters.getDatasetId();
 
-        try {
-            DataSet dataSet = getDatatset(parameters, dataSetId, preparationId);
+        try (DataSet dataSet = getDatatset(parameters, dataSetId, preparationId)) {
 
             // head is not allowed as step id
             final String version = getCleanStepId(preparation, stepId);
@@ -124,14 +123,12 @@ public class ApplyPreparationExportStrategy extends BaseSampleExportStrategy {
                 securityProxy.releaseIdentity();
             }
         }
-
     }
 
     /**
      * Return the dataset sample.
      *
      * @param parameters the export parameters
-     * @param
      * @param dataSet the sample
      * @param preparationId the id of the corresponding preparation
      *
@@ -164,6 +161,8 @@ public class ApplyPreparationExportStrategy extends BaseSampleExportStrategy {
             final Configuration configuration = configurationBuilder.build();
 
             factory.get(configuration).buildExecutable(dataSet, configuration).execute();
+
+            tee.flush();
 
         } catch (IOException e1) { // NOSONAR
             LOGGER.debug("evicting cache {}", key.getKey());

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/CachedExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/CachedExportStrategy.java
@@ -33,7 +33,7 @@ import org.talend.dataprep.transformation.service.ExportUtils;
 
 /**
  * A {@link BaseExportStrategy strategy} to reuse previous preparation export if available (if no previous content found
- * {@link #accept(ExportParameters)} returns <code>false</code>).
+ * {@link #accept(ExportParameters)} returns <code>false</code>). This strategy works fine when from equals to FILTER.
  */
 @Component
 public class CachedExportStrategy extends BaseSampleExportStrategy {
@@ -46,9 +46,6 @@ public class CachedExportStrategy extends BaseSampleExportStrategy {
     @Override
     public boolean accept(ExportParameters parameters) {
         if (parameters == null) {
-            return false;
-        }
-        if (parameters.getFrom() == ExportParameters.SourceType.FILTER) {
             return false;
         }
         if (parameters.getContent() != null) {

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategy.java
@@ -39,10 +39,9 @@ import org.talend.dataprep.transformation.format.CSVFormat;
 import org.talend.dataprep.transformation.service.BaseExportStrategy;
 import org.talend.dataprep.transformation.service.ExportUtils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
- * A {@link BaseExportStrategy strategy} to export a preparation, using its default data set with {@link ExportParameters.SourceType HEAD} sample.
+ * A {@link BaseExportStrategy strategy} to export a preparation, using its default data set with
+ * {@link ExportParameters.SourceType HEAD} sample.
  */
 @Component
 public class PreparationExportStrategy extends BaseSampleExportStrategy {
@@ -144,9 +143,5 @@ public class PreparationExportStrategy extends BaseSampleExportStrategy {
                 securityProxy.releaseIdentity(); // Release identity in case of error.
             }
         }
-    }
-
-    void setMapper(ObjectMapper mapper) {
-        this.mapper = mapper;
     }
 }

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/configuration/StandardExportStrategiesIntegrationTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/configuration/StandardExportStrategiesIntegrationTest.java
@@ -137,14 +137,18 @@ public class StandardExportStrategiesIntegrationTest {
     private void initPreparationDetails() throws Exception {
         doReturn(preparationDetailsGet).when(applicationContext).getBean(eq(PreparationDetailsGet.class), anyString(),
                 anyString());
-        final PreparationDetailsDTO preparationDetailsDTO = mapper.readerFor(PreparationDetailsDTO.class).readValue(this.getClass().getResourceAsStream("preparation_details.json"));
-        when(preparationDetailsGet.execute())
-                .thenReturn(preparationDetailsDTO)
+        final PreparationDetailsDTO preparationDetailsDTO = mapper
+                .readerFor(PreparationDetailsDTO.class) //
+                .readValue(this.getClass().getResourceAsStream("preparation_details.json"));
+        when(preparationDetailsGet.execute()) //
+                .thenReturn(preparationDetailsDTO) //
                 .thenReturn(preparationDetailsDTO);
 
         doReturn(preparationSummaryGet).when(applicationContext).getBean(eq(PreparationSummaryGet.class), anyString(),
                 anyString());
-        final PreparationDTO preparationDTO = mapper.readerFor(PreparationDTO.class).readValue(this.getClass().getResourceAsStream("preparation_details_summary.json"));
+        final PreparationDTO preparationDTO = mapper
+                .readerFor(PreparationDTO.class) //
+                .readValue(this.getClass().getResourceAsStream("preparation_details_summary.json"));
         when(preparationSummaryGet.execute()).thenReturn(preparationDTO, preparationDTO);
     }
 
@@ -185,7 +189,8 @@ public class StandardExportStrategiesIntegrationTest {
                 .findFirst();
     }
 
-    protected void assertElectedStrategyIsInstanceOf(Optional<? extends ExportStrategy> electedStrategy, Class<?> clazz) {
+    protected void assertElectedStrategyIsInstanceOf(Optional<? extends ExportStrategy> electedStrategy,
+            Class<?> clazz) {
         assertTrue("An ExportStrategy should be chosen but none was found", electedStrategy.isPresent());
         assertThat("The chosen ExportStrategy is not the expected one", electedStrategy.get(), instanceOf(clazz));
     }
@@ -193,6 +198,11 @@ public class StandardExportStrategiesIntegrationTest {
     @Test
     public void testCachedExportStrategyShouldBeChosenFromHEAD() throws Exception {
         doTestCachedExportStrategyShouldBeChosen(HEAD);
+    }
+
+    @Test
+    public void testCachedExportStrategyShouldBeChosenFromFilter() throws Exception {
+        doTestCachedExportStrategyShouldBeChosen(FILTER);
     }
 
     @Test
@@ -205,7 +215,8 @@ public class StandardExportStrategiesIntegrationTest {
         doTestCachedExportStrategyShouldBeChosen(null);
     }
 
-    private void doTestOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFrom(SourceType from) throws Exception {
+    private void doTestOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFrom(
+            SourceType from) throws Exception {
         // Given
         ExportParameters parameters = new ExportParameters();
         parameters.setFrom(from);
@@ -223,40 +234,49 @@ public class StandardExportStrategiesIntegrationTest {
 
     private String idOfPrepWith2StepsOrMore() throws IOException {
         reset(preparationDetailsGet);
-        final PreparationDetailsDTO preparationDetailsDTO = mapper.readerFor(PreparationDetailsDTO.class).readValue(this.getClass().getResourceAsStream("two_steps_preparation_details.json"));
-        when(preparationDetailsGet.execute())
-                .thenReturn(preparationDetailsDTO)
+        final PreparationDetailsDTO preparationDetailsDTO = mapper
+                .readerFor(PreparationDetailsDTO.class) //
+                .readValue(this.getClass().getResourceAsStream("two_steps_preparation_details.json"));
+        when(preparationDetailsGet.execute()) //
+                .thenReturn(preparationDetailsDTO) //
                 .thenReturn(preparationDetailsDTO);
 
-        final PreparationDTO preparationDTO = mapper.readerFor(PreparationDTO.class).readValue(this.getClass().getResourceAsStream("two_steps_preparation_details_summary.json"));
-        when(preparationSummaryGet.execute())
-                .thenReturn(preparationDTO)
+        final PreparationDTO preparationDTO = mapper
+                .readerFor(PreparationDTO.class) //
+                .readValue(this.getClass().getResourceAsStream("two_steps_preparation_details_summary.json"));
+        when(preparationSummaryGet.execute())//
+                .thenReturn(preparationDTO) //
                 .thenReturn(preparationDTO);
 
         return "prepId-1234";
     }
 
     @Test
-    public void testOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFromHEAD() throws Exception {
-        doTestOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFrom(HEAD);
+    public void testOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFromHEAD()
+            throws Exception {
+        doTestOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFrom(HEAD);
     }
 
     @Test
-    public void testOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFromFILTER() throws Exception {
-        doTestOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFrom(FILTER);
+    public void testOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFromFILTER()
+            throws Exception {
+        doTestOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFrom(FILTER);
     }
 
     @Test
-    public void testOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFromRESERVOIR() throws Exception {
-        doTestOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFrom(RESERVOIR);
+    public void testOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFromRESERVOIR()
+            throws Exception {
+        doTestOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFrom(RESERVOIR);
     }
 
     @Test
-    public void testOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFromNull() throws Exception {
-        doTestOptimizedExportStrategyShouldBeChosenWhenPrepHasAtLeastTwoStepsFrom(null);
+    public void testOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFromNull()
+            throws Exception {
+        doTestOptimizedExportStrategyShouldBeChosenWhenPrepIsNotInCacheAndHasAtLeastTwoStepsFrom(null);
     }
 
-    private void doTestOptimizedExportStrategyShouldNotBeChosenWhenPrepHasOnlyOneStep(SourceType from) throws Exception {
+    private void doTestOptimizedExportStrategyShouldNotBeChosenWhenPrepHasOnlyOneStep(SourceType from)
+            throws Exception {
         // Given
         ExportParameters parameters = new ExportParameters();
         parameters.setFrom(from);

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/export/CachedExportStrategyTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/export/CachedExportStrategyTest.java
@@ -14,6 +14,7 @@ package org.talend.dataprep.transformation.service.export;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.talend.dataprep.api.export.ExportParameters.SourceType.FILTER;
 import static org.talend.dataprep.api.export.ExportParameters.SourceType.HEAD;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.talend.ServiceBaseTest;
 import org.talend.dataprep.api.dataset.DataSet;
 import org.talend.dataprep.api.export.ExportParameters;
+import org.talend.dataprep.api.export.ExportParameters.SourceType;
 import org.talend.dataprep.api.preparation.Preparation;
 import org.talend.dataprep.cache.ContentCache;
 import org.talend.dataprep.preparation.store.PreparationRepository;
@@ -54,26 +56,40 @@ public class CachedExportStrategyTest extends ServiceBaseTest {
         preparationRepository.add(preparation);
 
         final TransformationCacheKey cacheKey = cacheKeyGenerator.generateContentKey("1234", "1234", "0", "text", HEAD, "");
+        putKeyInCache(cacheKey);
+        final TransformationCacheKey filteredSampleCacheKey = cacheKeyGenerator.generateContentKey("1234", "1234", "0", "text", FILTER, "");
+        putKeyInCache(filteredSampleCacheKey);
+    }
+
+    private void putKeyInCache(TransformationCacheKey cacheKey) {
         try (OutputStream text = cache.put(cacheKey, ContentCache.TimeToLive.DEFAULT)) {
             text.write("{}".getBytes());
         } catch (IOException e) {
             e.printStackTrace();
         }
-
     }
 
-    @Test
-    public void shouldAcceptIfCacheEntryExists() throws Exception {
+    private void doTestAcceptShouldPassIfCacheEntryExistsFrom(SourceType from) throws Exception {
         // Given
         final ExportParameters parameters = new ExportParameters();
         parameters.setDatasetId("1234");
         parameters.setPreparationId("1234");
         parameters.setStepId("0");
         parameters.setExportType("text");
-        parameters.setFrom(HEAD);
+        parameters.setFrom(from);
 
         // Then
         assertTrue(cachedExportStrategy.accept(parameters));
+    }
+
+    @Test
+    public void shouldAcceptIfCacheEntryExistsFromHEAD() throws Exception {
+        doTestAcceptShouldPassIfCacheEntryExistsFrom(HEAD);
+    }
+
+    @Test
+    public void shouldAcceptIfCacheEntryExistsFromFILTER() throws Exception {
+        doTestAcceptShouldPassIfCacheEntryExistsFrom(FILTER);
     }
 
     @Test
@@ -97,10 +113,10 @@ public class CachedExportStrategyTest extends ServiceBaseTest {
     }
 
     @Test
-    public void shouldNotAcceptNullParameterContent() throws Exception {
+    public void shouldNotAcceptWhenParameterContentIsPresent() throws Exception {
         // Then
         final ExportParameters parameters = new ExportParameters();
-        parameters.setContent(null);
+        parameters.setContent(new DataSet());
         assertFalse(cachedExportStrategy.accept(parameters));
     }
 

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategyTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/export/PreparationExportStrategyTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.stream.Stream;
 
@@ -24,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.context.ApplicationContext;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.talend.dataprep.api.dataset.DataSet;
 import org.talend.dataprep.api.dataset.DataSetContent;
@@ -48,6 +50,8 @@ import org.talend.dataprep.transformation.format.JsonFormat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.talend.dataprep.transformation.service.BaseExportStrategy;
+import org.talend.dataprep.transformation.service.ExportStrategy;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PreparationExportStrategyTest {
@@ -88,7 +92,7 @@ public class PreparationExportStrategyTest {
     public void setUp() throws Exception {
         // Given
         mapper.registerModule(new Jdk8Module());
-        strategy.setMapper(new ObjectMapper());
+        injectObjectMapper(strategy);
 
         when(formatRegistrationService.getByName(eq("JSON"))).thenReturn(new JsonFormat());
 
@@ -118,6 +122,12 @@ public class PreparationExportStrategyTest {
         when(factory.get(any())).thenReturn(transformer);
 
         when(contentCache.put(any(), any())).thenReturn(new NullOutputStream());
+    }
+
+    private void injectObjectMapper(ExportStrategy exportStrategy) throws Exception {
+        Field mapperField = ReflectionUtils.findField(BaseExportStrategy.class, "mapper");
+        ReflectionUtils.makeAccessible(mapperField);
+        ReflectionUtils.setField(mapperField, exportStrategy, mapper);
     }
 
     private void configurePreparation(PreparationDTO preparation, String preparationId, String stepId) {


### PR DESCRIPTION
* fix(TDP-5961): fix fetch more
* fix incorrect Integration Test for TDP-5733
* base the fetch more on the correct sample, a filtered dataset generated by the FilterSamplingPipeline
* apply the correct export strategy, that is PreparationSampleExportStrategy
* fix(TDP-5961): flush OutputStream (otherwise leads to issues on Windows)
* fix(TDP-5961): restore previous behavior when from == FILTER
* re-enable use of CachedExportStrategy
* enable asynchronism even if from == FILTER
* clean code
* fix(TDP-5961): add and fix unit tests
* Add comment (FetchMore.feature, CacheExportStrategy.java)
* Remove attribute declare in parent class (ApplyPreparationToContentStrategy.java)
* Remove unnecessary call to exportParametersUtil.populateFromPreparationExportParameter (TransformationService.java)

(cherry picked from commit a2a756f)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5961

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
