### PR TITLE
fix(TDP-6353): update dataset / DatasetDTO conversion

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/OwnerInjection.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/conversions/inject/OwnerInjection.java
@@ -1,15 +1,15 @@
 package org.talend.dataprep.conversions.inject;
 
+import java.util.function.BiFunction;
+
 import org.talend.dataprep.api.dataset.DatasetDTO;
 import org.talend.dataprep.api.dataset.DatasetDetailsDTO;
 import org.talend.dataprep.api.preparation.PreparationDTO;
 import org.talend.dataprep.dataset.adapter.Dataset;
 import org.talend.dataprep.preparation.store.PersistentPreparation;
 
-import java.util.function.BiFunction;
-
 /**
- * An API to ease {@link org.talend.dataprep.api.share.Owner} injection in {@link PreparationDTO} instances.
+ * An API to ease {@link org.talend.dataprep.api.share.Owner} injection in {@link PreparationDTO}, {@link DatasetDTO} and {@link DatasetDetailsDTO} instances.
  *
  * @see org.talend.dataprep.conversions.BeanConversionService#convert(Object, Class, BiFunction[])
  */

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/commands/DataSetGetSchema.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/dataset/adapter/commands/DataSetGetSchema.java
@@ -12,6 +12,11 @@
 
 package org.talend.dataprep.dataset.adapter.commands;
 
+import static org.apache.http.HttpHeaders.ACCEPT;
+import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
+import static org.talend.dataprep.command.Defaults.asNull;
+import static org.talend.dataprep.exception.error.CommonErrorCodes.UNEXPECTED_EXCEPTION;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -24,15 +29,9 @@ import org.apache.http.client.utils.URIBuilder;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.talend.dataprep.command.Defaults;
 import org.talend.dataprep.command.GenericCommand;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.util.avro.AvroUtils;
-
-import static org.apache.http.HttpHeaders.ACCEPT;
-import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
-import static org.talend.dataprep.command.Defaults.asNull;
-import static org.talend.dataprep.exception.error.CommonErrorCodes.UNEXPECTED_EXCEPTION;
 
 /**
  * Get the dataSet schema.
@@ -54,7 +53,6 @@ public class DataSetGetSchema extends GenericCommand<Schema> {
         super(GenericCommand.DATASET_GROUP);
         this.dataSetId = dataSetId;
 
-        onError(Defaults.passthrough());
         on(HttpStatus.NO_CONTENT).then(asNull());
     }
 

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversionTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversionTest.java
@@ -46,6 +46,7 @@ public class DatasetBeanConversionTest {
         assertEquals(dataset.getLabel(), datasetDTO.getName());
         assertEquals(dataset.getOwner(), datasetDTO.getAuthor());
         assertEquals(dataset.getType(), datasetDTO.getType());
+        assertEquals(dataset.getCertification(), datasetDTO.getCertification());
     }
 
     @Test

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversionTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/dataset/adapter/conversions/DatasetBeanConversionTest.java
@@ -14,7 +14,9 @@ import org.talend.dataprep.api.dataset.DatasetDTO;
 import org.talend.dataprep.conversions.BeanConversionService;
 import org.talend.dataprep.dataset.adapter.Dataset;
 import org.talend.dataprep.schema.Schema;
+import org.talend.dataprep.schema.csv.CSVFormatFamily;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DatasetBeanConversionTest {
@@ -27,6 +29,7 @@ public class DatasetBeanConversionTest {
 
     @Before
     public void setUp() throws IOException {
+        objectMapper.enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS);
         // conversion registration
         new DatasetBeanConversion(objectMapper).doWith(beanConversionService, "toto", null);
         // create catalog dataset from json file
@@ -45,7 +48,7 @@ public class DatasetBeanConversionTest {
         assertEquals(dataset.getUpdated(), datasetDTO.getLastModificationDate());
         assertEquals(dataset.getLabel(), datasetDTO.getName());
         assertEquals(dataset.getOwner(), datasetDTO.getAuthor());
-        assertEquals(dataset.getType(), datasetDTO.getType());
+        assertEquals(CSVFormatFamily.MEDIA_TYPE, datasetDTO.getType());
         assertEquals(dataset.getCertification(), datasetDTO.getCertification());
     }
 

--- a/dataprep-backend-service/src/test/resources/org/talend/dataprep/dataset/adapter/dataset_payload_example.json
+++ b/dataprep-backend-service/src/test/resources/org/talend/dataprep/dataset/adapter/dataset_payload_example.json
@@ -1,37 +1,36 @@
 {
   "entitlements": [
-    "DATASET_FETCH_SAMPLE",
-    "DATASET_UPDATE",
-    "DATASET_READ",
-    "DATASET_DELETE",
     "CONNECTION_READ",
-    "CONNECTION_UPDATE",
-    "DATASET_SHARE",
-    "CONNECTION_SHARE"
+    "TDP_DATASET_CERTIFY",
+    "DATASET_FETCH_SAMPLE",
+    "DATASET_DELETE",
+    "DATASET_READ",
+    "DATASET_UPDATE",
+    "DATASET_SHARE"
   ],
-  "__acl": 15910,
-  "id": "9640b5b6-9fa2-11e7-abc4-cec278b6b50a",
-  "created": 1529419221860,
-  "updated": 1529419221860,
-  "enabled": true,
-  "label": "French stations frequencies",
-  "type": "SimpleFileIoDataset",
-  "version": 0,
-  "datastoreId": "9abb1206-5f2b-4d51-97cd-f742991d3533",
+  "__acl": 15874,
+  "id": "15b9d7c8-106b-4f14-9b32-f030cb3c3550",
+  "created": 1542961848184,
+  "updated": 1542961880447,
+  "creator": "Aurélien Leboulanger",
+  "label": "Customers20",
   "datastore": {
-    "id": "9abb1206-5f2b-4d51-97cd-f742991d3533",
-    "label": "HDFS Datastore",
-    "type": "SimpleFileIoDatastore"
+    "id": "LOCAL_CONN",
+    "label": "Local storage",
+    "type": "LocalStorageDatastore"
   },
-  "properties": {
-    "path": "/frequentation-gares.csv",
-    "format": "CSV",
-    "fieldDelimiter": "SEMICOLON",
-    "@definitionName": "SimpleFileIoDataset",
-    "recordDelimiter": "LF",
-    "specificFieldDelimiter": ";",
-    "specificRecordDelimiter": "\\n"
+  "rating": {},
+  "certification": "none",
+  "format": "CSV",
+  "sharing": {
+    "isOwner": true,
+    "isSharedWithOthers": false
   },
-  "owner": "9e78073b-961a-4ce4-b807-3b961a5ce4d4",
-  "creator": "Jane Doe"
+  "favorite": false,
+  "talendGlobalQuality": {
+    "-1": 10,
+    "1": 223,
+    "0": 7,
+    "total": 240
+  }
 }


### PR DESCRIPTION
* remove useless DataSetGetShema onError instruction

* Add fields in Dataset / Datastore catalog entity

* Update Dataset Bean conversions

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-6353

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
