### PR TITLE
feat(TDP-6273): make ErrorCode serializable and correct persistence e…

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/CommonAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/CommonAPI.java
@@ -156,8 +156,7 @@ public class CommonAPI extends APIService {
     private void writeErrorsFromEnum(JsonGenerator generator, ErrorCode[] codes) throws IOException {
         for (ErrorCode code : codes) {
             // cast to JsonErrorCode needed to ease json handling
-            JsonErrorCodeDescription description = new JsonErrorCodeDescription(code);
-            generator.writeObject(description);
+            generator.writeObject(new JsonErrorCodeDescription(code));
         }
     }
 
@@ -172,8 +171,7 @@ public class CommonAPI extends APIService {
         Iterator<JsonErrorCodeDescription> iterator =
                 mapper.readerFor(JsonErrorCodeDescription.class).readValues(input);
         while (iterator.hasNext()) {
-            final JsonErrorCodeDescription description = iterator.next();
-            generator.writeObject(description);
+            generator.writeObject(iterator.next());
         }
     }
 }

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/FolderAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/FolderAPITest.java
@@ -133,7 +133,7 @@ public class FolderAPITest extends ApiServiceTestBase {
         assertThat(response.getStatusCode(), is(409));
         final String content = response.asString();
         assertTrue(StringUtils.isNoneBlank(content));
-        assertTrue(content.contains(FolderErrorCodes.FOLDER_NOT_EMPTY.name()));
+        assertTrue(content.contains(FolderErrorCodes.FOLDER_NOT_EMPTY.getCode()));
 
         final List<Folder> folders = getFolderChildren(home.getId());
         assertThat(folders, hasSize(1));

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -828,7 +828,7 @@ public class PreparationAPITest extends ApiServiceTestBase {
                 mapper.readerFor(AsyncExecutionMessage.class).readValue(response.asString());
 
         assertEquals(AsyncExecution.Status.FAILED, asyncExecutionMessage.getStatus());
-        assertEquals(BaseErrorCodes.UNABLE_TO_PARSE_FILTER.name(), asyncExecutionMessage.getError().getCode());
+        assertEquals(BaseErrorCodes.UNABLE_TO_PARSE_FILTER.getCode(), asyncExecutionMessage.getError().getCode());
     }
 
     @Test

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/api/exception/error/ErrorCodeMessagesTest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/api/exception/error/ErrorCodeMessagesTest.java
@@ -19,7 +19,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.talend.ServiceBaseTest;
-import org.talend.dataprep.exception.error.*;
+import org.talend.daikon.exception.error.ErrorCode;
+import org.talend.dataprep.exception.error.APIErrorCodes;
+import org.talend.dataprep.exception.error.CommonErrorCodes;
+import org.talend.dataprep.exception.error.DataSetErrorCodes;
+import org.talend.dataprep.exception.error.ErrorMessage;
+import org.talend.dataprep.exception.error.PreparationErrorCodes;
+import org.talend.dataprep.exception.error.TransformationErrorCodes;
 import org.talend.dataprep.i18n.MessagesBundle;
 
 /**
@@ -52,7 +58,7 @@ public class ErrorCodeMessagesTest extends ServiceBaseTest {
 
     @Test
     public void testCommonErrorCodeMessages() {
-        for (CommonErrorCodes code : CommonErrorCodes.values()) {
+        for (ErrorCode code : CommonErrorCodes.values()) {
             assertErrorCodeMessageExists(code.getCode());
             assertErrorCodeMessageTitleExists(code.getCode());
         }
@@ -60,7 +66,7 @@ public class ErrorCodeMessagesTest extends ServiceBaseTest {
 
     @Test
     public void testAPIErrorCodeMessages() {
-        for (APIErrorCodes code : APIErrorCodes.values()) {
+        for (ErrorCode code : APIErrorCodes.values()) {
             assertErrorCodeMessageExists(code.getCode());
             assertErrorCodeMessageTitleExists(code.getCode());
         }
@@ -68,7 +74,7 @@ public class ErrorCodeMessagesTest extends ServiceBaseTest {
 
     @Test
     public void testDatasetErrorCodeMessages() {
-        for (DataSetErrorCodes code : DataSetErrorCodes.values()) {
+        for (ErrorCode code : DataSetErrorCodes.values()) {
             assertErrorCodeMessageExists(code.getCode());
             assertErrorCodeMessageTitleExists(code.getCode());
         }
@@ -76,7 +82,7 @@ public class ErrorCodeMessagesTest extends ServiceBaseTest {
 
     @Test
     public void testTransformationErrorCodeMessages() {
-        for (TransformationErrorCodes code : TransformationErrorCodes.values()) {
+        for (ErrorCode code : TransformationErrorCodes.values()) {
             assertErrorCodeMessageExists(code.getCode());
             assertErrorCodeMessageTitleExists(code.getCode());
         }
@@ -84,7 +90,7 @@ public class ErrorCodeMessagesTest extends ServiceBaseTest {
 
     @Test
     public void testPreparationErrorCodeMessages() {
-        for (PreparationErrorCodes code : PreparationErrorCodes.values()) {
+        for (ErrorCode code : PreparationErrorCodes.values()) {
             assertErrorCodeMessageExists(code.getCode());
             assertErrorCodeMessageTitleExists(code.getCode());
         }

--- a/dataprep-async-api/src/main/java/org/talend/dataprep/async/AsyncExecution.java
+++ b/dataprep-async-api/src/main/java/org/talend/dataprep/async/AsyncExecution.java
@@ -58,8 +58,6 @@ public class AsyncExecution implements Comparable<AsyncExecution> {
     private AsyncExecutionResult result;
 
     /** The execution error code when it failed. */
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-    @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.NON_NULL)
     private ErrorCode error;
 
     /** The current execution progress. */
