### PR TITLE
feat(TDP-6198) : Delete dataset step doesn't remove it from the context

### DIFF
--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/config/FeatureContext.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/config/FeatureContext.java
@@ -101,6 +101,7 @@ public class FeatureContext {
     /**
      * Add suffix to a filename. This suffix is added before the filename extensions. For example "/tmp/file.csv" become
      * "/tmp/file_654321.csv".
+     * 
      * @param fileName The filename.
      *
      * @return The suffixed filename.
@@ -116,6 +117,7 @@ public class FeatureContext {
 
     /**
      * Remove the suffix from the filename.
+     * 
      * @param fileName The suffixed filename.
      *
      * @return The filename without suffix.
@@ -180,6 +182,16 @@ public class FeatureContext {
     public void storeDatasetRef(@NotNull String id, @NotNull String name) {
         storeExistingDatasetRef(id, name);
         datasetIdByNameToDelete.put(name, id);
+    }
+
+    /**
+     * Remove a dataset reference from the context.
+     * 
+     * @param name the dataset name.
+     */
+    public void removeDatastRef(@NotNull String name) {
+        datasetIdByName.remove(name);
+        datasetIdByNameToDelete.remove(name);
     }
 
     /**

--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/step/DatasetStep.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/step/DatasetStep.java
@@ -137,13 +137,10 @@ public class DatasetStep extends DataPrepStep {
 
     @When("^I delete the dataset called \"(.*)\"$") //
     public void iDeleteTheDataset(String datasetName) {
-        deleteDatasetByName(datasetName).then().statusCode(OK.value());
-    }
-
-    private Response deleteDatasetByName(String datasetName) {
         String suffixedDatasetName = suffixName(datasetName);
         String datasetId = context.getDatasetId(suffixedDatasetName);
-        return api.deleteDataset(datasetId);
+        api.deleteDataset(datasetId).then().statusCode(OK.value());
+        context.removeDatastRef(suffixedDatasetName);
     }
 
     @When("^I load the existing dataset called \"(.*)\"$")


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-6198

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
