### PR TITLE
fix(TDP-7086): Update the dataSet schema during preparation import 

### DIFF
--- a/dataprep-backend-common/src/main/java/org/talend/dataprep/api/type/Type.java
+++ b/dataprep-backend-common/src/main/java/org/talend/dataprep/api/type/Type.java
@@ -162,16 +162,11 @@ public enum Type implements Serializable {
         if (name == null) {
             throw new IllegalArgumentException("Name cannot be null.");
         }
-        List<Type> types = ANY.list();
 
-        Optional<Type> type = types.stream().filter(type1 -> type1.getName().equalsIgnoreCase(name)).findFirst();
-
-        if (type.isPresent()) {
-            return type.get();
-        }
-
-        // default type to String
-        return STRING;
+        return ANY.list().stream()
+                .filter(type -> type.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(STRING);
     }
 
     /**

--- a/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/DataSetErrorCodes.java
+++ b/dataprep-backend-service/src/main/java/org/talend/dataprep/exception/error/DataSetErrorCodes.java
@@ -12,13 +12,21 @@
 
 package org.talend.dataprep.exception.error;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.MOVED_PERMANENTLY;
+import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.talend.daikon.exception.error.ErrorCode;
 import org.talend.dataprep.api.dataset.DataSetLifecycle;
 
@@ -181,11 +189,11 @@ public enum DataSetErrorCodes implements ErrorCode {
     /**
      * A dataSet used by a preparation with a given name have not the expected format.
      */
-    PREPARATION_DATASET_BAD_FORMAT(NOT_FOUND.value(), "name"),
+    PREPARATION_DATASET_BAD_FORMAT(NOT_ACCEPTABLE.value(), "name"),
     /**
      * A lookup dataSet used by a preparation with a given name have not the expected format.
      */
-    PREPARATION_LOOKUP_BAD_FORMAT(NOT_FOUND.value(), "name"),
+    PREPARATION_LOOKUP_BAD_FORMAT(NOT_ACCEPTABLE.value(), "name"),
     /**
      * A user tries to run a live dataset without any TIC access.
      */

--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/step/ActionStep.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/step/ActionStep.java
@@ -68,7 +68,10 @@ public class ActionStep extends DataPrepStep {
         Action action = new Action();
         action.action = actionName;
         action.parameters.putAll(util.mapParamsToActionParameters(params));
-        api.addAction(prepId, action);
+
+        api.addAction(prepId, action)
+                .then().statusCode(200)
+                .log().ifValidationFails();
     }
 
     @When("^I add a \"(.*)\" step identified by \"(.*)\" on the preparation \"(.*)\" with parameters :$")

--- a/dataprep-test-api/src/test/java/org/talend/dataprep/qa/util/OSIntegrationTestUtil.java
+++ b/dataprep-test-api/src/test/java/org/talend/dataprep/qa/util/OSIntegrationTestUtil.java
@@ -1,5 +1,19 @@
 package org.talend.dataprep.qa.util;
 
+import static org.talend.dataprep.qa.config.FeatureContext.suffixName;
+import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.FILTER;
+import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.SCOPE;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import org.talend.dataprep.helper.api.Action;
@@ -8,30 +22,14 @@ import org.talend.dataprep.helper.api.ActionParamEnum;
 import org.talend.dataprep.helper.api.Filter;
 import org.talend.dataprep.qa.dto.Folder;
 
-import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-
-import static org.talend.dataprep.qa.config.FeatureContext.suffixName;
-import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.FILTER;
-import static org.talend.dataprep.transformation.actions.common.ImplicitParameters.SCOPE;
-
 /**
  * Utility class for Integration Tests in Data-prep OS.
  */
 @Component
 public class OSIntegrationTestUtil {
 
-    static final String ACTION_NAME = "actionName";
-
-    private final List<String> parametersToBeSuffixed = Collections.singletonList("new_domain_id");
+    private static final List<String>
+            PARAMETERS_TO_BE_SUFFIXED = Arrays.asList("new_domain_id", "new_domain_label", "lookup_ds_name");
 
     /**
      * Split a folder in a {@link Set} folder and subfolders.
@@ -79,7 +77,7 @@ public class OSIntegrationTestUtil {
                 ActionParamEnum.getActionParamEnum(k)
                         .ifPresent(actionParamEnum -> {
                             Object value;
-                            if (parametersToBeSuffixed.contains(actionParamEnum.getName())) {
+                            if (PARAMETERS_TO_BE_SUFFIXED.contains(actionParamEnum.getName())) {
                                 value = suffixName(v);
                             } else {
                                 value = StringUtils.isEmpty(v) ? null : v;


### PR DESCRIPTION
(cherry picked from commit be4d0780ae5137b40ce40333158bb902bfb7ae1b)

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5954

**Please check if the PR fulfills these requirements**
- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] The code coverage on new code is > 75 % for backend and > 95% for frontend
- [ ] The new code does not introduce new technical issues (sonar / eslint)
- [ ] Functional tests have been performed
- [ ] Docker configuration files for config-std or config-cloud profiles are impacted

**Please check the browsers you've tested on**
- [ ] Chrome, Firefox, Safari, Edge, IE11
- [ ] No, that's bad, this PR should not be merged !
- [ ] No, and no need to (backend changes only)