@@ -136,19 +134,14 @@ public class AsyncExecution implements Comparable<AsyncExecution> {
     }
 
     /**
-     * @return the execution error code.
+     * @return the execution error code.0
      */
     public ErrorCode getError() {
         return error;
     }
 
     public void setError(ErrorCode error) {
-        if (error instanceof ErrorCodeDto) {
-            LOGGER.debug("Execution '{}' has error from underlying service '{}'", getId(), error);
-            this.error = TransformationErrorCodes.UNABLE_TO_TRANSFORM_DATASET;
-        } else {
-            this.error = error;
-        }
+        this.error = error;
     }
 
     public ExecutionProgress getProgress() {

--- a/dataprep-backend-service/pom.xml
+++ b/dataprep-backend-service/pom.xml
@@ -193,6 +193,14 @@
             <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Converters.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/configuration/Converters.java
@@ -19,9 +19,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
-import org.talend.daikon.exception.error.ErrorCode;
-import org.talend.daikon.exception.json.JsonErrorCode;
-import org.talend.dataprep.exception.ErrorCodeDto;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
 
@@ -49,31 +46,6 @@ public class Converters {
                     return mapper.readTree(source);
                 } catch (IOException e) {
                     throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
-                }
-            }
-        };
-    }
-
-    @Bean
-    public Converter<String, ErrorCode> errorCodeConverter() {
-        // Don't convert to lambda -> cause issue for Spring to infer source and target types.
-        return new Converter<String, ErrorCode>() {
-
-            @Override
-            public ErrorCode convert(String source) {
-                ObjectMapper mapper = new ObjectMapper();
-                try {
-                    return mapper.readerFor(JsonErrorCode.class).readValue(source);
-                } catch (Exception e) {
-                    LOGGER.trace("Unable to read error code from '{}'", source, e);
-
-                    // Build a JSON error code out of "source" (mostly likely a error code as string).
-                    final ErrorCodeDto errorCodeDto = new ErrorCodeDto();
-                    errorCodeDto.setCode(source);
-                    errorCodeDto.setHttpStatus(CommonErrorCodes.UNEXPECTED_EXCEPTION.getHttpStatus());
-                    errorCodeDto.setGroup(CommonErrorCodes.UNEXPECTED_EXCEPTION.getGroup());
-                    errorCodeDto.setProduct(CommonErrorCodes.UNEXPECTED_EXCEPTION.getProduct());
-                    return errorCodeDto;
                 }
             }
         };

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/ErrorCodeDto.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/ErrorCodeDto.java
@@ -28,6 +28,14 @@ public class ErrorCodeDto implements ErrorCode {
 
     private Collection<String> expectedContextEntries = emptyList();
 
+    public ErrorCodeDto() {
+    }
+
+    // Allow direct deserialization of Enum value
+    public ErrorCodeDto(String code) {
+        this.code = code;
+    }
+
     @Override
     public String getProduct() {
         return product;

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/TDPException.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/TDPException.java
@@ -18,7 +18,6 @@ import static java.util.stream.StreamSupport.stream;
 import static org.talend.dataprep.exception.error.CommonErrorCodes.UNEXPECTED_EXCEPTION;
 
 import java.io.Writer;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -92,7 +91,7 @@ public class TDPException extends TalendRuntimeException {
 
         // Translation done at the object creation
         List<Object> values = getValuesFromContext(context);
-        this.localizedMessage = ErrorMessage.getMessage(getCode(), values.toArray(new Object[values.size()]));
+        this.localizedMessage = ErrorMessage.getMessage(getCode(), values.toArray(new Object[0]));
     }
 
     /**
@@ -107,9 +106,9 @@ public class TDPException extends TalendRuntimeException {
         super(code, cause, context);
 
         List<Object> values = getValuesFromContext(context);
-        message = ErrorMessage.getDefaultMessage(getCode(), values.toArray(new Object[values.size()]));
-        localizedMessage = ErrorMessage.getMessage(getCode(), values.toArray(new Object[values.size()]));
-        messageTitle = ErrorMessage.getMessageTitle(getCode(), values.toArray(new Object[values.size()]));
+        message = ErrorMessage.getDefaultMessage(getCode(), values.toArray(new Object[0]));
+        localizedMessage = ErrorMessage.getMessage(getCode(), values.toArray(new Object[0]));
+        messageTitle = ErrorMessage.getMessageTitle(getCode(), values.toArray(new Object[0]));
     }
 
     /**
@@ -176,25 +175,8 @@ public class TDPException extends TalendRuntimeException {
         throw new UnsupportedOperationException("Not supported.");
     }
 
-    // Needed to keep the compatibility with the deprecated writeTo(Writer) method.
-    // This code duplicates the one in ExceptionsConfiguration and should not be used anywhere else.
-    private static TdpExceptionDto toExceptionDto(TalendRuntimeException internal) {
-        ErrorCode errorCode = internal.getCode();
-        String serializedCode = errorCode.getProduct() + '_' + errorCode.getGroup() + '_' + errorCode.getCode();
-        String defaultMessage = internal.getMessage();
-        String message = internal.getLocalizedMessage();
-        String messageTitle = internal instanceof TDPException ? ((TDPException) internal).getMessageTitle() : null;
-        TdpExceptionDto cause =
-                internal.getCause() instanceof TDPException ? toExceptionDto((TDPException) internal.getCause()) : null;
-        Map<String, Object> context = new HashMap<>();
-        for (Map.Entry<String, Object> contextEntry : internal.getContext().entries()) {
-            context.put(contextEntry.getKey(), contextEntry.getValue());
-        }
-        return new TdpExceptionDto(serializedCode, cause, defaultMessage, message, messageTitle, context);
-    }
-
     /**
-     * Return thie list of object store in the context
+     * Return the list of object store in the context
      *
      * @param context the error context
      *

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/TDPExceptionFlowControl.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/TDPExceptionFlowControl.java
@@ -23,9 +23,8 @@ import org.talend.daikon.exception.error.ErrorCode;
  */
 public class TDPExceptionFlowControl extends TDPException {
 
-    public TDPExceptionFlowControl(ErrorCodeDto errorCodeDto, Throwable cause, String message, String messageTitle,
-            ExceptionContext context) {
-        super(errorCodeDto, cause, message, messageTitle, context);
+    // Needed to be able to convert with conversionService
+    public TDPExceptionFlowControl() {
     }
 
     /**

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/json/ErrorCodeModule.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/json/ErrorCodeModule.java
@@ -1,0 +1,53 @@
+// ============================================================================
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// https://github.com/Talend/data-prep/blob/master/LICENSE
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package org.talend.dataprep.exception.json;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+import org.talend.daikon.exception.error.ErrorCode;
+import org.talend.dataprep.exception.ErrorCodeDto;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * Jackson module that deals with ErrorCode.
+ * <bold>WARN:</bold> all anum ErrorCodes are serialized as a String field as their name.
+ *
+ * @see ErrorCode
+ */
+@Component
+public class ErrorCodeModule extends SimpleModule {
+
+    public ErrorCodeModule() {
+        super(ErrorCodeModule.class.getName(), new Version(1, 0, 0, null, null, null));
+        addDeserializer(ErrorCode.class, new Deserializer());
+    }
+
+    private static class Deserializer extends StdDeserializer<ErrorCode> {
+
+        Deserializer() {
+            super(ErrorCode.class);
+        }
+
+        @Override
+        public ErrorCode deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException {
+            return jsonParser.readValueAs(ErrorCodeDto.class);
+        }
+    }
+}

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/exception/json/ErrorCodeModuleTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/exception/json/ErrorCodeModuleTest.java
@@ -1,0 +1,67 @@
+package org.talend.dataprep.exception.json;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+
+import org.junit.Test;
+import org.talend.daikon.exception.error.ErrorCode;
+import org.talend.dataprep.exception.ErrorCodeDto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ErrorCodeModuleTest {
+
+    @Test
+    public void directSerializationOfErrorCodeShouldWork() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new ErrorCodeModule());
+        String s = mapper.writeValueAsString(new ErrorCodeDto()
+                .setGroup("GROUP")
+                .setProduct("PRODUCT")
+                .setCode("CODE")
+                .setHttpStatus(123)
+                .setExpectedContextEntries(singletonList("entry")));
+
+        ErrorCode readValue = mapper.readerFor(ErrorCode.class).readValue(s);
+
+        assertTrue(readValue instanceof ErrorCodeDto);
+    }
+
+    @Test
+    public void wrappedSerializationOfErrorCodeShouldWork() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new ErrorCodeModule());
+        TestNestingClass nesting = new TestNestingClass();
+        nesting.name = "toto";
+        nesting.code = new ErrorCodeDto()
+                .setGroup("GROUP")
+                .setProduct("PRODUCT")
+                .setCode("CODE")
+                .setHttpStatus(123)
+                .setExpectedContextEntries(singletonList("entry"));
+        nesting.otherField = singletonList("ahah");
+
+        String nestingAsText = mapper.writeValueAsString(nesting);
+
+        TestNestingClass readValue = mapper.readerFor(TestNestingClass.class).readValue(nestingAsText);
+
+        assertTrue(readValue.code instanceof ErrorCodeDto);
+        assertEquals(nesting.code.getProduct(), readValue.code.getProduct());
+        assertEquals(nesting.code.getGroup(), readValue.code.getGroup());
+        assertEquals(nesting.code.getCode(), readValue.code.getCode());
+        assertEquals(nesting.code.getHttpStatus(), readValue.code.getHttpStatus());
+        assertEquals(nesting.code.getExpectedContextEntries(), readValue.code.getExpectedContextEntries());
+    }
+
+    private static class TestNestingClass {
+
+        public String name;
+
+        public ErrorCode code;
+
+        public Collection<String> otherField;
+    }
+}

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/i18n/DataprepBundleTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/i18n/DataprepBundleTest.java
@@ -56,7 +56,7 @@ public class DataprepBundleTest {
 
     @Test
     public void errorTitle() throws Exception {
-        String producedKey = CommonErrorCodes.ILLEGAL_ORDER_FOR_LIST.name() + ".TITLE";
+        String producedKey = CommonErrorCodes.ILLEGAL_ORDER_FOR_LIST.getCode() + ".TITLE";
         assertEquals(messagesProperties.getProperty(producedKey),
                 DataprepBundle.errorTitle(CommonErrorCodes.ILLEGAL_ORDER_FOR_LIST));
     }

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/DataSetService.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/DataSetService.java
@@ -39,6 +39,7 @@ import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -831,13 +832,8 @@ public class DataSetService extends BaseDataSetService {
     @ApiOperation(value = "Get all dataset related error codes.",
             notes = "Returns the list of all dataset related error codes.")
     @Timed
-    public Iterable<JsonErrorCodeDescription> listErrors() {
-        // need to cast the typed dataset errors into mock ones to use json parsing
-        List<JsonErrorCodeDescription> errors = new ArrayList<>(DataSetErrorCodes.values().length);
-        for (DataSetErrorCodes code : DataSetErrorCodes.values()) {
-            errors.add(new JsonErrorCodeDescription(code));
-        }
-        return errors;
+    public Stream<JsonErrorCodeDescription> listErrors() {
+        return Arrays.stream(DataSetErrorCodes.values()).map(JsonErrorCodeDescription::new);
     }
 
     /**

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/analysis/synchronous/SchemaAnalysis.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/analysis/synchronous/SchemaAnalysis.java
@@ -99,7 +99,7 @@ public class SchemaAnalysis implements SynchronousDataSetAnalyzer {
                 }
             } catch (Exception e) {
                 LOGGER.error("Unable to analyse schema for dataset " + dataSetId + ".", e);
-                TDPException.rethrowOrWrap(e, UNABLE_TO_ANALYZE_COLUMN_TYPES);
+                throw TDPException.rethrowOrWrap(e, UNABLE_TO_ANALYZE_COLUMN_TYPES);
             }
         } finally {
             datasetLock.unlock();

--- a/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/DataSetServiceTest.java
+++ b/dataprep-dataset/src/test/java/org/talend/dataprep/dataset/service/DataSetServiceTest.java
@@ -751,7 +751,8 @@ public class DataSetServiceTest extends DataSetBaseTest {
                 .get("/datasets/{id}/content", dataSetId);
 
         assertEquals(400, response.statusCode());
-        assertTrue(response.jsonPath().get("code").toString().contains(BaseErrorCodes.UNABLE_TO_PARSE_FILTER.name()));
+        assertTrue(
+                response.jsonPath().get("code").toString().contains(BaseErrorCodes.UNABLE_TO_PARSE_FILTER.getCode()));
     }
 
     @Test
@@ -843,7 +844,7 @@ public class DataSetServiceTest extends DataSetBaseTest {
 
         // then
         assertEquals(200, response.getStatusCode());
-        assertTrue(response.asString().length() == 0);
+        assertEquals(0, response.asString().length());
     }
 
     @Test

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationController.java
@@ -458,7 +458,7 @@ public class PreparationController {
     @ApiOperation(value = "Get all preparation related error codes.",
             notes = "Returns the list of all preparation related error codes.")
     @Timed
-    public Iterable<JsonErrorCodeDescription> listErrors() {
+    public Stream<JsonErrorCodeDescription> listErrors() {
         return preparationService.listErrors();
     }
 

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/PreparationService.java
@@ -13,6 +13,7 @@
 package org.talend.dataprep.preparation.service;
 
 import static java.lang.Integer.MAX_VALUE;
+import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -1028,13 +1029,8 @@ public class PreparationService {
     /**
      * List all preparation related error codes.
      */
-    public Iterable<JsonErrorCodeDescription> listErrors() {
-        // need to cast the typed dataset errors into mock ones to use json parsing
-        List<JsonErrorCodeDescription> errors = new ArrayList<>(PreparationErrorCodes.values().length);
-        for (PreparationErrorCodes code : PreparationErrorCodes.values()) {
-            errors.add(new JsonErrorCodeDescription(code));
-        }
-        return errors;
+    public Stream<JsonErrorCodeDescription> listErrors() {
+        return stream(PreparationErrorCodes.values()).map(JsonErrorCodeDescription::new);
     }
 
     public boolean isDatasetUsedInPreparation(final String datasetId) {

--- a/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
+++ b/dataprep-transformation/src/main/java/org/talend/dataprep/transformation/service/TransformationService.java
@@ -13,6 +13,7 @@
 package org.talend.dataprep.transformation.service;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.stream;
 import static java.util.Collections.singletonList;
 import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -36,7 +37,6 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -753,13 +753,8 @@ public class TransformationService extends BaseTransformationService {
     @ApiOperation(value = "Get all transformation related error codes.",
             notes = "Returns the list of all transformation related error codes.")
     @Timed
-    public Iterable<JsonErrorCodeDescription> listErrors() {
-        // need to cast the typed dataset errors into mock ones to use json parsing
-        List<JsonErrorCodeDescription> errors = new ArrayList<>(TransformationErrorCodes.values().length);
-        for (TransformationErrorCodes code : TransformationErrorCodes.values()) {
-            errors.add(new JsonErrorCodeDescription(code));
-        }
-        return errors;
+    public Stream<JsonErrorCodeDescription> listErrors() {
+        return stream(TransformationErrorCodes.values()).map(JsonErrorCodeDescription::new);
     }
 
     /**


### PR DESCRIPTION
…rror (#1366)

* correct a misusage of mongo template API
* add mongo converters for error codes to make ErrorCode readable from database when stored as enum name, complete code or object.
* adapt control flow exceptions to pass in Beanconversionservice
* add an empty constructor in TDPExceptionFlowControl for bean conversion
* add mongo configuration testing for ErrorCode persistence (using fongo)
* add testing of AsyncExecutions persistence
* change some access to ErrorCode interface instead of implementation
* remove usage of JsonErrorCode
* remve configuration duplication in poms

cherry-pick master ffc459ed

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-XXXX

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
