### PR TITLE
fix(TDP-6725): prevent XXE on XLSX dataset parsing

### DIFF
--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/XlsUtils.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/XlsUtils.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -335,6 +336,17 @@ public class XlsUtils {
 
     }
 
+    /**
+     * Create a new XMLEventReader from a java.io.InputStream
+     *
+     * @param stream the InputStream to read from
+     * @return a correctly configured XMLEventReader (especially regarding XXE prevention)
+     * @throws XMLStreamException see {@link XMLInputFactory#createXMLEventReader(InputStream)}
+     */
+    public static XMLEventReader createXMLEventReader(InputStream stream) throws XMLStreamException {
+        return XML_INPUT_FACTORY.createXMLEventReader(stream);
+    }
+
     private static class XMLInputSingletonHolder {
 
         private static final XMLInputFactory xmlInputFactory = XMLInputFactory.newFactory();
@@ -342,6 +354,10 @@ public class XlsUtils {
         static {
             xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
             xmlInputFactory.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
+            // Disable DTDs entirely to prevent XXE attack
+            xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+            // Disable external entities
+            xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
         }
     }
 }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/XlsUtils.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/XlsUtils.java
@@ -354,7 +354,8 @@ public class XlsUtils {
         static {
             xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, Boolean.TRUE);
             xmlInputFactory.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
-            // Disable DTDs entirely to prevent XXE attack
+            // Disable DTDs entirely to prevent XXE attack, see
+            // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#XMLInputFactory_.28a_StAX_parser.29
             xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
             // Disable external entities
             xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/streaming/StreamingWorkbookReader.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/schema/xls/streaming/StreamingWorkbookReader.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.Attribute;
@@ -43,6 +42,7 @@ import org.apache.poi.xssf.eventusermodel.XSSFReader;
 import org.apache.poi.xssf.model.StylesTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.talend.dataprep.schema.xls.XlsUtils;
 import org.talend.dataprep.util.FilesHelper;
 import org.xml.sax.SAXException;
 
@@ -140,7 +140,7 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, AutoCloseable {
         Iterator<InputStream> iter = reader.getSheetsData();
         int i = 0;
         while (iter.hasNext()) {
-            XMLEventReader parser = XMLInputFactory.newInstance().createXMLEventReader(iter.next());
+            XMLEventReader parser = XlsUtils.createXMLEventReader(iter.next());
             sheets.add(new StreamingSheet(sheetNames.get(i++),
                     new StreamingSheetReader(sst, stylesTable, parser, rowCacheSize)));
         }
@@ -149,7 +149,7 @@ public class StreamingWorkbookReader implements Iterable<Sheet>, AutoCloseable {
     void lookupSheetNames(InputStream workBookData) throws IOException, InvalidFormatException, XMLStreamException {
         sheetNames.clear();
 
-        XMLEventReader parser = XMLInputFactory.newInstance().createXMLEventReader(workBookData);
+        XMLEventReader parser = XlsUtils.createXMLEventReader(workBookData);
         boolean parsingsSheets = false;
         while (parser.hasNext()) {
             XMLEvent event = parser.nextEvent();

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/schema/xls/XlsUtilsTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/schema/xls/XlsUtilsTest.java
@@ -112,6 +112,10 @@ public class XlsUtilsTest {
         Assertions.assertThat(XlsUtils.getColumnNumberFromCellRef("BB11")).isEqualTo(53);
     }
 
+    /**
+     * See https://jira.talendforge.org/browse/TDP-6725 and
+     * https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#XMLInputFactory_.28a_StAX_parser.29
+     */
     @Test
     public void testCreateXMLEventReader_shouldPreventXXE() throws Exception {
         XMLEventReader reader = XlsUtils.createXMLEventReader(new ByteArrayInputStream(new byte[0]));

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/schema/xls/XlsUtilsTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/schema/xls/XlsUtilsTest.java
@@ -13,21 +13,15 @@
 
 package org.talend.dataprep.schema.xls;
 
-import java.io.FileOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+
 import org.apache.poi.openxml4j.opc.OPCPackage;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.util.CellReference;
 import org.apache.poi.xssf.eventusermodel.XSSFReader;
-import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -116,6 +110,13 @@ public class XlsUtilsTest {
         Assertions.assertThat(XlsUtils.getColumnNumberFromCellRef("A15")).isEqualTo(0);
         Assertions.assertThat(XlsUtils.getColumnNumberFromCellRef("AG142")).isEqualTo(32);
         Assertions.assertThat(XlsUtils.getColumnNumberFromCellRef("BB11")).isEqualTo(53);
+    }
+
+    @Test
+    public void testCreateXMLEventReader_shouldPreventXXE() throws Exception {
+        XMLEventReader reader = XlsUtils.createXMLEventReader(new ByteArrayInputStream(new byte[0]));
+        Assert.assertEquals(false, reader.getProperty(XMLInputFactory.SUPPORT_DTD));
+        Assert.assertEquals(false, reader.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES));
     }
 
 }


### PR DESCRIPTION
* Disable DTD validation for XMLEventReader and XMLEventStreamer
* Disable external entities for XMLEventReader and XMLEventStreamer

(Backport from master)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-6725

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
