### PR TITLE
fix(TDP-6050): stream export create empty files

### DIFF
--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/config/FeatureContext.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/config/FeatureContext.java
@@ -89,9 +89,30 @@ public class FeatureContext {
         return name.substring(0, name.indexOf(TI_SUFFIX_UID));
     }
 
-    @PostConstruct
-    public void init() {
-        folders = folderUtil.getEmptyReverseSortedSet();
+    /**
+     * Add suffix to a filename. This suffix is added before the filename extensions. For example "/tmp/file.csv" become
+     * "/tmp/file_654321.csv".
+     * @param fileName The filename.
+     *
+     * @return The suffixed filename.
+     */
+    public static String suffixFileName(String fileName) {
+        if (fileName.lastIndexOf('.') < 0
+                || (fileName.lastIndexOf('/') >= 0 && fileName.lastIndexOf('.') < fileName.lastIndexOf('/'))) {
+            return suffixName(fileName);
+        }
+        return fileName.substring(0, fileName.lastIndexOf('.')) + TI_SUFFIX_UID
+                + fileName.substring(fileName.lastIndexOf('.'));
+    }
+
+    /**
+     * Remove the suffix from the filename.
+     * @param fileName The suffixed filename.
+     *
+     * @return The filename without suffix.
+     */
+    public static String removeSuffixFileName(String fileName) {
+        return fileName.replaceAll(TI_SUFFIX_UID, "");
     }
 
     /**
@@ -109,6 +130,11 @@ public class FeatureContext {
         return folderPath.startsWith("/")
                 ? "/" + folderPath.substring(1).replace("/", TI_SUFFIX_UID + "/") + TI_SUFFIX_UID
                 : folderPath.replace("/", TI_SUFFIX_UID + "/") + TI_SUFFIX_UID;
+    }
+
+    @PostConstruct
+    public void init() {
+        folders = folderUtil.getEmptyReverseSortedSet();
     }
 
     /**


### PR DESCRIPTION
*  add HDFS dataset creation and streams export integration test

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-6050

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [x] The new code does not introduce new technical issues (sonar / eslint)
- [x] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
