### PR TITLE
chore(cloud): Improve dataset name robustness

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/DataSetNameInjection.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/DataSetNameInjection.java
@@ -3,6 +3,8 @@ package org.talend.dataprep.conversions.inject;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.talend.dataprep.api.preparation.PreparationDTO;
 import org.talend.dataprep.api.preparation.PreparationListItemDTO;
@@ -19,6 +21,8 @@ import com.google.common.cache.CacheBuilder;
 
 public class DataSetNameInjection
         implements BiFunction<PreparationDTO, PreparationListItemDTO, PreparationListItemDTO> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DataSetNameInjection.class);
 
     private final Cache<String, Cache<String, String>> cache;
 
@@ -63,8 +67,12 @@ public class DataSetNameInjection
                 // On-the-fly update
                 final PersistentPreparation preparation =
                         preparationRepository.get(dto.getId(), PersistentPreparation.class);
-                preparation.setDataSetName(dataSetName);
-                preparationRepository.add(preparation);
+                if (preparation != null) {
+                    preparation.setDataSetName(dataSetName);
+                    preparationRepository.add(preparation);
+                } else {
+                    LOGGER.warn("Unable to update data set name of preparation #{} (preparation does not exist).", dto.getId());
+                }
             } catch (Exception e) {
                 throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
             }


### PR DESCRIPTION
* Improve dataset name robustness when a preparation is missing or not accessible.

**Link to the JIRA issue**
(no jira)

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
