### PR TITLE
feat(TDP-6198) : Delete dataset step doesn't remove it from the context

### DIFF
--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/config/FeatureContext.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/config/FeatureContext.java
@@ -187,11 +187,14 @@ public class FeatureContext {
     /**
      * Remove a dataset reference from the context.
      * 
-     * @param name the dataset name.
+     * @param datasetName the dataset name.
      */
-    public void removeDatastRef(@NotNull String name) {
-        datasetIdByName.remove(name);
-        datasetIdByNameToDelete.remove(name);
+    public void removeDatastRef(@NotNull String datasetName) {
+        String datasetId = datasetIdByName.get(datasetName);
+        if(datasetId!=null){
+            datasetIdByName.remove(datasetId);
+            datasetIdByNameToDelete.remove(datasetName);
+        }
     }
 
     /**

--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/config/FeatureContext.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/config/FeatureContext.java
@@ -189,12 +189,9 @@ public class FeatureContext {
      * 
      * @param datasetName the dataset name.
      */
-    public void removeDatastRef(@NotNull String datasetName) {
-        String datasetId = datasetIdByName.get(datasetName);
-        if(datasetId!=null){
-            datasetIdByName.remove(datasetId);
-            datasetIdByNameToDelete.remove(datasetName);
-        }
+    public void removeDatasetRef(@NotNull String datasetName) {
+        datasetIdByName.remove(datasetName);
+        datasetIdByNameToDelete.remove(datasetName);
     }
 
     /**

--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/step/DatasetStep.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/step/DatasetStep.java
@@ -140,7 +140,7 @@ public class DatasetStep extends DataPrepStep {
         String suffixedDatasetName = suffixName(datasetName);
         String datasetId = context.getDatasetId(suffixedDatasetName);
         api.deleteDataset(datasetId).then().statusCode(OK.value());
-        context.removeDatastRef(suffixedDatasetName);
+        context.removeDatasetRef(suffixedDatasetName);
     }
 
     @When("^I load the existing dataset called \"(.*)\"$")


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-6198

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
