### PR TITLE
fix(TDP-5791): accept case insensitive enums for jackson mapping

### DIFF
--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/dataset/adapter/DatasetTest.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/dataset/adapter/DatasetTest.java
@@ -22,13 +22,11 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@Ignore
 public class DatasetTest {
 
     @Test

--- a/dataprep-backend-common/src/test/java/org/talend/dataprep/dataset/adapter/DatasetTest.java
+++ b/dataprep-backend-common/src/test/java/org/talend/dataprep/dataset/adapter/DatasetTest.java
@@ -15,14 +15,18 @@
 
 package org.talend.dataprep.dataset.adapter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertNotNull;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Ignore
 public class DatasetTest {
@@ -31,9 +35,12 @@ public class DatasetTest {
     public void JsonDeserialization() throws IOException {
         InputStream resourceAsStream = this.getClass().getResourceAsStream("dataset-catalog-sample.json");
 
-        Dataset dataset = new ObjectMapper().readValue(resourceAsStream, Dataset.class);
+        Dataset dataset = new ObjectMapper() //
+                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+                .readValue(resourceAsStream, Dataset.class);
 
         assertNotNull(dataset);
         assertNotNull(dataset.getId());
+        assertThat(dataset.getCertification(), is(Dataset.CertificationState.NONE));
     }
 }

--- a/dataprep-backend-common/src/test/resources/org/talend/dataprep/dataset/adapter/dataset-catalog-sample.json
+++ b/dataprep-backend-common/src/test/resources/org/talend/dataprep/dataset/adapter/dataset-catalog-sample.json
@@ -16,8 +16,7 @@
   "enabled": true,
   "label": "French stations frequencies",
   "type": "SimpleFileIoDataset",
-  "version": 0,
-  "datastoreId": "9abb1206-5f2b-4d51-97cd-f742991d3533",
+  "certification": "none",
   "datastore": {
     "id": "9abb1206-5f2b-4d51-97cd-f742991d3533",
     "label": "HDFS Datastore",

--- a/dataprep-backend-service/src/main/resources/org/talend/dataprep/configuration/default.properties
+++ b/dataprep-backend-service/src/main/resources/org/talend/dataprep/configuration/default.properties
@@ -16,6 +16,7 @@ spring.jackson.deserialization.FAIL_ON_IGNORED_PROPERTIES=false
 spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
 spring.jackson.serialization.FLUSH_AFTER_WRITE_VALUE=false
 spring.jackson.default-property-inclusion=non_absent
+spring.jackson.mapper.ACCEPT_CASE_INSENSITIVE_ENUMS=true
 
 spring.mvc.async.request-timeout=300000
 


### PR DESCRIPTION
Data Catalog has implemented the certification state for a dataset and values are not in uppercase as expected so we have to be insensitive for mapping.

* fix deserialize issue of `org.talend.dataprep.dataset.adapter.Dataset$CertificationState` from String "none" -> declared Enum values: [NONE, CERTIFIED, PENDING]

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5791

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
