### PR TITLE
fix(TDP-6717): User can access to some preparations without permissions (on the same tenant)

### DIFF
--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/FolderAPI.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/FolderAPI.java
@@ -103,8 +103,7 @@ public class FolderAPI extends APIService {
     @RequestMapping(value = "/api/folders", method = PUT)
     @ApiOperation(value = "Add a folder.", produces = APPLICATION_JSON_VALUE)
     @Timed
-    public StreamingResponseBody addFolder(@RequestParam(required = false) final String parentId,
-            @RequestParam final String path) {
+    public StreamingResponseBody addFolder(@RequestParam final String parentId, @RequestParam final String path) {
         try {
             final HystrixCommand<InputStream> createChildFolder = getCommand(CreateChildFolder.class, parentId, path);
             return CommandHelper.toStreaming(createChildFolder);
@@ -132,7 +131,7 @@ public class FolderAPI extends APIService {
     @Timed
     public void renameFolder(@PathVariable final String id, @RequestBody final String newName) {
 
-        if (StringUtils.isEmpty(id) || StringUtils.isEmpty(newName)) {
+        if (StringUtils.isEmpty(id) || StringUtils.isEmpty(newName) || newName.contains("/")) {
             throw new TDPException(APIErrorCodes.UNABLE_TO_RENAME_FOLDER);
         }
 

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/folder/CreateChildFolder.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/folder/CreateChildFolder.java
@@ -13,7 +13,13 @@
 
 package org.talend.dataprep.api.service.command.folder;
 
-import org.apache.http.client.methods.HttpPut;
+import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.talend.dataprep.command.Defaults.pipeStream;
+
+import java.io.InputStream;
+import java.net.URISyntaxException;
+
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.springframework.context.annotation.Scope;
@@ -22,12 +28,6 @@ import org.springframework.stereotype.Component;
 import org.talend.dataprep.command.GenericCommand;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
-
-import java.io.InputStream;
-import java.net.URISyntaxException;
-
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
-import static org.talend.dataprep.command.Defaults.pipeStream;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
@@ -48,12 +48,9 @@ public class CreateChildFolder extends GenericCommand<InputStream> {
     private HttpRequestBase onExecute(final String parentId, final String path) {
         try {
 
-            URIBuilder uriBuilder = new URIBuilder(preparationServiceUrl + "/folders");
-            if (parentId != null) {
-                uriBuilder.addParameter("parentId", parentId);
-            }
+            URIBuilder uriBuilder = new URIBuilder(preparationServiceUrl + "/folders/" + parentId + "/folders");
             uriBuilder.addParameter("path", path);
-            return new HttpPut(uriBuilder.build());
+            return new HttpPost(uriBuilder.build());
         } catch (URISyntaxException e) {
             throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
         }

--- a/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/folder/CreateRootFolder.java
+++ b/dataprep-api/src/main/java/org/talend/dataprep/api/service/command/folder/CreateRootFolder.java
@@ -1,5 +1,6 @@
 // ============================================================================
-// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// Copyright (C) 2006-2019 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // https://github.com/Talend/data-prep/blob/master/LICENSE
@@ -13,43 +14,51 @@
 package org.talend.dataprep.api.service.command.folder;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
-import static org.talend.dataprep.command.Defaults.asNull;
-import static org.talend.dataprep.exception.error.APIErrorCodes.UNABLE_TO_RENAME_FOLDER;
+import static org.talend.dataprep.exception.error.APIErrorCodes.UNABLE_TO_CREATE_FOLDER;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 
-import org.apache.http.client.methods.HttpPut;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.StringEntity;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.talend.daikon.exception.ExceptionContext;
+import org.talend.dataprep.api.folder.Folder;
 import org.talend.dataprep.command.GenericCommand;
 import org.talend.dataprep.exception.TDPException;
 import org.talend.dataprep.exception.error.CommonErrorCodes;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class RenameFolder extends GenericCommand<Void> {
+public class CreateRootFolder extends GenericCommand<Folder> {
 
-    public RenameFolder(final String id, final String newName) {
-        super(GenericCommand.DATASET_GROUP);
-        execute(() -> onExecute(id, newName));
-        onError(e -> new TDPException(UNABLE_TO_RENAME_FOLDER, e, ExceptionContext.build()));
-        on(HttpStatus.OK).then(asNull());
+    public CreateRootFolder() {
+        super(GenericCommand.PREPARATION_GROUP);
+        execute(() -> onExecute());
+        on(HttpStatus.OK).then((req, resp) -> processResponse(req, resp));
     }
 
-    private HttpRequestBase onExecute(final String id, final String newName) {
+    private HttpRequestBase onExecute() {
         try {
-            final URIBuilder uriBuilder = new URIBuilder(preparationServiceUrl + "/folders/" + id + "/name");
-            final HttpPut put = new HttpPut(uriBuilder.build());
-            put.setEntity(new StringEntity(newName, "UTF-8"));
-            return put;
+
+            URIBuilder uriBuilder = new URIBuilder(preparationServiceUrl + "/folders");
+            return new HttpPost(uriBuilder.build());
         } catch (URISyntaxException e) {
             throw new TDPException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
         }
     }
 
+    private Folder processResponse(HttpRequestBase request, HttpResponse response) {
+        try {
+            return objectMapper.readerFor(Folder.class).readValue(response.getEntity().getContent());
+        } catch (IOException e) {
+            throw new TDPException(UNABLE_TO_CREATE_FOLDER, e);
+        } finally {
+            request.releaseConnection();
+        }
+
+    }
 }

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/ApiServiceTestBase.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/ApiServiceTestBase.java
@@ -69,7 +69,7 @@ public abstract class ApiServiceTestBase extends ServiceBaseTest {
         for (UrlRuntimeUpdater urlUpdater : urlUpdaters) {
             urlUpdater.setUp();
         }
-        home = folderRepository.getHome();
+        home = folderRepository.getOrCreateHome();
     }
 
     @After

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/FolderAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/FolderAPITest.java
@@ -374,7 +374,7 @@ public class FolderAPITest extends ApiServiceTestBase {
     public void updateFolderWithUnknownParent_TDP_4959() {
         // check non encoding issue on path query parameter
         Response response = given() //
-                .queryParam("parentId", "ZAP%n%s%n%s%n%s%n%s%n%s") //
+                .queryParam("parentId", "unknown") //
                 .queryParam("path", "new-folder") //
                 .expect()
                 .statusCode(400)

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/PreparationAPITest.java
@@ -725,7 +725,7 @@ public class PreparationAPITest extends ApiServiceTestBase {
     public void shouldCreatePreparationInDefaultFolder() throws Exception {
 
         // given
-        Folder home = folderRepository.getHome();
+        Folder home = folderRepository.getOrCreateHome();
         List<FolderEntry> entries = getEntries(home.getId());
         assertTrue(entries.isEmpty());
 
@@ -746,7 +746,7 @@ public class PreparationAPITest extends ApiServiceTestBase {
 
         // given
         final String path = "/folder-1/sub-folder-2";
-        Folder folder = folderRepository.addFolder(folderRepository.getHome().getId(), path);
+        Folder folder = folderRepository.addFolder(folderRepository.getOrCreateHome().getId(), path);
         List<FolderEntry> entries = getEntries(folder.getId());
         assertThat(entries.size(), is(0));
 
@@ -765,7 +765,7 @@ public class PreparationAPITest extends ApiServiceTestBase {
     @Test
     public void shouldNotAcceptPreparationWithoutRowMetadata() throws Exception {
         // given
-        Folder home = folderRepository.getHome();
+        Folder home = folderRepository.getOrCreateHome();
         final List<FolderEntry> entries = getEntries(home.getId());
         assertThat(entries.size(), is(0));
         String dataSetId = testClient.createDataset("dataset/dataset.csv", "testCreatePreparation");

--- a/dataprep-api/src/test/java/org/talend/dataprep/api/service/SearchAPITest.java
+++ b/dataprep-api/src/test/java/org/talend/dataprep/api/service/SearchAPITest.java
@@ -39,7 +39,7 @@ public class SearchAPITest extends ApiServiceTestBase {
     public void shouldReturnMatchingPreparationsWhenPerformingInventory() throws IOException {
         // given
         final String preparationId = testClient.createPreparationFromFile("t-shirt_100.csv",
-                "testInventoryOfPreparations", folderRepository.getHome().getId());
+                "testInventoryOfPreparations", folderRepository.getOrCreateHome().getId());
 
         // when
         final Response response = given() //
@@ -67,7 +67,7 @@ public class SearchAPITest extends ApiServiceTestBase {
     public void shouldReturnMatchingPreparationsWithSpaceWhenPerformingInventory() throws IOException {
         // given
         final String preparationId = testClient.createPreparationFromFile("t-shirt_100.csv",
-                "testInventory OfPreparations", folderRepository.getHome().getId());
+                "testInventory OfPreparations", folderRepository.getOrCreateHome().getId());
 
         // when
         final Response response = given() //
@@ -163,7 +163,7 @@ public class SearchAPITest extends ApiServiceTestBase {
     public void shouldFilterResultOnCategories() throws IOException {
         // given
         final String preparationId = testClient.createPreparationFromFile("t-shirt_100.csv",
-                "testInventoryOfPreparations", folderRepository.getHome().getId());
+                "testInventoryOfPreparations", folderRepository.getOrCreateHome().getId());
 
         // when
         Response response = given() //

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/FolderRepository.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/FolderRepository.java
@@ -52,7 +52,7 @@ public interface FolderRepository {
      *
      * @return the Home {@link Folder}.
      */
-    Folder getHome();
+    Optional<Folder> getHome();
 
     /**
      * Add a folder.

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/FolderRepository.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/FolderRepository.java
@@ -34,7 +34,7 @@ public interface FolderRepository {
 
     /**
      * Return true if the given folder exists.
-     * 
+     *
      * @param folderId the wanted folder folderId.
      * @return true if the given folder exists.
      */
@@ -42,6 +42,13 @@ public interface FolderRepository {
 
     /**
      * Get the current user home folder. If the folder does not yet exists, it's created.
+     *
+     * @return the Home {@link Folder}.
+     */
+    Folder getOrCreateHome();
+
+    /**
+     * Get the current user home folder. If the folder does not yet exists, return null.
      *
      * @return the Home {@link Folder}.
      */
@@ -99,7 +106,7 @@ public interface FolderRepository {
 
     /**
      * List the {@link FolderEntry} of the wanted type within the given folderId.
-     * 
+     *
      * @param folderId the parent folderId
      * @param contentType the contentClass to filter folder entries
      * @return A {@link java.lang.Iterable iterable} of {@link FolderEntry} content filtered for the given type
@@ -120,7 +127,7 @@ public interface FolderRepository {
 
     /**
      * <b>if the destination or entry doesn't exist a {@link IllegalArgumentException} will be thrown</b>
-     * 
+     *
      * @param folderEntry the {@link FolderEntry} to move.
      * @param fromId where to look for the folder entry.
      * @param toId the destination where to move the entry.
@@ -129,7 +136,7 @@ public interface FolderRepository {
 
     /**
      * Copy the given folder entry to the target destination.
-     * 
+     *
      * @param folderEntry the {@link FolderEntry} to move
      * @param toId the destination where to copy the entry
      */
@@ -209,7 +216,7 @@ public interface FolderRepository {
                 // we just add the current user home because every top level shared folder is considered
                 // as the user's home child
                 if (e.getCode().getHttpStatus() == 403) {
-                    hierarchy.add(0, this.getHome());
+                    hierarchy.add(0, this.getOrCreateHome());
                     break;
                 }
                 throw e;

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/file/FileSystemFolderRepository.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/file/FileSystemFolderRepository.java
@@ -101,9 +101,9 @@ public class FileSystemFolderRepository implements FolderRepository {
     }
 
     @Override
-    public Folder getHome() {
+    public Optional<Folder> getHome() {
         if (Files.exists(pathsConverter.getRootFolder())) {
-            return getOrCreateHome();
+            return Optional.of(getOrCreateHome());
         }
         return null;
     }

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/file/FileSystemFolderRepository.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/folder/store/file/FileSystemFolderRepository.java
@@ -96,8 +96,16 @@ public class FileSystemFolderRepository implements FolderRepository {
     }
 
     @Override
-    public Folder getHome() {
+    public Folder getOrCreateHome() {
         return toFolder(pathsConverter.getRootFolder(), security.getUserId());
+    }
+
+    @Override
+    public Folder getHome() {
+        if (Files.exists(pathsConverter.getRootFolder())) {
+            return getOrCreateHome();
+        }
+        return null;
     }
 
     @Override
@@ -402,7 +410,7 @@ public class FileSystemFolderRepository implements FolderRepository {
     @Override
     public Optional<Folder> getFolder(String path) {
         if ("/".equals(path)) {
-            return Optional.of(getHome());
+            return Optional.of(getOrCreateHome());
         }
         final String queryForFileSearch;
         if (path.startsWith("/")) {

--- a/dataprep-backend-service/src/test/java/org/talend/dataprep/folder/store/AbstractFolderTest.java
+++ b/dataprep-backend-service/src/test/java/org/talend/dataprep/folder/store/AbstractFolderTest.java
@@ -16,7 +16,11 @@ import static junit.framework.TestCase.assertFalse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.talend.dataprep.api.folder.FolderContentType.DATASET;
 import static org.talend.dataprep.api.folder.FolderContentType.PREPARATION;
 
@@ -25,7 +29,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.talend.ServiceBaseTest;
 import org.talend.dataprep.api.folder.Folder;
@@ -60,7 +67,7 @@ public abstract class AbstractFolderTest extends ServiceBaseTest {
     @Before
     public void setUp() {
         super.setUp();
-        this.homeFolderId = getFolderRepository().getHome().getId();
+        this.homeFolderId = getFolderRepository().getOrCreateHome().getId();
     }
 
     @After
@@ -456,7 +463,7 @@ public abstract class AbstractFolderTest extends ServiceBaseTest {
     @Test
     public void shouldLocateEntry() throws Exception {
         // given (root & 2 entries)
-        final Folder root = getFolderRepository().getHome();
+        final Folder root = getFolderRepository().getOrCreateHome();
 
         final FolderEntry littleCreatures = new FolderEntry(DATASET, "littleCreatures");
         getFolderRepository().addFolderEntry(littleCreatures, root.getId());
@@ -525,7 +532,7 @@ public abstract class AbstractFolderTest extends ServiceBaseTest {
     @Test
     public void parentIdShouldBeNullForHome() throws Exception {
         // when
-        final Folder home = getFolderRepository().getHome();
+        final Folder home = getFolderRepository().getOrCreateHome();
 
         // then
         assertNull(home.getParentId());
@@ -534,7 +541,7 @@ public abstract class AbstractFolderTest extends ServiceBaseTest {
     @Test
     public void shouldReturnHomeFolder() {
         // when
-        final Folder home = getFolderRepository().getHome();
+        final Folder home = getFolderRepository().getOrCreateHome();
 
         // then
         Assert.assertThat(home.getPath(), is("/"));

--- a/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/DataSetService.java
+++ b/dataprep-dataset/src/main/java/org/talend/dataprep/dataset/service/DataSetService.java
@@ -436,7 +436,14 @@ public class DataSetService extends BaseDataSetService {
             // So, let's read fully the request content before closing the connection.
             dataSetContentToNull(content);
         }
-        dataSetMetadataRepository.remove(id);
+        // remove dataSetMetadata
+        securityProxy.asTechnicalUser();
+        try {
+            dataSetMetadataRepository.remove(id);
+        } finally {
+            securityProxy.releaseIdentity();
+        }
+
         if (dataSetMetadata != null) {
             try {
                 contentStore.delete(dataSetMetadata);

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/FolderService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/FolderService.java
@@ -172,7 +172,7 @@ public class FolderService {
     @Timed
     public Folder addFolder(@RequestParam(required = false) String parentId, @RequestParam String path) {
         if (parentId == null) {
-            parentId = folderRepository.getHome().getId();
+            parentId = folderRepository.getOrCreateHome().getId();
         }
         Folder folderCreated = folderRepository.addFolder(parentId, path);
 
@@ -216,7 +216,7 @@ public class FolderService {
     @ApiOperation(value = "List all folders")
     @Timed
     public FolderTreeNode getTree() {
-        final Folder home = folderRepository.getHome();
+        final Folder home = folderRepository.getOrCreateHome();
         return getTree(home);
     }
 

--- a/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/FolderService.java
+++ b/dataprep-preparation/src/main/java/org/talend/dataprep/preparation/service/FolderService.java
@@ -15,6 +15,7 @@ package org.talend.dataprep.preparation.service;
 import static java.util.stream.Collectors.toList;
 import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
 import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 import static org.talend.daikon.exception.ExceptionContext.build;
 import static org.talend.dataprep.api.folder.FolderContentType.PREPARATION;
@@ -162,21 +163,27 @@ public class FolderService {
     }
 
     /**
-     * Add a folder.
+     * Creates a sub folder in a folder.
      *
-     * @param parentId where to add the folder.
      * @return the created folder.
      */
-    @RequestMapping(value = "/folders", method = PUT)
+    @RequestMapping(value = "/folders/{id}/folders", method = POST)
+    @ApiOperation(value = "Creates a sub folder in a folder", notes = "Creates a sub folder in a folder")
+    @Timed
+    public Folder addFolder(@PathVariable String id, @RequestParam String path) {
+        Folder folderCreated = folderRepository.addFolder(id, path);
+
+        auditService.auditFolderCreation(folderCreated.getId(), folderCreated.getName(), id);
+
+        return folderCreated;
+    }
+
+    @RequestMapping(value = "/folders", method = POST)
     @ApiOperation(value = "Create a Folder", notes = "Create a folder")
     @Timed
-    public Folder addFolder(@RequestParam(required = false) String parentId, @RequestParam String path) {
-        if (parentId == null) {
-            parentId = folderRepository.getOrCreateHome().getId();
-        }
-        Folder folderCreated = folderRepository.addFolder(parentId, path);
-
-        auditService.auditFolderCreation(folderCreated.getId(), folderCreated.getName(), parentId);
+    public Folder createRootFolder() {
+        Folder folderCreated = folderRepository.getOrCreateHome();
+        auditService.auditFolderCreation(folderCreated.getId(), folderCreated.getName(), null);
 
         return folderCreated;
     }

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/BasePreparationTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/BasePreparationTest.java
@@ -140,7 +140,7 @@ public abstract class BasePreparationTest extends ServiceBaseTest {
                 .log()
                 .ifError()//
                 .when() //
-                .put("/folders")
+                .post("/folders/" + parentId + "/folders")
                 .then()
                 .assertThat()
                 .statusCode(200);

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/BasePreparationTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/BasePreparationTest.java
@@ -67,7 +67,7 @@ public abstract class BasePreparationTest extends ServiceBaseTest {
     @Before
     public void setUp() {
         super.setUp();
-        home = folderRepository.getHome();
+        home = folderRepository.getOrCreateHome();
     }
 
     @After

--- a/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/test/PreparationClientTest.java
+++ b/dataprep-preparation/src/test/java/org/talend/dataprep/preparation/test/PreparationClientTest.java
@@ -69,7 +69,7 @@ public class PreparationClientTest {
 
     @PostConstruct
     private void init() {
-        this.homeFolderId = folderRepository.getHome().getId();
+        this.homeFolderId = folderRepository.getOrCreateHome().getId();
     }
 
     static {

--- a/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformationServiceBaseTest.java
+++ b/dataprep-transformation/src/test/java/org/talend/dataprep/transformation/service/TransformationServiceBaseTest.java
@@ -86,7 +86,7 @@ public abstract class TransformationServiceBaseTest extends TransformationBaseTe
     public void setUp() {
         super.setUp();
         urlUpdater.setUp();
-        home = folderRepository.getHome();
+        home = folderRepository.getOrCreateHome();
     }
 
     @After

--- a/dataprep-upgrade/src/main/java/org/talend/dataprep/upgrade/to_1_2_0_PE/AddAllPreparationsTaskToHome.java
+++ b/dataprep-upgrade/src/main/java/org/talend/dataprep/upgrade/to_1_2_0_PE/AddAllPreparationsTaskToHome.java
@@ -64,7 +64,7 @@ public class AddAllPreparationsTaskToHome implements BaseUpgradeTaskTo_1_2_0_PE 
     @Override
     public void run() {
         final Stream<Preparation> preparations = preparationRepository.list(Preparation.class);
-        final String homeId = folderRepository.getHome().getId();
+        final String homeId = folderRepository.getOrCreateHome().getId();
 
         preparations.forEach(p -> {
             folderRepository.addFolderEntry(new FolderEntry(FolderContentType.PREPARATION, p.id()), homeId);

--- a/dataprep-upgrade/src/test/java/org/talend/dataprep/upgrade/to_1_2_0_PE/AddAllPreparationsToHomeTest.java
+++ b/dataprep-upgrade/src/test/java/org/talend/dataprep/upgrade/to_1_2_0_PE/AddAllPreparationsToHomeTest.java
@@ -65,7 +65,7 @@ public class AddAllPreparationsToHomeTest extends Base_1_2_0_PE_Test {
     public void shouldAddAllPreparationsToHome() throws Exception {
 
         // given
-        final String homeFolderId = folderRepository.getHome().getId();
+        final String homeFolderId = folderRepository.getOrCreateHome().getId();
 
         // when
         task.run();


### PR DESCRIPTION
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-6717
https://jira.talendforge.org/browse/TDP-6290
https://jira.talendforge.org/browse/TDP-3422

**Please check if the PR fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
