### PR TITLE
fix(export): do not close dataset stream too early

### DIFF
--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/ApplyPreparationExportStrategy.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/export/ApplyPreparationExportStrategy.java
@@ -195,10 +195,9 @@ public class ApplyPreparationExportStrategy extends BaseSampleExportStrategy {
         LOGGER.info("using {} as content input", asyncSampleKey.getKey());
 
         if (contentCache.has(asyncSampleKey)) {
-            try (JsonParser parser =
-                    mapper.getFactory().createParser(new InputStreamReader(contentCache.get(asyncSampleKey), UTF_8))) {
-                return mapper.readerFor(DataSet.class).readValue(parser);
-            }
+            JsonParser parser =
+                    mapper.getFactory().createParser(new InputStreamReader(contentCache.get(asyncSampleKey), UTF_8));
+            return mapper.readerFor(DataSet.class).readValue(parser);
         }
 
         final boolean fullContent = parameters.getFrom() == ExportParameters.SourceType.FILTER;


### PR DESCRIPTION
Fix regression on export, introduced by a commit on 2018-08-24.

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
